### PR TITLE
fix(actionbar): actionbar buttons flickering

### DIFF
--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -113,7 +113,7 @@ export default {
 
 .Action {
 	margin-right: 8px;
-	-webkit-transform: translate3d(0, 0, 0);
+	-webkit-transform: translate3d(0, 0, 0); /* Fixes buttons flickering on mobile devices */
 	filter: drop-shadow(0 15px 10px rgb(0 0 0 / 20%));
 
 	&:last-child {

--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -113,6 +113,7 @@ export default {
 
 .Action {
 	margin-right: 8px;
+	-webkit-transform: translate3d(0, 0, 0);
 	filter: drop-shadow(0 15px 10px rgb(0 0 0 / 20%));
 
 	&:last-child {

--- a/src/components/ActionBar/src/AtomicActionBar.vue
+++ b/src/components/ActionBar/src/AtomicActionBar.vue
@@ -99,7 +99,7 @@ export default {
 
 .Action {
 	margin-right: 8px;
-	-webkit-transform: translate3d(0, 0, 0);
+	-webkit-transform: translate3d(0, 0, 0);  /* Fixes buttons flickering on mobile devices */
 	filter: drop-shadow(0 15px 10px rgb(0 0 0 / 20%));
 
 	&:last-child {

--- a/src/components/ActionBar/src/AtomicActionBar.vue
+++ b/src/components/ActionBar/src/AtomicActionBar.vue
@@ -99,6 +99,7 @@ export default {
 
 .Action {
 	margin-right: 8px;
+	-webkit-transform: translate3d(0, 0, 0);
 	filter: drop-shadow(0 15px 10px rgb(0 0 0 / 20%));
 
 	&:last-child {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
Action bar buttons were flickering and had border/outline around the buttons while loading the modal on mobile devices
![actionbar-before](https://user-images.githubusercontent.com/7245055/115593217-3efb7280-a2a2-11eb-85d2-a83ce34c6df3.gif)

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
Added `-webkit-transform: translate3D(0, 0, 0)`. See: https://stackoverflow.com/questions/10134935/weird-css3-transition-flickering
![actionbar-after](https://user-images.githubusercontent.com/7245055/115593422-7b2ed300-a2a2-11eb-8f53-04c324331434.gif)


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
