### PR TITLE
fix: this actionbar is GOING TO DA MOON

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@square/maker",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "📚 Maker Design System by Square",
   "license": "Apache-2.0",
   "files": [

--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -71,7 +71,7 @@ export default {
 
 <style module="$s">
 .ActionBarLayer {
-	padding-bottom: 128px;
+	padding-bottom: 146px;
 }
 
 .ActionBar {
@@ -83,7 +83,7 @@ export default {
 	display: flex;
 	justify-content: space-between;
 	box-sizing: border-box;
-	padding: 24px 24px 40px 24px;
+	padding: 24px 24px 58px 24px;
 	background-image: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
 }
 

--- a/src/components/ActionBar/src/AtomicActionBar.vue
+++ b/src/components/ActionBar/src/AtomicActionBar.vue
@@ -44,7 +44,7 @@ export default {
 	display: flex;
 	justify-content: space-between;
 	box-sizing: border-box;
-	padding: 24px 24px 40px 24px;
+	padding: 24px 24px 58px 24px;
 	background-image: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
 }
 

--- a/src/components/ActionBar/src/AtomicActionBar.vue
+++ b/src/components/ActionBar/src/AtomicActionBar.vue
@@ -58,6 +58,10 @@ export default {
 	.hide-on_tablet {
 		display: none;
 	}
+
+	.ActionBar {
+		padding: 24px 24px 32px 24px;
+	}
 }
 
 @media screen and (min-width: 1200px) {

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -29,7 +29,7 @@ export default {
 
 <style module="$s">
 .ActionBarWrapper {
-	padding-bottom: 146px;
+	padding-bottom: 120px;
 }
 
 @media screen and (min-width: 840px) {

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -29,12 +29,12 @@ export default {
 
 <style module="$s">
 .ActionBarWrapper {
-	padding-bottom: 128px;
+	padding-bottom: 146px;
 }
 
 @media screen and (min-width: 840px) {
 	.ActionBarWrapper {
-		padding-bottom: 112px;
+		padding-bottom: 130px;
 	}
 }
 </style>


### PR DESCRIPTION
🚀 🚀 🌔 🌔 

Increases ActionBar bottom padding to 58px on mobile to partially evade iOS Safari deadclick zone. Leaves desktop at 32px.