### PR TITLE
docs: comment out problematic styles

### DIFF
--- a/styleguide/App.vue
+++ b/styleguide/App.vue
@@ -29,6 +29,26 @@ body {
 </style>
 
 <style>
+/*
+While this import adds some syntax highlighting to the code
+examples inside the styleguide it looks terrible because:
+
+1. The styles clash with the default markdown styles,
+	i.e. github-markdown-css/github-markdown.css
+2. The styles contain weird z-index hacks which force
+	the code blocks to appear above opened layer components
+	like Modal & Blade which makes the demos for those components
+	incredibly difficult to use
+
 @import 'prismjs/themes/prism-coy.css';
+*/
+
 @import 'vue-demo-collapse/dist/style.css';
+
+/* override weird ugly hashed class from vue-demo-collapse */
+._1cQnY {
+	padding: 0 !important;
+	white-space: inherit !important;
+	border: none !important;
+}
 </style>


### PR DESCRIPTION
<!--
Prepend your PR title with one of the following:
- `feat:` A new feature
- `fix:` A bug fix
- `docs:` Documentation only changes
- `style:` Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- `refactor:` A code change that neither fixes a bug or adds a feature
- `perf:` A code change that improves performance
- `test:` Add missing tests
- `chore:` Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

**Describe the problem prior to this PR (link ticket/issue):**
Modal and Blade demos in styleguide were impossible to use because the syntax highlighting of prismjs forced source code to appear above the opened Modals/Blades, this PR comments out the problematic styles
