### PR TITLE
feat: success and error button variants

### DIFF
--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -483,6 +483,16 @@
 		>
 			One-Off Reversed Button
 		</m-button>
+			<m-button
+				variant="success"
+			>
+				Success button
+			</m-button>
+			<m-button
+				variant="error"
+			>
+				Error button
+			</m-button>
 	</div>
 </template>
 

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -534,18 +534,18 @@ body {
 
 Supports attributes from [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button).
 
-| Prop       | Type      | Default     | Possible values                    | Description                           |
-| ---------- | --------- | ----------- | ---------------------------------- | ------------------------------------- |
-| type       | `string`  | `'button'`  | —                                  | Type of the button                    |
-| size       | `string`  | `'medium'`  | `small`, `medium`, `large`         | Size of the button                    |
-| full-width | `boolean` | `false`     | —                                  | Whether to make the button full-width |
-| color      | `string`  | `'#000'`    | —                                  | Background color of button            |
-| text-color | `string`  | —           | —                                  | Text color of button                  |
-| variant    | `string`  | `'primary'` | `primary`, `secondary`, `tertiary` | Semantic variant                      |
-| shape      | `string`  | `'rounded'` | `squared`, `rounded`, `pill`       | Shape of button                       |
-| disabled   | `boolean` | `false`     | —                                  | Toggles button disabled state         |
-| align      | `string`  | `'center'`  | `center`, `stack`, `space-between` | How to align button's contents        |
-| loading    | `boolean` | `false`     | —                                  | Toggles button loading state          |
+| Prop       | Type      | Default     | Possible values                                        | Description                           |
+| ---------- | --------- | ----------- | ------------------------------------------------------ | ------------------------------------- |
+| type       | `string`  | `'button'`  | —                                                      | Type of the button                    |
+| size       | `string`  | `'medium'`  | `small`, `medium`, `large`                             | Size of the button                    |
+| full-width | `boolean` | `false`     | —                                                      | Whether to make the button full-width |
+| color      | `string`  | `'#000'`    | —                                                      | Background color of button            |
+| text-color | `string`  | —           | —                                                      | Text color of button                  |
+| variant    | `string`  | `'primary'` | `primary`, `secondary`, `tertiary`, `success`, `error` | Semantic variant                      |
+| shape      | `string`  | `'rounded'` | `squared`, `rounded`, `pill`                           | Shape of button                       |
+| disabled   | `boolean` | `false`     | —                                                      | Toggles button disabled state         |
+| align      | `string`  | `'center'`  | `center`, `stack`, `space-between`                     | How to align button's contents        |
+| loading    | `boolean` | `false`     | —                                                      | Toggles button loading state          |
 
 
 ## Slots

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -126,10 +126,57 @@ function ghost(tokens) {
 	};
 }
 
