### PR TITLE
ci: move build to prepublish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,5 +20,4 @@ jobs:
       run: |
         nvm i
         npm ci
-        npm run build
         npx semantic-release

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "pull-deploys": "node ./build/deploys/pull.js",
     "push-deploys": "node ./build/deploys/push.js",
     "release": "node ./build/checkout-master && npm run deploy-all && npm run build && npm publish",
-    "pre-release": "npm run deploy-all && npm run build && npm publish"
+    "pre-release": "npm run deploy-all && npm run build && npm publish",
+    "prepublishOnly": "npm run build"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
The release build was happening prior to publish, so it wasn't using the correct version for the CSS class names

For example, v4.1.4 uses class name [`.\1F4DA 0-0-0-semantic-releasevs3NG1`](https://unpkg.com/@square/maker@4.1.4/components/Button/styles.css)

![CleanShot 2021-04-26 at 15 27 21](https://user-images.githubusercontent.com/1075694/116287073-f6d6c700-a75d-11eb-89d1-ef47eb874170.png)

This was happening because the `npm run build` script was happening prior to bumping the version in `package.json`. According to [semantic-release docs](https://semantic-release.gitbook.io/semantic-release/support/faq#how-can-i-use-a-npm-build-script-that-requires-the-package-jsons-version) it should happen in the versioning cycle.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
Move the build script to the `prepublishOnly` hook, which should have the new version env var.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
Reference: https://semantic-release.gitbook.io/semantic-release/support/faq#how-can-i-use-a-npm-build-script-that-requires-the-package-jsons-version
