### PR TITLE
docs(input): remove double props section

### DIFF
--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -239,9 +239,6 @@ export default {
 </script>
 ```
 
-## Props
-Supports all `<input>` attributes
-
 <!-- api-tables:start -->
 ## Props
 


### PR DESCRIPTION
<!--
Prepend your PR title with one of the following:
- `feat:` A new feature
- `fix:` A bug fix
- `docs:` Documentation only changes
- `style:` Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- `refactor:` A code change that neither fixes a bug or adds a feature
- `perf:` A code change that improves performance
- `test:` Add missing tests
- `chore:` Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

**Describe the problem prior to this PR (link ticket/issue):**
Props section is now generated but Input docs had old props section left over from before


**Describe the changes in this PR:**
<!-- Tip: inline screenshots to better communicate the changes -->
Removed old props section heading

**Other information:**
