### PR TITLE
fix(action-bar): vnode listeners patch

### DIFF
--- a/lab/experiments/ActionBarTest/CartModal.vue
+++ b/lab/experiments/ActionBarTest/CartModal.vue
@@ -60,7 +60,10 @@ export default {
 	},
 
 	props: {
-		openedBy: String,
+		openedBy: {
+			type: String,
+			required: true,
+		},
 	},
 };
 </script>

--- a/lab/experiments/ActionBarTest/CartModal.vue
+++ b/lab/experiments/ActionBarTest/CartModal.vue
@@ -6,6 +6,8 @@
 			/>
 		</div>
 
+		<h2>Opened by {{ openedBy }}</h2>
+
 		<div>
 			<h1>Cart modal content</h1>
 			<div
@@ -55,6 +57,10 @@ export default {
 	},
 	inject: {
 		modalApi,
+	},
+
+	props: {
+		openedBy: String,
 	},
 };
 </script>

--- a/lab/experiments/ActionBarTest/PageA.vue
+++ b/lab/experiments/ActionBarTest/PageA.vue
@@ -1,8 +1,8 @@
 <template>
 	<div>
-		<h1>Welcome to Index</h1>
-		<router-link to="/ActionBarTest/PageA">
-			Go to Page A
+		<h1>Welcome to Page A</h1>
+		<router-link to="/ActionBarTest/PageB">
+			Go to Page B
 		</router-link>
 		<m-action-bar>
 			<m-action-bar-button
@@ -11,7 +11,7 @@
 				full-width
 				@click="openCart"
 			>
-				Open modal from index
+				Open modal from Page A
 			</m-action-bar-button>
 		</m-action-bar>
 	</div>
@@ -34,7 +34,7 @@ export default {
 
 	methods: {
 		openCart() {
-			this.modalApi.open(() => <CartModal opened-by="index" />);
+			this.modalApi.open(() => <CartModal opened-by="page-a" />);
 		},
 	},
 };

--- a/lab/experiments/ActionBarTest/PageB.vue
+++ b/lab/experiments/ActionBarTest/PageB.vue
@@ -1,8 +1,8 @@
 <template>
 	<div>
-		<h1>Welcome to Index</h1>
-		<router-link to="/ActionBarTest/PageA">
-			Go to Page A
+		<h1>Welcome to Page B</h1>
+		<router-link to="/ActionBarTest/">
+			Go to index
 		</router-link>
 		<m-action-bar>
 			<m-action-bar-button
@@ -11,7 +11,7 @@
 				full-width
 				@click="openCart"
 			>
-				Open modal from index
+				Open modal from Page B
 			</m-action-bar-button>
 		</m-action-bar>
 	</div>
@@ -34,7 +34,7 @@ export default {
 
 	methods: {
 		openCart() {
-			this.modalApi.open(() => <CartModal opened-by="index" />);
+			this.modalApi.open(() => <CartModal opened-by="page-b" />);
 		},
 	},
 };

--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -71,6 +71,10 @@ export default {
 
 	created() {
 		this.actionBarStatesStaged = [];
+
+		/* Throttling prevents infinite render loop from happening when
+		 * slot child updates the actionBarStates, which re-renders slot child.
+		 */
 		this.applyStaged = throttle(this.applyStaged, 50, { leading: false });
 	},
 


### PR DESCRIPTION
<!--
Prepend your PR title with one of the following:
- `feat:` A new feature
- `fix:` A bug fix
- `docs:` Documentation only changes
- `style:` Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- `refactor:` A code change that neither fixes a bug or adds a feature
- `perf:` A code change that improves performance
- `test:` Add missing tests
- `chore:` Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

**Describe the problem prior to this PR (link ticket/issue):**
When given two vNodes with the same key that are swapped for each other, the second vNode's listener extends the previous listener's via `.fns` property. This didn't handle a vNode reverse scenario, which broke when swapping the Action Bar vNodes back to the previous page's.

**Describe the changes in this PR:**
<!-- Tip: inline screenshots to better communicate the changes -->
- Added a custom patch that backs up and restores the vNode's original listeners
- Enhanced "ActionBarTest" lab to have multiple pages where each page can open a modal to demonstrate that this solution works.


**Other information:**
