### PR TITLE
fix: Inline margin to padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@square/maker",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "📚 Maker Design System by Square",
   "license": "Apache-2.0",
   "files": [

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -29,12 +29,12 @@ export default {
 
 <style module="$s">
 .ActionBarWrapper {
-	margin-bottom: 120px;
+	padding-bottom: 120px;
 }
 
 @media screen and (min-width: 1200px) {
 	.ActionBarWrapper {
-		margin-bottom: 104px;
+		padding-bottom: 104px;
 	}
 }
 </style>


### PR DESCRIPTION
<!--
Prepend your PR title with one of the following:
- `feat:` A new feature
- `fix:` A bug fix
- `docs:` Documentation only changes
- `style:` Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- `refactor:` A code change that neither fixes a bug or adds a feature
- `perf:` A code change that improves performance
- `test:` Add missing tests
- `chore:` Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

**Describe the problem prior to this PR (link ticket/issue):**
BX noticed some weird issues with actionbars used within modals on mobile safari and tracked it down to the `margin-bottom` style inside inlineactionbar, the fix is to switch to `padding-bottom`.
