### PR TITLE
ci: perform styleguide deploy after semantic release

### DIFF
--- a/.github/workflows/deploy-styleguide.yml
+++ b/.github/workflows/deploy-styleguide.yml
@@ -28,6 +28,7 @@ jobs:
           cd .dist
           git config user.name github-actions
           git config user.email github-actions@github.com
+          cd ..
           nvm i
           npm ci
           npm run styleguide-deploy

--- a/.github/workflows/deploy-styleguide.yml
+++ b/.github/workflows/deploy-styleguide.yml
@@ -23,8 +23,6 @@ jobs:
       - name: Build & deploy
         shell: bash -l {0}
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
           cd .dist
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,19 @@ jobs:
         nvm i
         npm ci
         npx semantic-release
+    - name: Checkout nested Maker Repo deploys branch in .dist directory
+      uses: actions/checkout@v2
+      with:
+        repository: square/maker
+        ref: deploys
+        path: .dist
+    - name: Build & deploy styleguide
+      shell: bash -l {0}
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        cd .dist
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        cd ..
+        npm run styleguide-deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,6 @@ jobs:
     - name: Build & deploy styleguide
       shell: bash -l {0}
       run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
         cd .dist
         git config user.name github-actions
         git config user.email github-actions@github.com

--- a/build/deploys/ensure.js
+++ b/build/deploys/ensure.js
@@ -53,4 +53,6 @@ module.exports = async function ensureDeployDirectory() {
 	if (gitBranch !== 'deploys') {
 		await exec('git checkout deploys');
 	}
+
+	return distPath;
 };