+function success(tokens) {
+	const color = chroma('#1fad1f');
+	const colorHover = getHover(color);
+	const colorActive = getActive(color);
+	const textColor = tokens.textColor ? 'rgba(255, 255, 255, 0.95)' : undefined;
+	const contrastColor = getContrast(color, textColor);
+	const contrastColorHover = getHover(contrastColor);
+	const contrastColorActive = getActive(contrastColor);
+	const focusColor = getFocus(color);
+	return {
+		'--small-padding': '8px 16px',
+		'--medium-padding': '12px 24px',
+		'--large-padding': '20px 32px',
+		'--color-main': color.hex(),
+		'--color-main-hover': colorHover.hex(),
+		'--color-main-active': colorActive.hex(),
+		'--color-contrast': contrastColor.hex(),
+		'--color-contrast-hover': contrastColorHover.hex(),
+		'--color-contrast-active': contrastColorActive.hex(),
+		'--color-focus': focusColor.hex(),
+	};
+}
+function error(tokens) {
+	const color = chroma('#ce3217');
+	const colorHover = getHover(color);
+	const colorActive = getActive(color);
+	const textColor = tokens.textColor ? 'rgba(255, 255, 255, 0.95)' : undefined;
+	const contrastColor = getContrast(color, textColor);
+	const contrastColorHover = getHover(contrastColor);
+	const contrastColorActive = getActive(contrastColor);
+	const focusColor = getFocus(color);
+	return {
+		'--small-padding': '8px 16px',
+		'--medium-padding': '12px 24px',
+		'--large-padding': '20px 32px',
+		'--color-main': color.hex(),
+		'--color-main-hover': colorHover.hex(),
+		'--color-main-active': colorActive.hex(),
+		'--color-contrast': contrastColor.hex(),
+		'--color-contrast-hover': contrastColorHover.hex(),
+		'--color-contrast-active': contrastColorActive.hex(),
+		'--color-focus': focusColor.hex(),
+	};
+}
+
 const VARIANTS = {
 	primary: fill,
 	secondary: outline,
 	tertiary: ghost,
+	success,
+	error,
 };
 
 /**
@@ -189,7 +236,7 @@ export default {
 		variant: {
 			type: String,
 			default: 'primary',
-			validator: (variant) => ['primary', 'secondary', 'tertiary'].includes(variant),
+			validator: (variant) => ['primary', 'secondary', 'tertiary', 'success', 'error'].includes(variant),
 		},
 		/**
 		 * Shape of button

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -505,12 +505,12 @@ export default {
 }
 
 .Icon.type_success {
-	--color-contrast: rgba(52, 199, 89, 1);
-	--color-main: rgba(239, 245, 241, 1);
+	--color-contrast: #1fad1f;
+	--color-main: rgba(255, 255, 255, 0.95);
 }
 
 .Icon.type_error {
-	--color-contrast: rgba(255, 59, 48, 1);
-	--color-main: rgba(245, 239, 239, 1);
+	--color-contrast: #ce3217;
+	--color-main: rgba(255, 255, 255, 0.95);
 }
 </style>

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -17,6 +17,19 @@
 		v-bind="$attrs"
 		v-on="$listeners"
 	>
+		<div
+			v-if="variant === 'success' || 'error'"
+			:class="$s.IconAligner"
+		>
+			<component
+				:is="iconComponent"
+				:class="[
+					$s.Icon,
+					$s[`type_${type}`],
+				]"
+				inline
+			/>
+		</div>
 		<m-loading
 			v-if="loading"
 			:class="$s.Loading"
@@ -41,6 +54,8 @@
 <script>
 import chroma from 'chroma-js';
 import { MLoading } from '@square/maker/components/Loading';
+import CheckCircle from '@square/maker-icons/CheckCircle';
+import AlertCircle from '@square/maker-icons/AlertCircle';
 
 function getContrast(chromaBg, targetChromaFg) {
 	if (!targetChromaFg || chroma.contrast(chromaBg, targetChromaFg) < 4.5) {
@@ -187,6 +202,8 @@ const VARIANTS = {
 export default {
 	components: {
 		MLoading,
+		CheckCircle,
+		AlertCircle,
 	},
 
 	inheritAttrs: false,
@@ -276,6 +293,15 @@ export default {
 				color: this.color,
 				textColor: this.textColor,
 			});
+		},
+		iconComponent() {
+			if (this.variant === 'error') {
+				return AlertCircle;
+			}
+			if (this.variant === 'success') {
+				return CheckCircle;
+			}
+			return undefined;
 		},
 	},
 
@@ -462,5 +488,29 @@ export default {
 
 .Button.align_space-between .InformationText {
 	margin-right: 8px;
+}
+
+.IconAligner {
+	display: flex;
+	align-items: center;
+	height: 24px;
+	margin-right: 8px;
+}
+
+.Icon {
+	width: 16px;
+	height: 16px;
+	fill: currentColor;
+	stroke: var(--color-main);
+}
+
+.Icon.type_success {
+	--color-contrast: rgba(52, 199, 89, 1);
+	--color-main: rgba(239, 245, 241, 1);
+}
+
+.Icon.type_error {
+	--color-contrast: rgba(255, 59, 48, 1);
+	--color-main: rgba(245, 239, 239, 1);
 }
 </style>


### PR DESCRIPTION
_THIS PR IS NOT READY TO MERGE_

**Describe the problem prior to this PR (link ticket/issue):**
https://jira.sqprod.co/browse/WBX-6004

**Describe the changes in this PR:**
Added the success and button variants, which auto selects the color / text color and adds in the respective icon.
![Screen Shot 2021-03-29 at 7 05 08 PM](https://user-images.githubusercontent.com/20190589/112922691-c1d54700-90c1-11eb-869f-69cb91cfd030.png)

**Other information:**
I made this PR to receive feedback before continuing on with this feature.