### PR TITLE
docs: Auto deploy + latest deploy

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
 		// eslint parsing bug: https://github.com/babel/babel/issues/10904
 		'template-curly-spacing': 'off',
 
+		'unicorn/no-process-exit': 'off',
 		'unicorn/no-useless-undefined': 'off',
 		'unicorn/filename-case': ['error', {
 			cases: {

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ node_modules/
 
 # Styleguide & Lab deploy distribution files
 /.dist/
+/.dist-test/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Square Maker
 
-A Vue.js component library.
+A Vue.js 2.x component library. [View the styleguide here](https://square.github.io/maker/styleguide/latest/#/).
 
 ## 🚀 Install
 

--- a/build/deploys/ensure.js
+++ b/build/deploys/ensure.js
@@ -5,17 +5,17 @@ const origin = require('remote-origin-url');
 const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
 
-module.exports = async function() {
+module.exports = async function ensureDeployDirectory() {
 	// check if .dist exists, otherwise create it
 
-	let distPath = path.resolve('./', '.dist');
+	const distPath = path.resolve('./', '.dist');
 	fse.ensureDirSync(distPath);
 	process.chdir(distPath);
 
 	// current working directory is now .dist
 	// check if .dist is a git repo, otherwise git init
 
-	let dotGitPath = path.resolve('./', '.git');
+	const dotGitPath = path.resolve('./', '.git');
 	let didInit = false;
 	if (!fse.existsSync(dotGitPath)) {
 		await exec('git init');
@@ -25,7 +25,7 @@ module.exports = async function() {
 	// check if git repo has square/maker as its remote origin
 
 	const remoteOrigin = origin.sync(); // returns undefined if no remote origin set
-	didAddOrigin = false;
+	let didAddOrigin = false;
 	if (remoteOrigin !== 'git@github.com:square/maker.git') {
 		if (!didInit) {
 			throw new Error(`you have some git repo in .dist with remote origin ${remoteOrigin} but the deploy script expects git@github.com:square/maker.git`);

--- a/build/deploys/ensure.js
+++ b/build/deploys/ensure.js
@@ -1,0 +1,49 @@
+const path = require('path');
+const fse = require('fs-extra');
+const branch = require('git-branch');
+const origin = require('remote-origin-url');
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec);
+
+module.exports = async function() {
+	// check if .dist exists, otherwise create it
+
+	let distPath = path.resolve('./', '.dist');
+	fse.ensureDirSync(distPath);
+	process.chdir(distPath);
+
+	// current working directory is now .dist
+	// check if .dist is a git repo, otherwise git init
+
+	let dotGitPath = path.resolve('./', '.git');
+	let didInit = false;
+	if (!fse.existsSync(dotGitPath)) {
+		await exec('git init');
+		didInit = true;
+	}
+
+	// check if git repo has square/maker as its remote origin
+
+	const remoteOrigin = origin.sync(); // returns undefined if no remote origin set
+	didAddOrigin = false;
+	if (remoteOrigin !== 'git@github.com:square/maker.git') {
+		if (!didInit) {
+			throw new Error(`you have some git repo in .dist with remote origin ${remoteOrigin} but the deploy script expects git@github.com:square/maker.git`);
+		}
+		await exec('git remote add origin git@github.com:square/maker.git');
+		didAddOrigin = true;
+	}
+
+	// fetch remote branches if necessary
+
+	if (didAddOrigin) {
+		await exec('git fetch');
+	}
+
+	// check if git repo has the deploys branch checked out
+
+	const gitBranch = branch.sync();
+	if (gitBranch !== 'deploys') {
+		await exec('git checkout deploys');
+	}
+};

--- a/build/deploys/pull.js
+++ b/build/deploys/pull.js
@@ -1,0 +1,9 @@
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec);
+
+(async function() {
+	await require('./ensure')();
+
+	// pull
+	await exec('git pull');
+})();

--- a/build/deploys/pull.js
+++ b/build/deploys/pull.js
@@ -1,9 +1,10 @@
 const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
+const ensureDeployDirectory = require('./ensure');
 
-(async function() {
-	await require('./ensure')();
+(async function pullDeploys() {
+	await ensureDeployDirectory();
 
 	// pull
 	await exec('git pull');
-})();
+}());

--- a/build/deploys/push.js
+++ b/build/deploys/push.js
@@ -1,0 +1,15 @@
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec);
+
+(async function() {
+	await require('./ensure')();
+
+	// add all changes
+	await exec('git add --all');
+
+	// commit
+	await exec('git commit -m "docs: update deploys"')
+
+	// push
+	await exec('git push');
+})();

--- a/build/deploys/push.js
+++ b/build/deploys/push.js
@@ -1,15 +1,16 @@
 const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
+const ensureDeployDirectory = require('./ensure');
 
-(async function() {
-	await require('./ensure')();
+(async function pushDeploys() {
+	await ensureDeployDirectory();
 
 	// add all changes
 	await exec('git add --all');
 
 	// commit
-	await exec('git commit -m "docs: update deploys"')
+	await exec('git commit -m "docs: update deploys"');
 
 	// push
 	await exec('git push');
-})();
+}());

--- a/build/sync-to-latest/index.js
+++ b/build/sync-to-latest/index.js
@@ -1,0 +1,11 @@
+const path = require('path');
+const branch = require('git-branch');
+const { version } = require('../../package.json');
+
+const branchName = branch.sync();
+const deploy = branchName === 'master' ? version : branchName;
+
+let deployPath = path.resolve('./', '.dist/styleguide', deploy);
+let latestPath = path.resolve('./', '.dist/styleguide/latest');
+
+console.log(deployPath, latestPath);

--- a/build/sync-to-latest/index.js
+++ b/build/sync-to-latest/index.js
@@ -6,12 +6,12 @@ const { version } = require('../../package.json');
 const branchName = branch.sync();
 if (branchName !== 'master') {
 	// only sync versioned releases to latest directory
-	return;
+	process.exit(0);
 }
 const deploy = version;
 
-let deployPath = path.resolve('./', '.dist/styleguide', deploy);
-let latestPath = path.resolve('./', '.dist/styleguide/latest');
+const deployPath = path.resolve('./', '.dist/styleguide', deploy);
+const latestPath = path.resolve('./', '.dist/styleguide/latest');
 
 fse.removeSync(latestPath);
 fse.copySync(deployPath, latestPath);

--- a/build/sync-to-latest/index.js
+++ b/build/sync-to-latest/index.js
@@ -13,7 +13,5 @@ const deploy = version;
 let deployPath = path.resolve('./', '.dist/styleguide', deploy);
 let latestPath = path.resolve('./', '.dist/styleguide/latest');
 
-console.log(deployPath, latestPath);
-
 fse.removeSync(latestPath);
 fse.copySync(deployPath, latestPath);

--- a/build/sync-to-latest/index.js
+++ b/build/sync-to-latest/index.js
@@ -1,11 +1,19 @@
 const path = require('path');
+const fse = require('fs-extra');
 const branch = require('git-branch');
 const { version } = require('../../package.json');
 
 const branchName = branch.sync();
-const deploy = branchName === 'master' ? version : branchName;
+if (branchName !== 'master') {
+	// only sync versioned releases to latest directory
+	return;
+}
+const deploy = version;
 
 let deployPath = path.resolve('./', '.dist/styleguide', deploy);
 let latestPath = path.resolve('./', '.dist/styleguide/latest');
 
 console.log(deployPath, latestPath);
+
+fse.removeSync(latestPath);
+fse.copySync(deployPath, latestPath);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6082,6 +6082,12 @@
         "findup-sync": "^2.0.0"
       }
     },
+    "git-config-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-2.0.0.tgz",
+      "integrity": "sha512-qc8h1KIQbJpp+241id3GuAtkdyJ+IK+LIVtkiFTRKRrmddDzs3SI9CvP1QYmWBFvm1I/PWRwj//of8bgAc0ltA==",
+      "dev": true
+    },
     "git-raw-commits": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.8.tgz",
@@ -8879,6 +8885,16 @@
         "is-hexadecimal": "^1.0.0"
       }
     },
+    "parse-git-config": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-3.0.0.tgz",
+      "integrity": "sha512-wXoQGL1D+2COYWCD35/xbiKma1Z15xvZL8cI25wvxzled58V51SJM04Urt/uznS900iQor7QO04SgdfT/XlbuA==",
+      "dev": true,
+      "requires": {
+        "git-config-path": "^2.0.0",
+        "ini": "^1.3.5"
+      }
+    },
     "parse-json": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
@@ -10981,6 +10997,15 @@
       "dev": true,
       "requires": {
         "mdast-util-to-markdown": "^0.6.0"
+      }
+    },
+    "remote-origin-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-2.0.0.tgz",
+      "integrity": "sha512-4TKz5bTDEHFzsqgjQZY/NxNqceWhtWD69Fgwetm+172GT2NoljyQssB649ECUBHGhBINuGwKw8mfcjQFugdIlg==",
+      "dev": true,
+      "requires": {
+        "parse-git-config": "^3.0.0"
       }
     },
     "remove-trailing-separator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@square/maker",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5945,15 +5945,15 @@
       }
     },
     "fs-extra": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
       }
     },
     "fs-minipass": {
@@ -7328,14 +7328,6 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
-      },
-      "dependencies": {
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
-        }
       }
     },
     "jsonparse": {
@@ -13657,9 +13649,9 @@
       }
     },
     "universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
     },
     "unpipe": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint": "npm run lint:js && npm run lint:css",
     "lint:js": "eslint --format=pretty --ext vue,js,md --max-warnings=0 --cache src lab styleguide build",
     "lint:css": "stylelint --max-warnings=0 src/**/*.{vue,css}",
