### PR TITLE
fix(actionbar): stack align styles and truncate main text

### DIFF
--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -19,12 +19,10 @@
 			v-if="loading"
 			:class="$s.Loading"
 		/>
-
 		<span :class="[$s.MainText, $s.TruncateText]">
 			<!-- @slot Button label -->
 			<slot />
 		</span>
-
 		<span
 			v-if="$scopedSlots.information"
 			:class="[$s.InformationText, $s.TruncateText]"

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -19,14 +19,15 @@
 			v-if="loading"
 			:class="$s.Loading"
 		/>
-		<span :class="$s.MainText">
+
+		<span :class="[$s.MainText, $s.TruncateText]">
 			<!-- @slot Button label -->
 			<slot />
 		</span>
 
 		<span
 			v-if="$scopedSlots.information"
-			:class="$s.InformationText"
+			:class="[$s.InformationText, $s.TruncateText]"
 		>
 			<!-- @slot Information label -->
 			<slot
@@ -172,14 +173,17 @@ export default {
 
 <style module="$s">
 .Button {
+	--button-large: 64px;
+	--button-medium: 48px;
+
 	position: relative;
 	display: inline-flex;
 	align-items: center;
 	min-width: 0;
-	min-height: 64px;
+	height: var(--button-large);
 
 	/* large size */
-	padding: 20px 32px;
+	padding: 0 32px;
 	color: var(--text-color);
 	font-weight: 500;
 	font-size: 16px;
@@ -205,8 +209,12 @@ export default {
 	}
 
 	&.iconButton {
+		display: inline-flex;
 		flex: 0 0 auto;
-		padding: 20px;
+		align-items: center;
+		width: var(--button-large);
+		height: var(--button-large);
+		padding: 0;
 	}
 
 	--text-color: var(--color-contrast, #000);
@@ -225,6 +233,9 @@ export default {
 
 	&.align_stack {
 		flex-direction: column;
+		justify-content: space-evenly;
+		padding-top: 4px;
+		padding-bottom: 4px;
 	}
 
 	&.align_space-between {
@@ -263,10 +274,10 @@ export default {
 
 @media screen and (min-width: 840px) {
 	.Button {
-		min-height: 48px;
+		height: var(--button-medium);
 
 		/* medium size */
-		padding: 12px 24px;
+		padding: 0 24px;
 		font-size: 14px;
 
 		& > * {
@@ -275,7 +286,8 @@ export default {
 
 		&.iconButton {
 			flex: 0 0 auto;
-			padding: 12px;
+			width: var(--button-medium);
+			height: var(--button-medium);
 		}
 	}
 }
@@ -295,25 +307,35 @@ export default {
 }
 
 .MainText {
-	display: flex;
 	gap: 8px;
-	align-items: center;
 	width: max-content;
-	max-width: 100%;
-	overflow: hidden;
-	line-height: 1;
-	white-space: nowrap;
-	text-overflow: ellipsis;
+}
+
+.iconButton .MainText {
+	display: flex;
+}
+
+@media screen and (max-width: 839px) {
+	.MainText {
+		min-width: 50%;
+	}
 }
 
 .InformationText {
 	width: min-content;
+	opacity: 0.6;
+}
+
+.align_stack .InformationText {
+	font-size: 12px;
+}
+
+.TruncateText {
 	max-width: 100%;
 	overflow: hidden;
 	line-height: 1;
 	white-space: nowrap;
 	text-overflow: ellipsis;
-	opacity: 0.6;
 }
 
 .Button.align_center .InformationText {

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -313,12 +313,6 @@ export default {
 	display: flex;
 }
 
-@media screen and (max-width: 839px) {
-	.MainText {
-		min-width: 50%;
-	}
-}
-
 .InformationText {
 	width: min-content;
 	opacity: 0.6;


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
1. Main text on the default button was being cut off w/o `...` at the end
![Screen Shot 2021-04-23 at 10 59 28 AM](https://user-images.githubusercontent.com/7245055/115891444-169b8180-a424-11eb-94c7-011f35581e6f.png)

2. Need `stack` align style updates
![Screen Shot 2021-04-23 at 11 00 03 AM](https://user-images.githubusercontent.com/7245055/115891474-1f8c5300-a424-11eb-935d-9442b33e1717.png)
![Screen Shot 2021-04-23 at 11 00 31 AM](https://user-images.githubusercontent.com/7245055/115891627-45195c80-a424-11eb-9cd8-5362c6381515.png)

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
![Screen Shot 2021-04-23 at 10 53 49 AM](https://user-images.githubusercontent.com/7245055/115891646-4c406a80-a424-11eb-83fd-151fe7a301a5.png)
![Screen Shot 2021-04-23 at 11 10 54 AM](https://user-images.githubusercontent.com/7245055/115891908-a17c7c00-a424-11eb-8111-23e0f42e808c.png)
![Screen Shot 2021-04-23 at 10 54 26 AM](https://user-images.githubusercontent.com/7245055/115891668-5498a580-a424-11eb-9885-76cb4e00660d.png)

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