--- a/build/deploys/pull.js
+++ b/build/deploys/pull.js
@@ -3,7 +3,8 @@ const exec = promisify(require('child_process').exec);
 const ensureDeployDirectory = require('./ensure');
 
 (async function pullDeploys() {
-	await ensureDeployDirectory();
+	const deployDir = await ensureDeployDirectory();
+	process.chdir(deployDir);
 
 	// pull
 	await exec('git pull');

--- a/build/deploys/push.js
+++ b/build/deploys/push.js
@@ -3,7 +3,8 @@ const exec = promisify(require('child_process').exec);
 const ensureDeployDirectory = require('./ensure');
 
 (async function pushDeploys() {
-	await ensureDeployDirectory();
+	const deployDir = await ensureDeployDirectory();
+	process.chdir(deployDir);
 
 	// add all changes
 	await exec('git add --all');

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -23,12 +23,12 @@ function getDirectories(baseDirectory) {
 ensureDirectory(LAB_DIST);
 ensureDirectory(STYLEGUIDE_DIST);
 
-const STYLEGUIDE_DEPLOYS = getDirectories(STYLEGUIDE_DIST);
+const STYLEGUIDE_DEPLOYS = getDirectories(STYLEGUIDE_DIST).filter(d => d !== '0.0.0-semantic-release');
 const LAB_DEPLOYS = getDirectories(LAB_DIST);
 
 const VERSION_REGEX = /^\d+\.\d+\.\d+/;
 function isVersion(deployName) {
-	return deployName === 'latest' || VERSION_REGEX.test(deployName);
+	return ['latest', 'latest-preview'].includes(deployName) || VERSION_REGEX.test(deployName);
 }
 function isntVersion(deployName) {
 	return !isVersion(deployName);

--- a/build/sync-to-latest/index.js
+++ b/build/sync-to-latest/index.js
@@ -1,23 +1,44 @@
 const path = require('path');
 const fse = require('fs-extra');
-const branch = require('git-branch');
-const { version } = require('../../package.json');
+const semver = require('semver');
+const { getCurrentBranch, getLibVersion, isStableRelease, isPreviewRelease } = require('../utils');
 
-// branch.sync() doesn't work in the Github Actions env
-let branchName = branch.sync();
-if (!branchName) {
-	// but that's okay because the Github Actions env provides this var
-	branchName = process.env.GITHUB_HEAD_REF;
-}
+let branchName = getCurrentBranch();
+let isStable = isStableRelease(branchName);
+let isPreview = isPreviewRelease(branchName);
 
-if (branchName !== 'master') {
-	// only sync versioned releases to latest directory
+if (!isStable && !isPreview) {
+	// only sync versioned releases to latest or latest-preview directories
+	// e.g. no WIP branches or draft branches
 	process.exit(0);
 }
-const deploy = version;
 
-const deployPath = path.resolve('./', '.dist/styleguide', deploy);
-const latestPath = path.resolve('./', '.dist/styleguide/latest');
+const latestAlias = isStable ? 'latest' : 'latest-preview';
+
+function getDirectories(baseDirectory) {
+	return fse.readdirSync(baseDirectory, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((directory) => directory.name);
+}
+
+const DIST = path.resolve(process.cwd(), '.dist');
+const STYLEGUIDE_DIST = path.resolve(DIST, 'styleguide');
+const STYLEGUIDE_SEMVER_DEPLOYS = getDirectories(STYLEGUIDE_DIST).filter(deploy => semver.valid(deploy));
+STYLEGUIDE_SEMVER_DEPLOYS.sort((semverA, semverB) => {
+	if (semver.gt(semverA, semverB)) {
+		return -1;
+	}
+	return 1;
+});
+
+if (STYLEGUIDE_SEMVER_DEPLOYS.length === 0) {
+	// nothing to sync
+	process.exit(0);
+}
+
+const latestDeploy = STYLEGUIDE_SEMVER_DEPLOYS[0];
+const deployPath = path.resolve('./', '.dist/styleguide', latestDeploy);
+const latestPath = path.resolve('./', '.dist/styleguide', latestAlias);
 
 fse.removeSync(latestPath);
 fse.copySync(deployPath, latestPath);

--- a/build/utils.js
+++ b/build/utils.js
@@ -1,4 +1,8 @@
 const _ = require('lodash');
+const branch = require('git-branch');
+const { version } = require('../package.json');
+const { execSync } = require('child_process');
+const semver = require("semver");
 
 function merge(...objects) {
 	return _.mergeWith(...objects, (objectValue, sourceValue) => {
@@ -9,6 +13,57 @@ function merge(...objects) {
 	});
 }
 
+function getCurrentBranch() {
+	// branch.sync() doesn't work in the Github Actions env
+	let branchName = branch.sync();
+	if (!branchName) {
+		// but that's okay because the Github Actions env provides this var
+		branchName = process.env.GITHUB_HEAD_REF;
+	}
+	return branchName;
+}
+
+function isSemanticReleaseBranch(branchName) {
+	return ['master', 'next', 'next-major', 'beta', 'alpha'].includes(branchName);
+}
+
+function isStableRelease(branchName) {
+	return branchName === 'master';
+}
+
+function isPreviewRelease(branchName) {
+	return ['next', 'next-major', 'beta', 'alpha'].includes(branchName);
+}
+
+function getLibVersion() {
+	let libVersion = version;
+	if (libVersion === '0.0.0-semantic-release') {
+		let tagsOutput = execSync('git tag --points-at HEAD'); // returns byte buffer
+		tagsOutput = tagsOutput.toString(); // converts byte buffer to string
+		let semverTags = tagsOutput
+			.trim()
+			.split(/(\s+)/)
+			.filter(tag => tag.trim().length > 0)
+			.map(tag => semver.clean(tag)) // may return null
+			.filter(tag => !!tag); // null check
+		semverTags.sort((tagA, tagB) => {
+			if (semver.gt(tagA, tagB)) {
+				return -1;
+			}
+			return 1;
+		});
+		if (semverTags.length > 0) {
+			libVersion = semverTags[0]; // latest semver tag
+		}
+	}
+	return libVersion;
+}
+
 module.exports = {
 	merge,
+	getCurrentBranch,
+	getLibVersion,
+	isSemanticReleaseBranch,
+	isStableRelease,
+	isPreviewRelease,
 };

--- a/styleguide/webpack-styleguide-config.js
+++ b/styleguide/webpack-styleguide-config.js
@@ -4,18 +4,13 @@ const webpack = require('webpack');
 const { JustSsrPlugin } = require('vue-just-ssr');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ent = require('ent');
-const branch = require('git-branch');
 const { merge } = require('../build/utils');
 const webpackBaseConfig = require('../build/webpack-base-config');
 const { version } = require('../package.json');
+const { getCurrentBranch, isSemanticReleaseBranch, getLibVersion } = require('../build/utils');
 
-// branch.sync() doesn't work in the Github Actions env
-let branchName = branch.sync();
-if (!branchName) {
-	// but that's okay because the Github Actions env provides this var
-	branchName = process.env.GITHUB_HEAD_REF;
-}
-const deploy = branchName === 'master' ? version : branchName;
+let branchName = getCurrentBranch();
+const deploy = isSemanticReleaseBranch(branchName) ? getLibVersion() : branchName;
 
 // console.log(`branchName: ${branchName}, version: ${version}, deploy: ${deploy}`);
 // console.log('ENV VARS:', JSON.stringify(process.env, undefined, 4));


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
runs styleguide deploys after semantic releases in CI

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
no screenshots

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
maybe it works or maybe it doesn't, there's no way of knowing until we merge into master

note to future self: if it doesn't work it's probably because the github checkout action does not check out tags along with the head commit, so look into that if this fails