-    "lint:fix": "npm run lint:js -- --fix && npm run lint:css -- --fix"
+    "lint:fix": "npm run lint:js -- --fix && npm run lint:css -- --fix",
+		"sync-to-latest": "node ./build/sync-to-latest"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -11,16 +11,18 @@
     "build": "NODE_ENV=production webpack --config build/webpack-build-config",
     "dev": "npm run generate-api-tables && just-ssr --webpack-config build/webpack-development-config --open",
     "lab": "just-ssr --webpack-config lab/webpack-lab-config --open --port 8081",
-    "lab-build": "NODE_ENV=production webpack --config lab/webpack-lab-config && npm run generate-deploy-index",
+    "lab-build": "npm run pull-deploys && NODE_ENV=production webpack --config lab/webpack-lab-config && npm run generate-deploy-index && npm run push-deploys",
     "generate-api-tables": "node ./build/generate-readme-api-tables",
     "styleguide": "npm run generate-api-tables && just-ssr --webpack-config styleguide/webpack-styleguide-config --open",
-    "styleguide-build": "npm run generate-api-tables && NODE_ENV=production webpack --config styleguide/webpack-styleguide-config && npm run sync-to-latest && npm run generate-deploy-index",
+    "styleguide-build": "npm run generate-api-tables && npm run pull-deploys && NODE_ENV=production webpack --config styleguide/webpack-styleguide-config && npm run sync-to-latest && npm run generate-deploy-index && npm run push-deploys",
     "generate-deploy-index": "node ./build/generate-deploy-index",
     "lint": "npm run lint:js && npm run lint:css",
     "lint:js": "eslint --format=pretty --ext vue,js,md --max-warnings=0 --cache src lab styleguide build",
     "lint:css": "stylelint --max-warnings=0 src/**/*.{vue,css}",
     "lint:fix": "npm run lint:js -- --fix && npm run lint:css -- --fix",
