### PR TITLE
feat: Notice refresh

### DIFF
--- a/src/components/Checkbox/src/CheckboxControl.vue
+++ b/src/components/Checkbox/src/CheckboxControl.vue
@@ -97,7 +97,7 @@ export default {
 	--color-foreground: rgba(255, 255, 255, 0.95);
 	--color-disabled: rgba(0, 0, 0, 0.05);
 	--color-disabled-checked: rgba(0, 0, 0, 0.15);
-	--color-error: #ff3b30;
+	--color-error: rgba(206, 50, 23, 1);
 }
 
 .Checkbox {

--- a/src/components/Input/src/InputControl.vue
+++ b/src/components/Input/src/InputControl.vue
@@ -128,7 +128,7 @@ export default {
 	--color-disabled: rgba(0, 0, 0, 0.3);
 	--color-background-disabled: rgba(0, 0, 0, 0.05);
 	--color-accent: #222;
-	--color-error: #ff3b30;
+	--color-error: rgba(206, 50, 23, 1);
 	--focus-shadow: 0 0 0 2px rgba(34, 34, 34, 0.3);
 	--border-radius: 8px;
 	--border-color: transparent;
@@ -143,7 +143,7 @@ export default {
 	--color-disabled: rgba(0, 0, 0, 0.3);
 	--color-background-disabled: rgba(0, 0, 0, 0.05);
 	--color-accent: #222;
-	--color-error: #ff3b30;
+	--color-error: rgba(206, 50, 23, 1);
 	--focus-shadow: none;
 	--border-radius: 8px;
 	--border-color: rgba(0, 0, 0, 0.15);

--- a/src/components/Notice/README.md
+++ b/src/components/Notice/README.md
@@ -12,7 +12,7 @@ Use Notice to notify users of things.
 
 ```vue
 <template>
-	<div>
+	<div class="spaceout">
 		<m-notice type="error">
 			I am a error notice
 		</m-notice>
@@ -54,6 +54,15 @@ export default {
 	},
 };
 </script>
+
+<style scoped>
+.spaceout > * {
+	margin-bottom: 16px;
+}
+.spaceout > *:last-child {
+	margin-bottom: 0;
+}
+</style>
 ```
 
 
@@ -61,7 +70,7 @@ export default {
 
 ```vue
 <template>
-	<div>
+	<div class="spaceout">
 		<m-notice type="success">
 			I am a success notice
 		</m-notice>
@@ -103,6 +112,15 @@ export default {
 	},
 };
 </script>
+
+<style scoped>
+.spaceout > * {
+	margin-bottom: 16px;
+}
+.spaceout > *:last-child {
+	margin-bottom: 0;
+}
+</style>
 ```
 
 
@@ -110,7 +128,7 @@ export default {
 
 ```vue
 <template>
-	<div>
+	<div class="spaceout">
 		<m-notice type="warning">
 			I am a warning notice
 		</m-notice>
@@ -152,6 +170,15 @@ export default {
 	},
 };
 </script>
+
+<style scoped>
+.spaceout > * {
+	margin-bottom: 16px;
+}
+.spaceout > *:last-child {
+	margin-bottom: 0;
+}
+</style>
 ```
 
 
@@ -160,7 +187,7 @@ export default {
 
 ```vue
 <template>
-	<div>
+	<div class="spaceout">
 		<m-notice type="info">
 			I am a info notice
 		</m-notice>
@@ -202,6 +229,15 @@ export default {
 	},
 };
 </script>
+
+<style scoped>
+.spaceout > * {
+	margin-bottom: 16px;
+}
+.spaceout > *:last-child {
+	margin-bottom: 0;
+}
+</style>
 ```
 
 <!-- api-tables:start -->

--- a/src/components/Notice/README.md
+++ b/src/components/Notice/README.md
@@ -1,20 +1,27 @@
 # Notice
 
+Use Notice to notify users of things.
+
+
+
+## Examples
+
+
+
+### Error
+
 ```vue
 <template>
 	<div>
-		<h4>error notice</h4>
 		<m-notice type="error">
-			I am an error notice
+			I am a error notice
 		</m-notice>
 
-		<h4>long error notice</h4>
 		<m-notice type="error">
 			I am a long error notice text text text wrap wrap wrap
 			see me wrap wrap wrap text text text text text text
 		</m-notice>
 
-		<h4>long error block notice</h4>
 		<m-notice
 			type="error"
 			variant="block"
@@ -23,18 +30,47 @@
 			see me wrap wrap wrap text text text text text text
 		</m-notice>
 
-		<h4>success notice</h4>
+		<m-notice
+			type="error"
+			variant="block"
+		>
+			I am a long error notice text text text wrap wrap wrap
+			see me wrap wrap wrap text text text text text text
+			<template #actions>
+				<m-notice-button>button</m-notice-button>
+				<m-notice-button>dismiss</m-notice-button>
+			</template>
+		</m-notice>
+	</div>
+</template>
+
+<script>
+import { MNotice, MNoticeButton } from '@square/maker/components/Notice';
+
+export default {
+	components: {
+		MNotice,
+		MNoticeButton,
+	},
+};
+</script>
+```
+
+
+### Success
+
+```vue
+<template>
+	<div>
 		<m-notice type="success">
-			I am an success notice
+			I am a success notice
 		</m-notice>
 
-		<h4>long success notice</h4>
 		<m-notice type="success">
 			I am a long success notice text text text wrap wrap wrap
 			see me wrap wrap wrap text text text text text text
 		</m-notice>
 
-		<h4>long success block notice</h4>
 		<m-notice
 			type="success"
 			variant="block"
@@ -43,18 +79,47 @@
 			see me wrap wrap wrap text text text text text text
 		</m-notice>
 
-		<h4>warning notice</h4>
+		<m-notice
+			type="success"
+			variant="block"
+		>
+			I am a long success notice text text text wrap wrap wrap
+			see me wrap wrap wrap text text text text text text
+			<template #actions>
+				<m-notice-button>button</m-notice-button>
+				<m-notice-button>dismiss</m-notice-button>
+			</template>
+		</m-notice>
+	</div>
+</template>
+
+<script>
+import { MNotice, MNoticeButton } from '@square/maker/components/Notice';
+
+export default {
+	components: {
+		MNotice,
+		MNoticeButton,
+	},
+};
+</script>
+```
+
+
+### Warning
+
+```vue
+<template>
+	<div>
 		<m-notice type="warning">
-			I am an warning notice
+			I am a warning notice
 		</m-notice>
 
-		<h4>long warning notice</h4>
 		<m-notice type="warning">
 			I am a long warning notice text text text wrap wrap wrap
 			see me wrap wrap wrap text text text text text text
 		</m-notice>
 
-		<h4>long warning block notice</h4>
 		<m-notice
 			type="warning"
 			variant="block"
@@ -63,18 +128,48 @@
 			see me wrap wrap wrap text text text text text text
 		</m-notice>
 
-		<h4>info notice</h4>
+		<m-notice
+			type="warning"
+			variant="block"
+		>
+			I am a long warning notice text text text wrap wrap wrap
+			see me wrap wrap wrap text text text text text text
+			<template #actions>
+				<m-notice-button>button</m-notice-button>
+				<m-notice-button>dismiss</m-notice-button>
+			</template>
+		</m-notice>
+	</div>
+</template>
+
+<script>
+import { MNotice, MNoticeButton } from '@square/maker/components/Notice';
+
+export default {
+	components: {
+		MNotice,
+		MNoticeButton,
+	},
+};
+</script>
+```
+
+
+
+### Info
+
+```vue
+<template>
+	<div>
 		<m-notice type="info">
-			I am an info notice
+			I am a info notice
 		</m-notice>
 
-		<h4>long info notice</h4>
 		<m-notice type="info">
 			I am a long info notice text text text wrap wrap wrap
 			see me wrap wrap wrap text text text text text text
 		</m-notice>
 
-		<h4>long info block notice</h4>
 		<m-notice
 			type="info"
 			variant="block"
@@ -82,22 +177,35 @@
 			I am a long info notice text text text wrap wrap wrap
 			see me wrap wrap wrap text text text text text text
 		</m-notice>
+
+		<m-notice
+			type="info"
+			variant="block"
+		>
+			I am a long info notice text text text wrap wrap wrap
+			see me wrap wrap wrap text text text text text text
+			<template #actions>
+				<m-notice-button>button</m-notice-button>
+				<m-notice-button>dismiss</m-notice-button>
+			</template>
+		</m-notice>
 	</div>
 </template>
 
 <script>
-import { MNotice } from '@square/maker/components/Notice';
+import { MNotice, MNoticeButton } from '@square/maker/components/Notice';
 
 export default {
 	components: {
 		MNotice,
+		MNoticeButton,
 	},
 };
 </script>
 ```
 
 <!-- api-tables:start -->
-## Props
+## Notice Props
 
 Supports attributes from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div).
 
@@ -107,14 +215,31 @@ Supports attributes from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/
 | variant | `string` | `'inline'` | `inline`, `block`                     | notice variant |
 
 
-## Slots
+## Notice Slots
 
 | Slot    | Description    |
 | ------- | -------------- |
 | default | notice content |
 
 
-## Events
+## Notice Events
 
 Supports events from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div).
+
+
+## NoticeButton Props
+
+Supports attributes from [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button).
+
+
+## NoticeButton Slots
+
+| Slot    | Description    |
+| ------- | -------------- |
+| default | button content |
+
+
+## NoticeButton Events
+
+Supports events from [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button).
 <!-- api-tables:end -->

--- a/src/components/Notice/README.md
+++ b/src/components/Notice/README.md
@@ -217,9 +217,10 @@ Supports attributes from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/
 
 ## Notice Slots
 
-| Slot    | Description    |
-| ------- | -------------- |
-| default | notice content |
+| Slot    | Description             |
+| ------- | ----------------------- |
+| default | notice content          |
+| actions | put notice buttons here |
 
 
 ## Notice Events

--- a/src/components/Notice/index.js
+++ b/src/components/Notice/index.js
@@ -1,1 +1,2 @@
 export { default as MNotice } from './src/Notice.vue';
+export { default as MNoticeButton } from './src/NoticeButton.vue';

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -74,13 +74,13 @@ export default {
 	computed: {
 		iconComponent() {
 			if (this.type === 'error') {
-				return AlertTriangle;
+				return AlertCircle;
 			}
 			if (this.type === 'success') {
 				return CheckCircle;
 			}
 			if (this.type === 'warning') {
-				return AlertCircle;
+				return AlertTriangle;
 			}
 			return Info;
 		},

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -117,21 +117,18 @@ export default {
 	--color: rgba(161, 39, 18, 1);
 	--color-icon: rgba(206, 51, 22, 1);
 	--color-bg: rgba(252, 235, 232, 1);
-;
 }
 
 .type_warning {
 	--color: rgba(77, 59, 0, 1);
 	--color-icon: rgba(242, 189, 13, 1);
 	--color-bg: rgba(252, 242, 207, 1);
-
 }
 
 .type_success {
 	--color: rgba(8, 69, 8, 1);
 	--color-icon: rgba(33, 172, 30, 1);
 	--color-bg: rgba(233, 251, 233, 1);
-
 }
 
 .type_info {

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -8,16 +8,25 @@
 		v-bind="$attrs"
 		v-on="$listeners"
 	>
-		<div :class="$s.IconAligner">
-			<component
-				:is="iconComponent"
-				:class="$s.Icon"
-				inline
-			/>
+		<div :class="$s.IconContentWrapper">
+			<div :class="$s.IconAligner">
+				<component
+					:is="iconComponent"
+					:class="$s.Icon"
+					inline
+				/>
+			</div>
+			<div>
+				<!-- @slot notice content -->
+				<slot />
+			</div>
 		</div>
-		<div>
-			<!-- @slot notice content -->
-			<slot />
+		<div
+			v-if="$slots.actions"
+			:class="$s.ActionsWrapper"
+		>
+			<!-- @slot put notice buttons here -->
+			<slot name="actions" />
 		</div>
 	</div>
 </template>
@@ -80,34 +89,55 @@ export default {
 
 <style module="$s">
 .Notice {
-	--font-family: inherit;
-
-	display: flex;
 	color: var(--color);
 	font-size: 14px;
-	font-family: var(--font-family);
+	font-family: inherit;
 	line-height: 24px;
 	border-radius: 8px;
 }
 
+.IconContentWrapper {
+	display: flex;
+}
+
+.ActionsWrapper {
+	display: flex;
+	justify-content: flex-end;
+}
+
+.ActionsWrapper > * {
+	margin-right: 24px;
+}
+
+.ActionsWrapper > *:last-child {
+	margin-right: 0;
+}
+
 .type_error {
-	--color: rgba(255, 59, 48, 1);
-	--color-bg: rgba(245, 239, 239, 1);
+	--color: rgba(161, 39, 18, 1);
+	--color-icon: rgba(206, 51, 22, 1);
+	--color-bg: rgba(252, 235, 232, 1);
+;
 }
 
 .type_warning {
-	--color: rgba(255, 149, 0, 1);
-	--color-bg: rgba(245, 243, 239, 1);
+	--color: rgba(77, 59, 0, 1);
+	--color-icon: rgba(242, 189, 13, 1);
+	--color-bg: rgba(252, 242, 207, 1);
+
 }
 
 .type_success {
-	--color: rgba(52, 199, 89, 1);
-	--color-bg: rgba(239, 245, 241, 1);
+	--color: rgba(8, 69, 8, 1);
+	--color-icon: rgba(33, 172, 30, 1);
+	--color-bg: rgba(233, 251, 233, 1);
+
 }
 
 .type_info {
-	--color: hsl(0, 0%, 69%);
-	--color-bg: hsl(0, 0%, 97%);
+	--color: rgba(24, 24, 24, 1);
+	--color-icon: rgba(169, 169, 169, 1);
+	--color-bg: rgba(241, 241, 241, 1);
 }
 
 .variant_block {
@@ -125,7 +155,7 @@ export default {
 .Icon {
 	width: 16px;
 	height: 16px;
-	fill: currentColor;
+	fill: var(--color-icon);
 	stroke: white;
 }
 </style>

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -22,7 +22,7 @@
 			</div>
 		</div>
 		<div
-			v-if="$slots.actions"
+			v-if="showActions"
 			:class="$s.ActionsWrapper"
 		>
 			<!-- @slot put notice buttons here -->
@@ -36,6 +36,7 @@ import AlertTriangle from '@square/maker-icons/AlertTriangle';
 import AlertCircle from '@square/maker-icons/AlertCircle';
 import CheckCircle from '@square/maker-icons/CheckCircle';
 import Info from '@square/maker-icons/Info';
+import assert from '@square/maker/utils/assert';
 
 /**
  * @inheritAttrs div
@@ -83,6 +84,13 @@ export default {
 			}
 			return Info;
 		},
+		showActions() {
+			return this.$slots.actions && this.variant === 'block';
+		},
+	},
+
+	created() {
+		assert.warn(this.variant === 'inline' && !this.$slots.actions, 'inline Notices can not have an actions slot');
 	},
 };
 </script>

--- a/src/components/Notice/src/NoticeButton.vue
+++ b/src/components/Notice/src/NoticeButton.vue
@@ -15,13 +15,13 @@ export default {};
 
 <style module="$s">
 .Button {
-	font-weight: 600;
-	border: none;
-	background: none;
-	color: inherit;
-	cursor: pointer;
 	padding: 0;
+	color: inherit;
+	font-weight: 600;
 	font-size: inherit;
 	line-height: inherit;
+	background: none;
+	border: none;
+	cursor: pointer;
 }
 </style>

--- a/src/components/Notice/src/NoticeButton.vue
+++ b/src/components/Notice/src/NoticeButton.vue
@@ -1,0 +1,27 @@
+<template>
+	<button :class="$s.Button">
+		<!-- @slot button content -->
+		<slot />
+	</button>
+</template>
+
+<script>
+/**
+ * @inheritAttrs button
+ * @inheritListeners button
+ */
+export default {};
+</script>
+
+<style module="$s">
+.Button {
+	font-weight: 600;
+	border: none;
+	background: none;
+	color: inherit;
+	cursor: pointer;
+	padding: 0;
+	font-size: inherit;
+	line-height: inherit;
+}
+</style>

--- a/src/components/Radio/src/RadioControl.vue
+++ b/src/components/Radio/src/RadioControl.vue
@@ -95,7 +95,7 @@ export default {
 	--color-background: rgba(255, 255, 255, 0.95);
 	--color-fill: rgba(0, 0, 0, 0.9);
 	--color-focus: rgba(0, 0, 0, 0.9);
-	--color-error: #ff3b30;
+	--color-error: rgba(206, 50, 23, 1);
 	--color-disabled: rgba(0, 0, 0, 0.05);
 	--color-disabled-fill: rgba(0, 0, 0, 0.15);
 }

--- a/src/components/Select/src/SelectControl.vue
+++ b/src/components/Select/src/SelectControl.vue
@@ -159,7 +159,7 @@ export default {
 	--color-accent: #222;
 	--color-border: transparent;
 	--color-border-active: #222;
-	--color-error: #ff3b30;
+	--color-error: rgba(206, 50, 23, 1);
 	--focus-shadow: 0 0 0 2px rgba(34, 34, 34, 0.3);
 	--border-radius: 8px;
 }
@@ -173,7 +173,7 @@ export default {
 	--color-accent: #222;
 	--color-border: rgba(0, 0, 0, 0.15);
 	--color-border-active: rgba(0, 0, 0, 0.3);
-	--color-error: #ff3b30;
+	--color-error: rgba(206, 50, 23, 1);
 	--focus-shadow: 0 0 0 2px rgba(34, 34, 34, 0.3);
 	--border-radius: 8px;
 	--focus-shadow: none;

--- a/src/components/Textarea/src/TextareaControl.vue
+++ b/src/components/Textarea/src/TextareaControl.vue
@@ -107,7 +107,7 @@ export default {
 	--color-border: transparent;
 	--color-border-active: #222;
 	--border-radius: 8px;
-	--color-error: #ff3b30;
+	--color-error: rgba(206, 50, 23, 1);
 	--focus-shadow: 0 0 0 2px rgba(34, 34, 34, 0.3);
 }
 
@@ -121,7 +121,7 @@ export default {
 	--color-border: rgb(0, 0, 0, 0.15);
 	--color-border-active: rgb(0, 0, 0, 0.3);
 	--border-radius: 8px;
-	--color-error: #ff3b30;
+	--color-error: rgba(206, 50, 23, 1);
 	--focus-shadow: none;
 }
 

--- a/src/components/Toggle/src/ToggleControl.vue
+++ b/src/components/Toggle/src/ToggleControl.vue
@@ -92,7 +92,7 @@ export default {
 	--color-black-30: rgba(0, 0, 0, 0.3);
 	--color-black-15: rgba(0, 0, 0, 0.15);
 	--color-black-05: rgba(0, 0, 0, 0.05);
-	--color-error: #ff3b30;
+	--color-error: rgba(206, 50, 23, 1);
 	--color-white: #fff;
 	--transition: 0.2s ease;
 

--- a/src/utils/BlockFormControlLayout/src/BlockFormControlLayout.vue
+++ b/src/utils/BlockFormControlLayout/src/BlockFormControlLayout.vue
@@ -23,7 +23,7 @@
 
 .Error {
 	/* provided by theme eventually */
-	--color-error: #ff3b30;
+	--color-error: rgba(206, 50, 23, 1);
 
 	display: inline-block;
 	margin-top: 8px;


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
Notice refresh

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
- updates Notice status colors (including the Error status color which is updated across all components)
- adds NoticeButton child component to be used with Notice

https://square.github.io/maker/styleguide/notice-refresh/#/Notice

![image](https://user-images.githubusercontent.com/7769424/116707547-cf217200-a99c-11eb-8b14-721934281682.png)
![image](https://user-images.githubusercontent.com/7769424/116707583-d8124380-a99c-11eb-9508-dad3d7c02484.png)


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
none