### PR TITLE
feat(actionbar): add window.esc to add ability to close modal on ESC

### DIFF
--- a/src/components/ActionBar/README.md
+++ b/src/components/ActionBar/README.md
@@ -233,6 +233,10 @@ Supports attributes from [`<button>`](https://developer.mozilla.org/en-US/docs/W
 
 Supports events from [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button).
 
+| Event      | Type | Description |
+| ---------- | ---- | ----------- |
+| window-esc | -    | —           |
+
 
 ## ActionBarLayer Slots
 

--- a/src/components/ActionBar/README.md
+++ b/src/components/ActionBar/README.md
@@ -233,9 +233,9 @@ Supports attributes from [`<button>`](https://developer.mozilla.org/en-US/docs/W
 
 Supports events from [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button).
 
-| Event      | Type | Description |
-| ---------- | ---- | ----------- |
-| window-esc | -    | —           |
+| Event      | Type     | Description     |
+| ---------- | -------- | --------------- |
+| window-esc | `string` | ESC keyup event |
 
 
 ## ActionBarLayer Slots

--- a/src/components/ActionBar/README.md
+++ b/src/components/ActionBar/README.md
@@ -233,9 +233,9 @@ Supports attributes from [`<button>`](https://developer.mozilla.org/en-US/docs/W
 
 Supports events from [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button).
 
-| Event      | Type     | Description     |
-| ---------- | -------- | --------------- |
-| window-esc | `string` | ESC keyup event |
+| Event      | Type     | Description               |
+| ---------- | -------- | ------------------------- |
+| window-esc | `string` | ESC keyup event on window |
 
 
 ## ActionBarLayer Slots

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -35,7 +35,7 @@
 		</span>
 		<pseudo-window
 			document
-			@keyup.esc="$emit('window-esc')"
+			@keyup.esc="handleEscKey"
 		/>
 	</button>
 </template>
@@ -157,6 +157,14 @@ export default {
 				(vnode) => vnode.tag || vnode.text.trim().length > 0,
 			);
 			return children.length === 1 && children[0].tag;
+		},
+
+		handleEscKey() {
+			/**
+			 * ESC keyup event
+			 * @property {string}
+			 */
+			this.$emit('window-esc');
 		},
 	},
 };

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -33,11 +33,16 @@
 				name="information"
 			/>
 		</span>
+		<pseudo-window
+			document
+			@keyup.esc="$emit('window-esc')"
+		/>
 	</button>
 </template>
 
 <script>
 import chroma from 'chroma-js';
+import PseudoWindow from 'vue-pseudo-window';
 import { MLoading } from '@square/maker/components/Loading';
 
 // TODO: refactor the code below so it's shared with Button component