-    "sync-to-latest": "node ./build/sync-to-latest"
+    "sync-to-latest": "node ./build/sync-to-latest",
+    "pull-deploys": "node ./build/deploys/pull.js",
+    "push-deploys": "node ./build/deploys/push.js"
   },
   "husky": {
     "hooks": {
@@ -79,6 +81,7 @@
     "postcss-loader": "^4.0.2",
     "postcss-preset-env": "^6.7.0",
     "prismjs": "^1.23.0",
+    "remote-origin-url": "^2.0.0",
     "stylelint": "^13.9.0",
     "stylelint-config-css-modules": "^2.2.0",
     "stylelint-config-rational-order": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "lab-build": "NODE_ENV=production webpack --config lab/webpack-lab-config && npm run generate-deploy-index",
     "generate-api-tables": "node ./build/generate-readme-api-tables",
     "styleguide": "npm run generate-api-tables && just-ssr --webpack-config styleguide/webpack-styleguide-config --open",
-    "styleguide-build": "npm run generate-api-tables && NODE_ENV=production webpack --config styleguide/webpack-styleguide-config && npm run generate-deploy-index",
+    "styleguide-build": "npm run generate-api-tables && NODE_ENV=production webpack --config styleguide/webpack-styleguide-config && npm run sync-to-latest && npm run generate-deploy-index",
     "generate-deploy-index": "node ./build/generate-deploy-index",
     "lint": "npm run lint:js && npm run lint:css",
     "lint:js": "eslint --format=pretty --ext vue,js,md --max-warnings=0 --cache src lab styleguide build",
     "lint:css": "stylelint --max-warnings=0 src/**/*.{vue,css}",
     "lint:fix": "npm run lint:js -- --fix && npm run lint:css -- --fix",
-		"sync-to-latest": "node ./build/sync-to-latest"
+    "sync-to-latest": "node ./build/sync-to-latest"
   },
   "husky": {
     "hooks": {
@@ -63,6 +63,7 @@
     "eslint-plugin-unicorn": "^22.0.0",
     "eslint-plugin-vue": "^7.4.1",
     "eslint-webpack-plugin": "^2.4.3",
+    "fs-extra": "^9.1.0",
     "git-branch": "^2.0.1",
     "github-markdown-css": "^4.0.0",
     "has-own-prop": "^2.0.0",


### PR DESCRIPTION
**Describe the problem prior to this PR (link ticket/issue):**
deploying styleguide and lab was an ad-hoc process that only I understood

**Describe the changes in this PR:**
adds scripts which auto-deploys the lab and styleguide after lab and styleguide builds respectively. everything should work auto-magically even if the person has never done a deploy before. also automatically copies versioned styleguide releases to a `latest` branch so we have a stable URL, i.e. `square.github.io/maker/styleguide/latest`, that we can share with people and will always have the latest updates.