### PR TITLE
fix: removes orbit-icons, uses better maker-icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 A Vue.js component library.
 
 ## 🚀 Install
+
 ```sh
+# install maker
 npm i @square/maker
+
+# install peer dependencies
+npx i-peers -a
 ```

--- a/lab/Laboratory.vue
+++ b/lab/Laboratory.vue
@@ -12,7 +12,7 @@
 		</div>
 
 		<component
-			:is="sidebarOpen ? 'x-icon' : 'menu-icon'"
+			:is="sidebarOpen ? 'x' : 'x'"
 			v-if="isSmallScreen"
 			:class="$s.ToggleSidebar"
 			inline
@@ -63,15 +63,14 @@
 
 <script>
 import { MTheme } from '@square/maker/components/Theme';
-import { DragBarsIcon, XIcon } from '@square/orbit-icons';
+import { X } from '@square/maker-icons';
 import ControlPanel from '~/components/ControlPanel.vue';
 
 export default {
 	components: {
 		MTheme,
 		ControlPanel,
-		DragBarsIcon,
-		XIcon,
+		X,
 	},
 
 	data() {
@@ -113,7 +112,6 @@ export default {
 </script>
 
 <style module="$s">
-
 .Page {
 	font-family: system-ui;
 
@@ -141,5 +139,4 @@ export default {
 	width: 300px;
 	padding: 32px;
 }
-
 </style>

--- a/lab/Laboratory.vue
+++ b/lab/Laboratory.vue
@@ -63,7 +63,7 @@
 
 <script>
 import { MTheme } from '@square/maker/components/Theme';
-import { X } from '@square/maker-icons';
+import X from '@square/maker-icons/X';
 import ControlPanel from '~/components/ControlPanel.vue';
 
 export default {

--- a/lab/Laboratory.vue
+++ b/lab/Laboratory.vue
@@ -12,7 +12,7 @@
 		</div>
 
 		<component
-			:is="sidebarOpen ? 'x' : 'x'"
+			:is="sidebarOpen ? 'x' : 'menu'"
 			v-if="isSmallScreen"
 			:class="$s.ToggleSidebar"
 			inline
@@ -63,6 +63,7 @@
 
 <script>
 import { MTheme } from '@square/maker/components/Theme';
+import Menu from '@square/maker-icons/Menu';
 import X from '@square/maker-icons/X';
 import ControlPanel from '~/components/ControlPanel.vue';
 
@@ -71,6 +72,7 @@ export default {
 		MTheme,
 		ControlPanel,
 		X,
+		Menu,
 	},
 
 	data() {

--- a/lab/experiments/ActionBar.vue
+++ b/lab/experiments/ActionBar.vue
@@ -24,7 +24,7 @@
 <script>
 import { MActionBar, MActionBarLayer } from '@square/maker/components/ActionBar';
 import { MButton } from '@square/maker/components/Button';
-import { X } from '@square/maker-icons';
+import X from '@square/maker-icons/X';
 
 export default {
 	components: {

--- a/lab/experiments/ActionBar.vue
+++ b/lab/experiments/ActionBar.vue
@@ -6,10 +6,7 @@
 				size="large"
 				shape="pill"
 			>
-				<x-icon
-					inline
-					class="icon"
-				/>
+				<x class="icon" />
 			</m-button>
 			<m-button
 				key="primary"
@@ -27,14 +24,14 @@
 <script>
 import { MActionBar, MActionBarLayer } from '@square/maker/components/ActionBar';
 import { MButton } from '@square/maker/components/Button';
-import { XIcon } from '@square/orbit-icons';
+import { X } from '@square/maker-icons';
 
 export default {
 	components: {
 		MActionBar,
 		MActionBarLayer,
 		MButton,
-		XIcon,
+		X,
 	},
 };
 </script>

--- a/lab/experiments/ActionBarTest/index/Modal.vue
+++ b/lab/experiments/ActionBarTest/index/Modal.vue
@@ -49,7 +49,7 @@ import { MModal } from '@square/maker/components/Modal';
 import { MActionBar } from '@square/maker/components/ActionBar';
 import { MButton } from '@square/maker/components/Button';
 import { MImage } from '@square/maker/components/Image';
-import { X } from '@square/maker-icons';
+import X from '@square/maker-icons/X';
 
 export default {
 	components: {

--- a/lab/experiments/ActionBarTest/index/Modal.vue
+++ b/lab/experiments/ActionBarTest/index/Modal.vue
@@ -25,10 +25,7 @@
 					size="large"
 					shape="pill"
 				>
-					<x-icon
-						inline
-						class="icon"
-					/>
+					<x class="icon" />
 				</m-button>
 			</router-link>
 			<m-button
@@ -52,7 +49,7 @@ import { MModal } from '@square/maker/components/Modal';
 import { MActionBar } from '@square/maker/components/ActionBar';
 import { MButton } from '@square/maker/components/Button';
 import { MImage } from '@square/maker/components/Image';
-import { XIcon } from '@square/orbit-icons';
+import { X } from '@square/maker-icons';
 
 export default {
 	components: {
@@ -60,7 +57,7 @@ export default {
 		MActionBar,
 		MButton,
 		MImage,
-		XIcon,
+		X,
 	},
 };
 </script>

--- a/lab/experiments/Button.vue
+++ b/lab/experiments/Button.vue
@@ -7,7 +7,7 @@
 
 <script>
 import { MButton } from '@square/maker/components/Button';
-import { XIcon } from '@square/orbit-icons';
+import { X } from '@square/maker-icons';
 import Combinations from '~/components/Combinations';
 
 export default {
@@ -30,7 +30,7 @@ export default {
 					// 'Primary label',
 					`Really long text${' long'.repeat(30)}`,
 					// (<XIcon inline />),
-					[(<XIcon inline class="icon" />), `Really long text${' long'.repeat(30)}`],
+					[(<X class="icon" />), `Really long text${' long'.repeat(30)}`],
 					// (<AddIcon />),
 				],
 				'$slots.information': [

--- a/lab/experiments/Button.vue
+++ b/lab/experiments/Button.vue
@@ -7,7 +7,7 @@
 
 <script>
 import { MButton } from '@square/maker/components/Button';
-import { X } from '@square/maker-icons';
+import X from '@square/maker-icons/X';
 import Combinations from '~/components/Combinations';
 
 export default {

--- a/lab/experiments/KitchenSink.vue
+++ b/lab/experiments/KitchenSink.vue
@@ -431,7 +431,8 @@ import { MStepper } from '@square/maker/components/Stepper';
 import { MText } from '@square/maker/components/Text';
 import { MTextarea } from '@square/maker/components/Textarea';
 import { MToggle } from '@square/maker/components/Toggle';
-import { Plus, X } from '@square/maker-icons';
+import X from '@square/maker-icons/X';
+import Plus from '@square/maker-icons/Plus';
 
 export default {
 	components: {

--- a/lab/experiments/KitchenSink.vue
+++ b/lab/experiments/KitchenSink.vue
@@ -12,24 +12,15 @@
 				Button
 			</m-button>
 			<m-button>
-				<plus-icon
-					inline
-					class="icon"
-				/>
+				<plus class="icon" />
 				Button
 			</m-button>
 			<m-button>
 				Button
-				<plus-icon
-					inline
-					class="icon"
-				/>
+				<plus class="icon" />
 			</m-button>
 			<m-button>
-				<x-icon
-					inline
-					class="icon"
-				/>
+				<x class="icon" />
 			</m-button>
 			<m-button disabled>
 				Disabled button
@@ -41,24 +32,15 @@
 				Button
 			</m-button>
 			<m-button variant="secondary">
-				<plus-icon
-					inline
-					class="icon"
-				/>
+				<plus class="icon" />
 				Button
 			</m-button>
 			<m-button variant="secondary">
 				Button
-				<plus-icon
-					inline
-					class="icon"
-				/>
+				<plus class="icon" />
 			</m-button>
 			<m-button variant="secondary">
-				<x-icon
-					inline
-					class="icon"
-				/>
+				<x class="icon" />
 			</m-button>
 			<m-button
 				variant="secondary"
@@ -76,24 +58,15 @@
 				Button
 			</m-button>
 			<m-button variant="tertiary">
-				<plus-icon
-					inline
-					class="icon"
-				/>
+				<plus class="icon" />
 				Button
 			</m-button>
 			<m-button variant="tertiary">
 				Button
-				<plus-icon
-					inline
-					class="icon"
-				/>
+				<plus class="icon" />
 			</m-button>
 			<m-button variant="tertiary">
-				<x-icon
-					inline
-					class="icon"
-				/>
+				<x class="icon" />
 			</m-button>
 			<m-button
 				variant="tertiary"
@@ -196,10 +169,7 @@
 			</m-input>
 			<m-input placeholder="prefix icon">
 				<template #prefix>
-					<pencil-icon
-						inline
-						class="icon"
-					/>
+					<plus class="icon" />
 				</template>
 			</m-input>
 			<m-input
@@ -207,10 +177,7 @@
 				align="right"
 			>
 				<template #suffix>
-					<calendar-icon
-						inline
-						class="icon"
-					/>
+					<x class="icon" />
 				</template>
 			</m-input>
 			<m-input placeholder="with error message">
@@ -448,9 +415,6 @@
 </template>
 
 <script>
-import {
-	PlusIcon, XIcon, PencilIcon, CalendarIcon,
-} from '@square/orbit-icons';
 import { MButton } from '@square/maker/components/Button';
 import { MCheckbox } from '@square/maker/components/Checkbox';
 import { MDivider } from '@square/maker/components/Divider';
@@ -467,13 +431,12 @@ import { MStepper } from '@square/maker/components/Stepper';
 import { MText } from '@square/maker/components/Text';
 import { MTextarea } from '@square/maker/components/Textarea';
 import { MToggle } from '@square/maker/components/Toggle';
+import { Plus, X } from '@square/maker-icons';
 
 export default {
 	components: {
-		PlusIcon,
-		XIcon,
-		PencilIcon,
-		CalendarIcon,
+		Plus,
+		X,
 		MButton,
 		MCheckbox,
 		MDivider,

--- a/lab/experiments/StackedModals/index/FirstModal.vue
+++ b/lab/experiments/StackedModals/index/FirstModal.vue
@@ -55,7 +55,7 @@ import { MModal } from '@square/maker/components/Modal';
 import { MActionBar } from '@square/maker/components/ActionBar';
 import { MButton } from '@square/maker/components/Button';
 import { MImage } from '@square/maker/components/Image';
-import { X } from '@square/maker-icons';
+import X from '@square/maker-icons/X';
 
 export default {
 	components: {

--- a/lab/experiments/StackedModals/index/FirstModal.vue
+++ b/lab/experiments/StackedModals/index/FirstModal.vue
@@ -31,10 +31,7 @@
 					size="large"
 					shape="pill"
 				>
-					<x-icon
-						inline
-						class="icon"
-					/>
+					<x class="icon" />
 				</m-button>
 			</router-link>
 			<m-button
@@ -58,7 +55,7 @@ import { MModal } from '@square/maker/components/Modal';
 import { MActionBar } from '@square/maker/components/ActionBar';
 import { MButton } from '@square/maker/components/Button';
 import { MImage } from '@square/maker/components/Image';
-import { XIcon } from '@square/orbit-icons';
+import { X } from '@square/maker-icons';
 
 export default {
 	components: {
@@ -66,7 +63,7 @@ export default {
 		MActionBar,
 		MButton,
 		MImage,
-		XIcon,
+		X,
 	},
 };
 </script>

--- a/lab/experiments/StackedModals/index/FirstModal/SecondModal.vue
+++ b/lab/experiments/StackedModals/index/FirstModal/SecondModal.vue
@@ -46,7 +46,7 @@ import { MModal } from '@square/maker/components/Modal';
 import { MActionBar } from '@square/maker/components/ActionBar';
 import { MButton } from '@square/maker/components/Button';
 import { MImage } from '@square/maker/components/Image';
-import { X } from '@square/maker-icons';
+import X from '@square/maker-icons/X';
 
 export default {
 	components: {

--- a/lab/experiments/StackedModals/index/FirstModal/SecondModal.vue
+++ b/lab/experiments/StackedModals/index/FirstModal/SecondModal.vue
@@ -25,10 +25,7 @@
 					size="large"
 					shape="pill"
 				>
-					<x-icon
-						inline
-						class="icon"
-					/>
+					<x class="icon" />
 				</m-button>
 			</router-link>
 			<m-button
@@ -49,7 +46,7 @@ import { MModal } from '@square/maker/components/Modal';
 import { MActionBar } from '@square/maker/components/ActionBar';
 import { MButton } from '@square/maker/components/Button';
 import { MImage } from '@square/maker/components/Image';
-import { XIcon } from '@square/orbit-icons';
+import { X } from '@square/maker-icons';
 
 export default {
 	components: {
@@ -57,7 +54,7 @@ export default {
 		MActionBar,
 		MButton,
 		MImage,
-		XIcon,
+		X,
 	},
 };
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1509,13 +1509,10 @@
       "dev": true
     },
     "@square/maker-icons": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@square/maker-icons/-/maker-icons-1.0.1.tgz",
-      "integrity": "sha512-aEXhMVJv/JB//eZBU6WluhDMwdimbVgRHRFhJEfEnMuHOHTTvQ9OlgCiVZcZoFeE89EUQyBaKNvF4Qxu6rkN3w==",
-      "dev": true,
-      "requires": {
-        "feather-icons": "^4.26.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@square/maker-icons/-/maker-icons-2.0.0.tgz",
+      "integrity": "sha512-pel3XO5E4mMVsoRVrCA+ERTZdYvJrtxvhCqc8LpPoXG2HeO9kRceczLBjUcHXoDzFUfz/JoAJ4N/7sbZH/xtAQ==",
+      "dev": true
     },
     "@stylelint/postcss-css-in-js": {
       "version": "0.37.2",
@@ -3158,12 +3155,6 @@
           }
         }
       }
-    },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
-      "dev": true
     },
     "clean-css": {
       "version": "4.2.3",
@@ -5634,16 +5625,6 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
-      }
-    },
-    "feather-icons": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/feather-icons/-/feather-icons-4.28.0.tgz",
-      "integrity": "sha512-gRdqKESXRBUZn6Nl0VBq2wPHKRJgZz7yblrrc2lYsS6odkNFDnA4bqvrlEVRUPjE1tFax+0TdbJKZ31ziJuzjg==",
-      "dev": true,
-      "requires": {
-        "classnames": "^2.2.5",
-        "core-js": "^3.1.3"
       }
     },
     "figgy-pudding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@square/maker",
-  "version": "0.0.0",
+  "version": "1.0.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1508,13 +1508,13 @@
       "integrity": "sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw==",
       "dev": true
     },
-    "@square/orbit-icons": {
-      "version": "1.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@square/orbit-icons/-/orbit-icons-1.0.0-rc.1.tgz",
-      "integrity": "sha512-EFjM5glvscc/K0F59iQn6bQyFD1q8jIbdNqPg6O1LsTbo/d+qr8uaaG4CDdKSEllA0YZ19QqalQEFrlgj4f0gw==",
+    "@square/maker-icons": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@square/maker-icons/-/maker-icons-1.0.1.tgz",
+      "integrity": "sha512-aEXhMVJv/JB//eZBU6WluhDMwdimbVgRHRFhJEfEnMuHOHTTvQ9OlgCiVZcZoFeE89EUQyBaKNvF4Qxu6rkN3w==",
+      "dev": true,
       "requires": {
-        "feather-icons": "^4.24.1",
-        "simple-icons": "^2.0.0"
+        "feather-icons": "^4.26.0"
       }
     },
     "@stylelint/postcss-css-in-js": {
@@ -3162,7 +3162,8 @@
     "classnames": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+      "dev": true
     },
     "clean-css": {
       "version": "4.2.3",
@@ -3689,7 +3690,8 @@
     "core-js": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.1.tgz",
-      "integrity": "sha512-9Id2xHY1W7m8hCl8NkhQn5CufmF/WuR30BTRewvCXc1aZd3kMECwNZ69ndLbekKfakw9Rf2Xyc+QR6E7Gg+obg=="
+      "integrity": "sha512-9Id2xHY1W7m8hCl8NkhQn5CufmF/WuR30BTRewvCXc1aZd3kMECwNZ69ndLbekKfakw9Rf2Xyc+QR6E7Gg+obg==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.8.1",
@@ -5638,6 +5640,7 @@
       "version": "4.28.0",
       "resolved": "https://registry.npmjs.org/feather-icons/-/feather-icons-4.28.0.tgz",
       "integrity": "sha512-gRdqKESXRBUZn6Nl0VBq2wPHKRJgZz7yblrrc2lYsS6odkNFDnA4bqvrlEVRUPjE1tFax+0TdbJKZ31ziJuzjg==",
+      "dev": true,
       "requires": {
         "classnames": "^2.2.5",
         "core-js": "^3.1.3"
@@ -11372,11 +11375,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
-    },
-    "simple-icons": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-2.19.0.tgz",
-      "integrity": "sha512-DI0ZIKGoZlEnGqPF5jIGaOWWDvcXL323SZc7JBQp+pT/k0p72GU9Vxy7+UEtU9zZfWTbKiSQgtERF3pzPFhV2A=="
     },
     "simple-swizzle": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@square/maker",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0",
   "description": "📚 Maker Design System by Square",
   "license": "Apache-2.0",
   "files": [

--- a/package.json
+++ b/package.json
@@ -33,9 +33,11 @@
   "peerDependencies": {
     "chroma-js": "^2.1.0",
     "popmotion": "^8.7.5",
-    "vue": "^2.6.12"
+    "vue": "^2.6.12",
+    "@square/maker-icons": "1.0.1"
   },
   "devDependencies": {
+    "@square/maker-icons": "1.0.1",
     "@babel/preset-env": "^7.11.5",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
@@ -99,8 +101,5 @@
     "webpack": "^4.44.2",
     "webpack-cli": "^3.3.12",
     "webpack-distsize": "^0.1.0"
-  },
-  "dependencies": {
-    "@square/orbit-icons": "^1.0.0-rc.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "chroma-js": "^2.1.0",
     "popmotion": "^8.7.5",
     "vue": "^2.6.12",
-    "@square/maker-icons": "2.0.0"
+    "@square/maker-icons": "^2.0.0"
   },
   "devDependencies": {
-    "@square/maker-icons": "2.0.0",
+    "@square/maker-icons": "^2.0.0",
     "@babel/preset-env": "^7.11.5",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "chroma-js": "^2.1.0",
     "popmotion": "^8.7.5",
     "vue": "^2.6.12",
-    "@square/maker-icons": "1.0.1"
+    "@square/maker-icons": "2.0.0"
   },
   "devDependencies": {
-    "@square/maker-icons": "1.0.1",
+    "@square/maker-icons": "2.0.0",
     "@babel/preset-env": "^7.11.5",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -45,10 +45,7 @@
 							size="large"
 							:color="color"
 						>
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 							Button
 						</m-button>
 						<m-button
@@ -57,20 +54,14 @@
 							:color="color"
 						>
 							Button
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 						</m-button>
 						<m-button
 							variant="primary"
 							size="large"
 							:color="color"
 						>
-							<x-icon
-								inline
-								class="icon"
-							/>
+							<x class="icon" />
 						</m-button>
 						<m-button
 							variant="primary"
@@ -102,10 +93,7 @@
 							size="large"
 							:color="color"
 						>
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 							Button
 						</m-button>
 						<m-button
@@ -114,20 +102,14 @@
 							:color="color"
 						>
 							Button
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 						</m-button>
 						<m-button
 							variant="secondary"
 							size="large"
 							:color="color"
 						>
-							<x-icon
-								inline
-								class="icon"
-							/>
+							<x class="icon" />
 						</m-button>
 						<m-button
 							variant="secondary"
@@ -159,10 +141,7 @@
 							size="large"
 							:color="color"
 						>
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 							Button
 						</m-button>
 						<m-button
@@ -171,20 +150,14 @@
 							:color="color"
 						>
 							Button
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 						</m-button>
 						<m-button
 							variant="tertiary"
 							size="large"
 							:color="color"
 						>
-							<x-icon
-								inline
-								class="icon"
-							/>
+							<x class="icon" />
 						</m-button>
 						<m-button
 							variant="tertiary"
@@ -221,10 +194,7 @@
 							size="medium"
 							:color="color"
 						>
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 							Button
 						</m-button>
 						<m-button
@@ -233,20 +203,14 @@
 							:color="color"
 						>
 							Button
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 						</m-button>
 						<m-button
 							variant="primary"
 							size="medium"
 							:color="color"
 						>
-							<x-icon
-								inline
-								class="icon"
-							/>
+							<x class="icon" />
 						</m-button>
 						<m-button
 							variant="primary"
@@ -278,10 +242,7 @@
 							size="medium"
 							:color="color"
 						>
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 							Button
 						</m-button>
 						<m-button
@@ -290,20 +251,14 @@
 							:color="color"
 						>
 							Button
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 						</m-button>
 						<m-button
 							variant="secondary"
 							size="medium"
 							:color="color"
 						>
-							<x-icon
-								inline
-								class="icon"
-							/>
+							<x class="icon" />
 						</m-button>
 						<m-button
 							variant="secondary"
@@ -335,10 +290,7 @@
 							size="medium"
 							:color="color"
 						>
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 							Button
 						</m-button>
 						<m-button
@@ -347,20 +299,14 @@
 							:color="color"
 						>
 							Button
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 						</m-button>
 						<m-button
 							variant="tertiary"
 							size="medium"
 							:color="color"
 						>
-							<x-icon
-								inline
-								class="icon"
-							/>
+							<x class="icon" />
 						</m-button>
 						<m-button
 							variant="tertiary"
@@ -397,10 +343,7 @@
 							size="small"
 							:color="color"
 						>
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 							Button
 						</m-button>
 						<m-button
@@ -409,20 +352,14 @@
 							:color="color"
 						>
 							Button
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 						</m-button>
 						<m-button
 							variant="primary"
 							size="small"
 							:color="color"
 						>
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 						</m-button>
 						<m-button
 							variant="primary"
@@ -454,10 +391,7 @@
 							size="small"
 							:color="color"
 						>
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 							Button
 						</m-button>
 						<m-button
@@ -466,20 +400,14 @@
 							:color="color"
 						>
 							Button
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 						</m-button>
 						<m-button
 							variant="secondary"
 							size="small"
 							:color="color"
 						>
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 						</m-button>
 						<m-button
 							variant="secondary"
@@ -511,10 +439,7 @@
 							size="small"
 							:color="color"
 						>
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 							Button
 						</m-button>
 						<m-button
@@ -523,20 +448,14 @@
 							:color="color"
 						>
 							Button
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 						</m-button>
 						<m-button
 							variant="tertiary"
 							size="small"
 							:color="color"
 						>
-							<plus-icon
-								inline
-								class="icon"
-							/>
+							<plus class="icon" />
 						</m-button>
 						<m-button
 							variant="tertiary"
@@ -568,14 +487,14 @@
 </template>
 
 <script>
-import { PlusIcon, XIcon } from '@square/orbit-icons';
+import { Plus, X } from '@square/maker-icons';
 import { MButton } from '@square/maker/components/Button';
 
 export default {
 	components: {
 		MButton,
-		PlusIcon,
-		XIcon,
+		Plus,
+		X,
 	},
 	data() {
 		return {

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -487,7 +487,8 @@
 </template>
 
 <script>
-import { Plus, X } from '@square/maker-icons';
+import X from '@square/maker-icons/X';
+import Plus from '@square/maker-icons/Plus';
 import { MButton } from '@square/maker/components/Button';
 
 export default {

--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -92,7 +92,8 @@
 <script>
 import { MInput } from '@square/maker/components/Input';
 import { MNotice } from '@square/maker/components/Notice';
-import { Plus, X } from '@square/maker-icons';
+import X from '@square/maker-icons/X';
+import Plus from '@square/maker-icons/Plus';
 
 export default {
 	components: {

--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -44,10 +44,7 @@
 		<h4>prefix icon</h4>
 		<m-input placeholder="Placeholder">
 			<template #prefix>
-				<pencil-icon
-					inline
-					class="icon"
-				/>
+				<plus class="icon" />
 			</template>
 		</m-input>
 
@@ -57,10 +54,7 @@
 			align="right"
 		>
 			<template #suffix>
-				<calendar-icon
-					inline
-					class="icon"
-				/>
+				<x class="icon" />
 			</template>
 		</m-input>
 
@@ -70,10 +64,7 @@
 			disabled
 		>
 			<template #prefix>
-				<pencil-icon
-					inline
-					class="icon"
-				/>
+				<plus class="icon" />
 			</template>
 		</m-input>
 
@@ -83,10 +74,7 @@
 			invalid
 		>
 			<template #prefix>
-				<pencil-icon
-					inline
-					class="icon"
-				/>
+				<plus class="icon" />
 			</template>
 		</m-input>
 
@@ -102,16 +90,16 @@
 </template>
 
 <script>
-import { CalendarIcon, PencilIcon } from '@square/orbit-icons';
 import { MInput } from '@square/maker/components/Input';
 import { MNotice } from '@square/maker/components/Notice';
+import { Plus, X } from '@square/maker-icons';
 
 export default {
 	components: {
 		MInput,
 		MNotice,
-		PencilIcon,
-		CalendarIcon,
+		Plus,
+		X,
 	},
 };
 </script>

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -23,9 +23,10 @@
 </template>
 
 <script>
-import {
-	AlertTriangle, AlertCircle, CheckCircle, Info,
-} from '@square/maker-icons';
+import AlertTriangle from '@square/maker-icons/AlertTriangle';
+import AlertCircle from '@square/maker-icons/AlertCircle';
+import CheckCircle from '@square/maker-icons/CheckCircle';
+import Info from '@square/maker-icons/Info';
 
 /**
  * @inheritAttrs div

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -24,8 +24,8 @@
 
 <script>
 import {
- ExclamationTriangleIcon, CheckIcon, AlertCircleIcon, CircleIcon,
-} from '@square/orbit-icons';
+	AlertTriangle, AlertCircle, CheckCircle, Info,
+} from '@square/maker-icons';
 
 /**
  * @inheritAttrs div
@@ -33,10 +33,10 @@ import {
  */
 export default {
 	components: {
-		ExclamationTriangleIcon,
-		CheckIcon,
-		AlertCircleIcon,
-		CircleIcon,
+		AlertTriangle,
+		AlertCircle,
+		CheckCircle,
+		Info,
 	},
 
 	inheritAttrs: false,
@@ -63,15 +63,15 @@ export default {
 	computed: {
 		iconComponent() {
 			if (this.type === 'error') {
-				return ExclamationTriangleIcon;
+				return AlertTriangle;
 			}
 			if (this.type === 'success') {
-				return CheckIcon;
+				return CheckCircle;
 			}
 			if (this.type === 'warning') {
-				return AlertCircleIcon;
+				return AlertCircle;
 			}
-			return CircleIcon;
+			return Info;
 		},
 	},
 };
@@ -125,5 +125,6 @@ export default {
 	width: 16px;
 	height: 16px;
 	fill: currentColor;
+	stroke: white;
 }
 </style>

--- a/src/components/Select/src/SelectControl.vue
+++ b/src/components/Select/src/SelectControl.vue
@@ -35,15 +35,12 @@
 				{{ option.label }}
 			</option>
 		</select>
-		<arrow-down-icon
-			:class="$s.Icon"
-			inline
-		/>
+		<chevron-down :class="$s.Icon" />
 	</div>
 </template>
 
 <script>
-import { ArrowDownIcon } from '@square/orbit-icons';
+import { ChevronDown } from '@square/maker-icons';
 
 /**
  * @inheritAttrs select
@@ -51,7 +48,7 @@ import { ArrowDownIcon } from '@square/orbit-icons';
  */
 export default {
 	components: {
-		ArrowDownIcon,
+		ChevronDown,
 	},
 
 	inheritAttrs: false,
@@ -224,6 +221,5 @@ export default {
 	color: var(--color-disabled);
 	transform: translateY(-50%);
 	pointer-events: none;
-	fill: currentColor;
 }
 </style>

--- a/src/components/Select/src/SelectControl.vue
+++ b/src/components/Select/src/SelectControl.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script>
-import { ChevronDown } from '@square/maker-icons';
+import ChevronDown from '@square/maker-icons/ChevronDown';
 
 /**
  * @inheritAttrs select

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -32,7 +32,8 @@
 
 <script>
 import { MButton } from '@square/maker/components/Button';
-import { Plus, Minus } from '@square/maker-icons';
+import Plus from '@square/maker-icons/Plus';
+import Minus from '@square/maker-icons/Minus';
 
 export default {
 	components: {

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -11,10 +11,7 @@
 			:disabled="value === minVal"
 			@click="decrement"
 		>
-			<minus-icon
-				inline
-				:class="$s.Icon"
-			/>
+			<minus :class="$s.Icon" />
 		</m-button>
 		<span :class="$s.Quantity">
 			{{ value }}
@@ -28,23 +25,20 @@
 			:disabled="value === maxVal"
 			@click="increment"
 		>
-			<plus-icon
-				inline
-				:class="$s.Icon"
-			/>
+			<plus :class="$s.Icon" />
 		</m-button>
 	</div>
 </template>
 
 <script>
 import { MButton } from '@square/maker/components/Button';
-import { PlusIcon, MinusIcon } from '@square/orbit-icons';
+import { Plus, Minus } from '@square/maker-icons';
 
 export default {
 	components: {
 		MButton,
-		PlusIcon,
-		MinusIcon,
+		Plus,
+		Minus,
 	},
 
 	inheritAttrs: false,
@@ -148,7 +142,7 @@ export default {
 }
 
 .Icon {
-	width: 16px;
-	height: 16px;
+	width: 24px;
+	height: 24px;
 }
 </style>


### PR DESCRIPTION
**Describe the problem prior to this PR (link ticket/issue):**
some icons were off (wrong size or wrong style, i.e. outlined instead of filled)

**Describe the changes in this PR:**
- removes `orbit-icons`
- adds `maker-icons`: https://github.com/square/maker-icons