@@ -74,6 +79,7 @@ function fill(tokens) {
 export default {
 	components: {
 		MLoading,
+		PseudoWindow,
 	},
 
 	inheritAttrs: false,

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -161,7 +161,7 @@ export default {
 
 		handleEscKey() {
 			/**
-			 * ESC keyup event
+			 * ESC keyup event on window
 			 * @property {string}
 			 */
 			this.$emit('window-esc');

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -45,7 +45,7 @@ _DemoModal.vue_
 
 ```vue
 <template>
-	<m-modal @window-esc="modalApi.close()">
+	<m-modal>
 		<img
 			class="cover-photo"
 			src="https://picsum.photos/800/300"
@@ -278,6 +278,7 @@ _ActionBarDemoModal.vue_
 					key="close"
 					color="#f6f6f6"
 					@click="modalApi.close()"
+					@window-esc="modalApi.close()"
 				>
 					<x-icon class="icon" />
 				</m-action-bar-button>
@@ -381,7 +382,7 @@ _StackingDemoFirstModal.vue_
 
 ```vue
 <template>
-	<m-modal @window-esc="handleEscKey">
+	<m-modal>
 		<img
 			class="cover-photo"
 			src="https://picsum.photos/600/300"
@@ -398,6 +399,7 @@ _StackingDemoFirstModal.vue_
 					key="close"
 					color="#f6f6f6"
 					@click="modalApi.close()"
+					@window-esc="handleEscKey"
 				>
 					<x-icon class="icon" />
 				</m-action-bar-button>
@@ -559,13 +561,6 @@ export default {
 | Slot    | Description   |
 | ------- | ------------- |
 | default | Modal content |
-
-
-## Modal Events
-
-| Event      | Type | Description |
-| ---------- | ---- | ----------- |
-| window-esc | -    | —           |
 
 
 ## ModalContent Slots

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -212,6 +212,40 @@ export default {
 };
 </script>
 ```
+
+To close a modal on ESC, use the `@window-esc` from the `MActionBarButton` component.
+
+```html
+<template>
+	<m-modal>
+		Modal content
+
+		<!-- modalApi is provided by the injected the modalApi key below -->
+		<m-action-bar-button
+			@click="modalApi.close()"
+			@window-esc="modalApi.close()"
+		>
+			Close modal
+		</m-action-bar-button>
+	</m-modal>
+</template>
+
+<script>
+import { MModal, modalApi } from '@square/maker/components/Modal';
+import { MActionBarButton } from '@square/maker/components/ActionBar';
+
+export default {
+	components: {
+		MModal,
+		MActionBarButton,
+	},
+
+	inject: {
+		modalApi,
+	},
+};
+</script>
+```
 ## Examples
 
 ### Modal + ActionBar

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -45,7 +45,7 @@ _DemoModal.vue_
 
 ```vue
 <template>
-	<m-modal :close-on-esc="true">
+	<m-modal @window-esc="modalApi.close()">
 		<img
 			class="cover-photo"
 			src="https://picsum.photos/800/300"
@@ -381,7 +381,7 @@ _StackingDemoFirstModal.vue_
 
 ```vue
 <template>
-	<m-modal :close-on-esc="true">
+	<m-modal @window-esc="handleEscKey">
 		<img
 			class="cover-photo"
 			src="https://picsum.photos/600/300"
@@ -444,6 +444,12 @@ export default {
 		},
 		closeFirst() {
 			this.modalApi.close();
+		},
+		handleEscKey() {
+			const isClosingStackedModal = !!this.modalApi.state.vnode;
+			if (!isClosingStackedModal) {
+				this.modalApi.close();
+			}
 		},
 	},
 };
@@ -548,18 +554,18 @@ export default {
 ```
 
 <!-- api-tables:start -->
-## Modal Props
-
-| Prop         | Type      | Default | Possible values | Description            |
-| ------------ | --------- | ------- | --------------- | ---------------------- |
-| close-on-esc | `boolean` | `false` | —               | Close the modal on ESC |
-
-
 ## Modal Slots
 
 | Slot    | Description   |
 | ------- | ------------- |
 | default | Modal content |
+
+
+## Modal Events
+
+| Event      | Type | Description |
+| ---------- | ---- | ----------- |
+| window-esc | -    | —           |
 
 
 ## ModalContent Slots

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -433,7 +433,7 @@ _StackingDemoFirstModal.vue_
 					key="close"
 					color="#f6f6f6"
 					@click="modalApi.close()"
-					@window-esc="handleEscKey"
+					@window-esc="modalApi.close()"
 				>
 					<x-icon class="icon" />
 				</m-action-bar-button>
@@ -480,12 +480,6 @@ export default {
 		},
 		closeFirst() {
 			this.modalApi.close();
-		},
-		handleEscKey() {
-			const isClosingStackedModal = !!this.modalApi.state.vnode;
-			if (!isClosingStackedModal) {
-				this.modalApi.close();
-			}
 		},
 	},
 };

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -45,7 +45,7 @@ _DemoModal.vue_
 
 ```vue
 <template>
-	<m-modal>
+	<m-modal :close-on-esc="true">
 		<img
 			class="cover-photo"
 			src="https://picsum.photos/800/300"
@@ -381,7 +381,7 @@ _StackingDemoFirstModal.vue_
 
 ```vue
 <template>
-	<m-modal>
+	<m-modal :close-on-esc="true">
 		<img
 			class="cover-photo"
 			src="https://picsum.photos/600/300"
@@ -548,6 +548,13 @@ export default {
 ```
 
 <!-- api-tables:start -->
+## Modal Props
+
+| Prop         | Type      | Default | Possible values | Description            |
+| ------------ | --------- | ------- | --------------- | ---------------------- |
+| close-on-esc | `boolean` | `false` | —               | Close the modal on ESC |
+
+
 ## Modal Slots
 
 | Slot    | Description   |

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -4,13 +4,22 @@
 			<!-- @slot Modal content -->
 			<slot />
 		</div>
+		<pseudo-window
+			document
+			@keyup.esc="handleEscKey"
+		/>
 	</div>
 </template>
 
 <script>
+import PseudoWindow from 'vue-pseudo-window';
 import modalApi from './modal-api';
 
 export default {
+	components: {
+		PseudoWindow,
+	},
+
 	inject: {
 		modalApi,
 	},
@@ -25,30 +34,10 @@ export default {
 		},
 	},
 
-	mounted() {
-		this.addEvents();
-	},
-
-	destroyed() {
-		this.removeEvents();
-	},
-
 	methods: {
-		addEvents() {
-			if (this.closeOnEsc) {
-				document.addEventListener('keyup', this.handleEscKey);
-			}
-		},
-
-		removeEvents() {
-			if (this.closeOnEsc) {
-				document.removeEventListener('keyup', this.handleEscKey);
-			}
-		},
-
 		handleEscKey(event) {
 			const isClosingStackedModal = !!this.modalApi.state.vnode;
-			if (!isClosingStackedModal && event.key === 'Escape') {
+			if (this.closeOnEsc && !isClosingStackedModal && event.key === 'Escape') {
 				this.modalApi.close();
 			}
 		},

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -6,7 +6,7 @@
 		</div>
 		<pseudo-window
 			document
-			@keyup.esc="handleEscKey"
+			@keyup.esc="$emit('window-esc')"
 		/>
 	</div>
 </template>
@@ -22,25 +22,6 @@ export default {
 
 	inject: {
 		modalApi,
-	},
-
-	props: {
-		/**
-		 * Close the modal on ESC
-		 */
-		closeOnEsc: {
-			type: Boolean,
-			default: false,
-		},
-	},
-
-	methods: {
-		handleEscKey() {
-			const isClosingStackedModal = !!this.modalApi.state.vnode;
-			if (this.closeOnEsc && !isClosingStackedModal) {
-				this.modalApi.close();
-			}
-		},
 	},
 };
 </script>

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -13,15 +13,10 @@
 
 <script>
 import PseudoWindow from 'vue-pseudo-window';
-import modalApi from './modal-api';
 
 export default {
 	components: {
 		PseudoWindow,
-	},
-
-	inject: {
-		modalApi,
 	},
 };
 </script>

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -35,9 +35,9 @@ export default {
 	},
 
 	methods: {
-		handleEscKey(event) {
+		handleEscKey() {
 			const isClosingStackedModal = !!this.modalApi.state.vnode;
-			if (this.closeOnEsc && !isClosingStackedModal && event.key === 'Escape') {
+			if (this.closeOnEsc && !isClosingStackedModal) {
 				this.modalApi.close();
 			}
 		},

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -7,6 +7,55 @@
 	</div>
 </template>
 
+<script>
+import modalApi from './modal-api';
+
+export default {
+	inject: {
+		modalApi,
+	},
+
+	props: {
+		/**
+		 * Close the modal on ESC
+		 */
+		closeOnEsc: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	mounted() {
+		this.addEvents();
+	},
+
+	destroyed() {
+		this.removeEvents();
+	},
+
+	methods: {
+		addEvents() {
+			if (this.closeOnEsc) {
+				document.addEventListener('keyup', this.handleEscKey);
+			}
+		},
+
+		removeEvents() {
+			if (this.closeOnEsc) {
+				document.removeEventListener('keyup', this.handleEscKey);
+			}
+		},
+
+		handleEscKey(event) {
+			const isClosingStackedModal = !!this.modalApi.state.vnode;
+			if (!isClosingStackedModal && event.key === 'Escape') {
+				this.modalApi.close();
+			}
+		},
+	},
+};
+</script>
+
 <style module="$s">
 .Container {
 	position: relative;

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -4,22 +4,8 @@
 			<!-- @slot Modal content -->
 			<slot />
 		</div>
-		<pseudo-window
-			document
-			@keyup.esc="$emit('window-esc')"
-		/>
 	</div>
 </template>
-
-<script>
-import PseudoWindow from 'vue-pseudo-window';
-
-export default {
-	components: {
-		PseudoWindow,
-	},
-};
-</script>
 
 <style module="$s">
 .Container {

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -74,7 +74,8 @@ const apiMixin = {
 			},
 
 			close() {
-				if (vm.currentLayer) {
+				const isModalActive = !this.state.vnode; // Verify there's no modal on top
+				if (isModalActive && vm.currentLayer) {
 					vm.currentLayer.state.vnode = undefined;
 				}
 			},


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
We need the ability to close the modal on ESC key press

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
Added `closeOnEsc` prop

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
`closeOnEsc` isn't supported on the stacked modal
