### PR TITLE
fix: Increase ActionBar padding on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@square/maker",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "📚 Maker Design System by Square",
   "license": "Apache-2.0",
   "files": [

--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -71,7 +71,9 @@ export default {
 
 <style module="$s">
 .ActionBarLayer {
-	padding-bottom: 146px;
+	--action-bar-bottom-padding: 64px;
+
+	padding-bottom: calc(88px + var(--action-bar-bottom-padding));
 }
 
 .ActionBar {
@@ -83,7 +85,7 @@ export default {
 	display: flex;
 	justify-content: space-between;
 	box-sizing: border-box;
-	padding: 24px 24px 64px 24px;
+	padding: 24px 24px var(--action-bar-bottom-padding) 24px;
 	background-image: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
 }
 

--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -83,7 +83,7 @@ export default {
 	display: flex;
 	justify-content: space-between;
 	box-sizing: border-box;
-	padding: 24px 24px 58px 24px;
+	padding: 24px 24px 64px 24px;
 	background-image: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
 }
 

--- a/src/components/ActionBar/src/AtomicActionBar.vue
+++ b/src/components/ActionBar/src/AtomicActionBar.vue
@@ -44,7 +44,7 @@ export default {
 	display: flex;
 	justify-content: space-between;
 	box-sizing: border-box;
-	padding: 24px 24px 58px 24px;
+	padding: 24px 24px 64px 24px;
 	background-image: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
 }
 

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -34,7 +34,9 @@ export default {
 
 @media screen and (min-width: 840px) {
 	.ActionBarWrapper {
-		padding-bottom: 130px;
+		--action-bar-bottom-padding: 64px;
+
+		padding-bottom: calc(72px + var(--action-bar-bottom-padding));
 	}
 }
 </style>


### PR DESCRIPTION
<!--
Prepend your PR title with one of the following:
- `feat:` A new feature
- `fix:` A bug fix
- `docs:` Documentation only changes
- `style:` Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- `refactor:` A code change that neither fixes a bug or adds a feature
- `perf:` A code change that improves performance
- `test:` Add missing tests
- `chore:` Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

**Describe the problem prior to this PR (link ticket/issue):**
Deadclick on Safari still easily occurs unless you tap the very top of the button

**Describe the changes in this PR:**
Increased ActionBar bottom padding to 64px on mobile to fix deadclick on Safari

**Other information:**
