### PR TITLE
feat: update stepper to include a size slot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@square/maker",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "📚 Maker Design System by Square",
   "license": "Apache-2.0",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@square/maker",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "📚 Maker Design System by Square",
   "license": "Apache-2.0",
   "files": [

--- a/src/components/Stepper/README.md
+++ b/src/components/Stepper/README.md
@@ -2,11 +2,40 @@
 
 ```vue
 <template>
-	<div>
-		<m-stepper
-			v-model="number"
-		/>
-		{{ number }}
+	<div
+		style="text-align: center"
+	>
+		<div>
+			<h3>Small</h3>
+			<m-stepper
+				v-model="smallNumber"
+				min="0"
+				max="10"
+			/>
+			v-model: {{ smallNumber }}
+		</div>
+		<div>
+			<h3>Medium</h3>
+			<m-stepper
+				v-model="mediumNumber"
+				size="medium"
+				color="black"
+				min="0"
+				max="10"
+			/>
+			v-model: {{ mediumNumber }}
+		</div>
+		<div>
+			<h3>Large</h3>
+			<m-stepper
+				v-model="largeNumber"
+				size="large"
+				color="black"
+				min="0"
+				max="10"
+			/>
+			v-model: {{ largeNumber }}
+		</div>
 	</div>
 </template>
 
@@ -20,7 +49,9 @@ export default {
 
 	data() {
 		return {
-			number: 0,
+			smallNumber: 0,
+			mediumNumber: 0,
+			largeNumber: 0,
 		};
 	},
 };
@@ -30,13 +61,14 @@ export default {
 <!-- api-tables:start -->
 ## Props
 
-| Prop       | Type            | Default     | Possible values | Description                     |
-| ---------- | --------------- | ----------- | --------------- | ------------------------------- |
-| v-model*   | `number`        | —           | —               | stepper's current value         |
-| min        | `number|string` | —           | —               | stepper min value               |
-| max        | `number|string` | —           | —               | stepper max value               |
-| color      | `string`        | `'#cccccc'` | —               | stepper button background color |
-| text-color | `string`        | `'#000000'` | —               | stepper button text color       |
+| Prop       | Type            | Default     | Possible values               | Description                     |
+| ---------- | --------------- | ----------- | ----------------------------- | ------------------------------- |
+| v-model*   | `number`        | —           | —                             | stepper's current value         |
+| min        | `number|string` | —           | —                             | stepper min value               |
+| max        | `number|string` | —           | —                             | stepper max value               |
+| color      | `string`        | `'#cccccc'` | —                             | stepper button background color |
+| text-color | `string`        | `'#000000'` | —                             | stepper button text color       |
+| size       | `string`        | `'small'`   | `small`, `medium`, `large`    | stepper size variation          |
 
 
 ## Events

--- a/src/components/Stepper/README.md
+++ b/src/components/Stepper/README.md
@@ -19,7 +19,6 @@
 			<m-stepper
 				v-model="mediumNumber"
 				size="medium"
-				color="black"
 				min="0"
 				max="10"
 			/>
@@ -30,7 +29,6 @@
 			<m-stepper
 				v-model="largeNumber"
 				size="large"
-				color="black"
 				min="0"
 				max="10"
 			/>
@@ -61,14 +59,14 @@ export default {
 <!-- api-tables:start -->
 ## Props
 
-| Prop       | Type            | Default     | Possible values               | Description                     |
-| ---------- | --------------- | ----------- | ----------------------------- | ------------------------------- |
-| v-model*   | `number`        | —           | —                             | stepper's current value         |
-| min        | `number|string` | —           | —                             | stepper min value               |
-| max        | `number|string` | —           | —                             | stepper max value               |
-| color      | `string`        | `'#cccccc'` | —                             | stepper button background color |
-| text-color | `string`        | `'#000000'` | —                             | stepper button text color       |
-| size       | `string`        | `'small'`   | `small`, `medium`, `large`    | stepper size variation          |
+| Prop       | Type            | Default     | Possible values            | Description                                     |
+| ---------- | --------------- | ----------- | -------------------------- | ----------------------------------------------- |
+| v-model*   | `number`        | —           | —                          | stepper's current value                         |
+| min        | `number|string` | —           | —                          | stepper min value                               |
+| max        | `number|string` | —           | —                          | stepper max value                               |
+| color      | `string`        | `'#cccccc'` | —                          | stepper button background color                 |
+| text-color | `string`        | `'#000000'` | —                          | stepper button text color                       |
+| size       | `string`        | `'small'`   | `small`, `medium`, `large` | stepper button size                             |
 
 
 ## Events

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -3,9 +3,9 @@
 		:class="$s.Stepper"
 	>
 		<m-button
-			size="large"
-			variant="primary"
 			shape="pill"
+			:variant="buttonVariant"
+			:size="size"
 			:color="color"
 			:text-color="textColor"
 			:disabled="value === minVal"
@@ -17,9 +17,9 @@
 			{{ value }}
 		</span>
 		<m-button
-			size="large"
-			variant="primary"
 			shape="pill"
+			:variant="buttonVariant"
+			:size="size"
 			:color="color"
 			:text-color="textColor"
 			:disabled="value === maxVal"
@@ -85,6 +85,15 @@ export default {
 			type: String,
 			default: '#000000',
 		},
+
+		/**
+		 * stepper size, adjusts button variation and size
+		 */
+		size: {
+			type: String,
+			default: 'small',
+			validator: (size) => ['small', 'medium', 'large'].includes(size),
+		},
 	},
 
 	computed: {
@@ -94,6 +103,10 @@ export default {
 
 		minVal() {
 			return Number.parseInt(this.min, 10);
+		},
+
+		buttonVariant() {
+			return this.size === 'small' ? 'primary' : 'secondary';
 		},
 	},
 

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -4,7 +4,7 @@
 	>
 		<m-button
 			shape="pill"
-			:variant="buttonVariant"
+			variant="primary"
 			:size="size"
 			:color="color"
 			:text-color="textColor"
@@ -18,7 +18,7 @@
 		</span>
 		<m-button
 			shape="pill"
-			:variant="buttonVariant"
+			variant="primary"
 			:size="size"
 			:color="color"
 			:text-color="textColor"
@@ -87,7 +87,7 @@ export default {
 		},
 
 		/**
-		 * stepper size, adjusts button variation and size
+		 * stepper button size
 		 */
 		size: {
 			type: String,
@@ -103,10 +103,6 @@ export default {
 
 		minVal() {
 			return Number.parseInt(this.min, 10);
-		},
-
-		buttonVariant() {
-			return this.size === 'small' ? 'primary' : 'secondary';
 		},
 	},
 


### PR DESCRIPTION
**Describe the problem prior to this PR (link ticket/issue):**
Added size variations to stepper component
**Describe the changes in this PR:**
https://www.figma.com/file/2cgnI0Cb5L7DqdCNiIRrot/%F0%9F%8D%81-Maker-Design-System?node-id=2379%3A19590

- Small stepper size uses small buttons, and primary button type
- Medium and large buttons use medium and large buttons respectively, and use secondary button type

<img width="441" alt="Screen Shot 2021-03-09 at 2 02 31 PM" src="https://user-images.githubusercontent.com/23425012/110523663-67f3e980-80e0-11eb-964a-682e067db19a.png">

**Other information:**
