### PR TITLE
Disable segmentedcontrol validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@square/maker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "📚 Maker Design System by Square",
   "license": "Apache-2.0",
   "files": [

--- a/src/components/SegmentedControl/src/SegmentedControl.vue
+++ b/src/components/SegmentedControl/src/SegmentedControl.vue
@@ -15,7 +15,7 @@
 
 <script>
 import Subslot from 'vue-subslot';
-import assert from '@square/maker/utils/assert';
+// import assert from '@square/maker/utils/assert';
 import { MSegment } from '@square/maker/components/SegmentedControl';
 import key from './key';
 
@@ -73,7 +73,10 @@ export default {
 	},
 	methods: {
 		onNoSegments() {
-			assert.error(false, "You must pass 2-4 MSegment components to MSegmentedControl's default slot.");
+			// currently disabled because of weird behavior in Website Springboard
+			// commented out for now until we revisit enabling it again later
+			// assert.error(false, "You must pass 2-4 MSegment components to \
+			// MSegmentedControl's default slot.");
 		},
 	},
 };


### PR DESCRIPTION
Got a reported error case with the failed-to-validate logic firing even in seemingly correct uses of the component and its child component, gonna disable it for now to see if that fixes things.