### PR TITLE
style: update modal breakpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@square/maker",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "📚 Maker Design System by Square",
   "license": "Apache-2.0",
   "files": [

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -247,7 +247,7 @@ export default {
 	}
 }
 
-@media screen and (min-width: 1200px) {
+@media screen and (min-width: 840px) {
 	.Button {
 		min-height: 48px;
 

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -32,7 +32,7 @@ export default {
 	padding-bottom: 120px;
 }
 
-@media screen and (min-width: 1200px) {
+@media screen and (min-width: 840px) {
 	.ActionBarWrapper {
 		padding-bottom: 104px;
 	}

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -21,7 +21,7 @@
 	background: #f5f6f7;
 }
 
-@media screen and (min-width: 1200px) {
+@media screen and (min-width: 840px) {
 	.Container {
 		display: inline-block;
 		width: auto;
@@ -32,6 +32,7 @@
 
 	.Modal {
 		width: 600px;
+		min-height: 180px;
 		max-height: calc(100vh - 64px);
 	}
 }

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -35,7 +35,7 @@ import PseudoWindow from 'vue-pseudo-window';
 import { MTransitionFade } from '@square/maker/components/TransitionFade';
 import { MTransitionSpringResponsive } from '@square/maker/utils/TransitionSpringResponsive';
 import {
-	fadeIn, fadeOut, springUp, springDown, mobileMinWidth, desktopMinWidth,
+	fadeIn, fadeOut, springUp, springDown, mobileMinWidth, tabletMinWidth,
 } from '@square/maker/utils/transitions';
 import modalApi from './modal-api';
 
@@ -108,7 +108,7 @@ export default {
 				enter: springUp,
 				leave: springDown,
 			}, {
-				minWidth: desktopMinWidth,
+				minWidth: tabletMinWidth,
 				enter: fadeIn,
 				leave: fadeOut,
 			}],

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -1,5 +1,6 @@
 export const mobileMinWidth = 0;
-export const desktopMinWidth = 840;
+export const tabletMinWidth = 840;
+export const desktopMinWidth = 1200;
 
 export const stiffness = 600;
 export const damping = 60;
@@ -56,5 +57,6 @@ export default {
 	stiffness,
 	damping,
 	mobileMinWidth,
+	tabletMinWidth,
 	desktopMinWidth,
 };

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -1,5 +1,5 @@
 export const mobileMinWidth = 0;
-export const desktopMinWidth = 1200;
+export const desktopMinWidth = 840;
 
 export const stiffness = 600;
 export const damping = 60;


### PR DESCRIPTION
**Describe the problem prior to this PR (link ticket/issue):**
Modal breakpoint of 1200px was too large.. it was decided to reduce this to 840px
**Describe the changes in this PR:**
Reduced breakpoints from 1200px to 840px for modals, the inline-action-bar, and the transition variable.

**Other information:**
I left the atomic action bar and action bar layer at 1200px since those breakpoints were unrelated to modals specifically.
