### PR TITLE
fix: hides actionbarlayer padding if actionbar not present

### DIFF
--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -1,6 +1,9 @@
 <template>
 	<div
-		:class="$s.ActionBarLayer"
+		:class="[
+			$s.ActionBarLayer,
+			{ [$s.NoActionBar]: !hasActionBar },
+		]"
 		v-bind="$attrs"
 		v-on="$listeners"
 	>
@@ -57,6 +60,12 @@ export default {
 		};
 	},
 
+	computed: {
+		hasActionBar() {
+			return !!this.actionBarVnodes;
+		},
+	},
+
 	created() {
 		this.setActionbar = throttle(this.setActionbar, 50, { leading: false });
 	},
@@ -74,6 +83,10 @@ export default {
 	--action-bar-bottom-padding: 64px;
 
 	padding-bottom: calc(88px + var(--action-bar-bottom-padding));
+
+	&.NoActionBar {
+		padding-bottom: 0;
+	}
 }
 
 .ActionBar {

--- a/src/components/ActionBar/src/AtomicActionBar.vue
+++ b/src/components/ActionBar/src/AtomicActionBar.vue
@@ -41,10 +41,12 @@ export default {
 
 <style module="$s">
 .ActionBar {
+	--action-bar-bottom-padding: 64px;
+
 	display: flex;
 	justify-content: space-between;
 	box-sizing: border-box;
-	padding: 24px 24px 64px 24px;
+	padding: 24px 24px var(--action-bar-bottom-padding) 24px;
 	background-image: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
 }
 


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
people complained about empty padding at the bottom of their sites when no actionbar is present

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
removes padding from actionbarlayer when actionbar is not present

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
nope
