### PR TITLE
feat(modal): close modal on click outside and before close hook

### DIFF
--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -227,7 +227,7 @@ export default {
 </script>
 ```
 ### Configurable options
-The `modalApi.open()` function has a second optional object parameter that you allows for configurable options. Current available options are:
+The `modalApi.open()` function has a second optional object parameter that offers configurable options. Current available options are:
 
 ```html
 {

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -34,7 +34,12 @@ export default {
 
 	methods: {
 		openModal() {
-			this.modalApi.open(() => <DemoModal />);
+			this.modalApi.open(
+				() => <DemoModal />,
+				{
+					closeOnOutsideClick: true,
+				},
+			);
 		},
 	},
 };
@@ -405,7 +410,10 @@ export default {
 
 	methods: {
 		openModal() {
-			this.modalApi.open(() => <StackingDemoFirstModal />);
+			this.modalApi.open(
+				() => <StackingDemoFirstModal />,
+				{ closeOnOutsideClick: true },
+			);
 		},
 	},
 };
@@ -476,7 +484,7 @@ export default {
 
 	methods: {
 		openSecondModal() {
-			this.modalApi.open(() => <StackingDemoSecondModal />);
+			this.modalApi.open(() => <StackingDemoSecondModal />, { closeOnOutsideClick: true });
 		},
 		closeFirst() {
 			this.modalApi.close();

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -37,7 +37,7 @@ export default {
 			this.modalApi.open(
 				() => <DemoModal />,
 				{
-					closeOnOutsideClick: true,
+					closeOnClickOutside: true,
 				},
 			);
 		},
@@ -136,7 +136,16 @@ export default {
 	methods: {
 		openMyModal() {
 			// this.modalApi is provided by MModalLayer.apiMixin
-			this.modalApi.open(() => <MyModal />);
+			this.modalApi.open(
+				() => <MyModal />,
+				{
+					closeOnClickOutside: true,
+					beforeCloseHook: () => {
+						// Intercept logic here
+						return true; // or false if you want to block modal from closing
+					},
+				},
+			);
 		}
 	}
 };
@@ -216,6 +225,17 @@ export default {
 	},
 };
 </script>
+```
+### Configurable options
+The `modalApi.open()` function has a second optional object parameter that you allows for configurable options. Current available options are:
+
+```html
+{
+	// Modal will close when clicked outside of it - default false
+	closeOnClickOutside: boolean,
+	// function to run before modal is closed. If return value is false modal will not close.
+	beforeCloseHook: () => { return boolean },
+}
 ```
 
 To close a modal on ESC, use the `@window-esc` from the `MActionBarButton` component.
@@ -412,7 +432,9 @@ export default {
 		openModal() {
 			this.modalApi.open(
 				() => <StackingDemoFirstModal />,
-				{ closeOnOutsideClick: true },
+				{
+					closeOnClickOutside: true,
+				},
 			);
 		},
 	},
@@ -484,7 +506,12 @@ export default {
 
 	methods: {
 		openSecondModal() {
-			this.modalApi.open(() => <StackingDemoSecondModal />, { closeOnOutsideClick: true });
+			this.modalApi.open(
+				() => <StackingDemoSecondModal />,
+				{
+					closeOnClickOutside: true,
+				},
+			);
 		},
 		closeFirst() {
 			this.modalApi.close();

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -50,7 +50,9 @@ _DemoModal.vue_
 
 ```vue
 <template>
-	<m-modal>
+	<m-modal
+		:before-close="beforeCloseHook"
+	>
 		<img
 			class="cover-photo"
 			src="https://picsum.photos/800/300"
@@ -91,6 +93,13 @@ export default {
 
 	inject: {
 		modalApi,
+	},
+
+	methods: {
+		beforeCloseHook() {
+			// intercept close here
+			return true; // or false if you want to block modal from closing
+		},
 	},
 };
 </script>
@@ -140,10 +149,6 @@ export default {
 				() => <MyModal />,
 				{
 					closeOnClickOutside: true,
-					beforeCloseHook: () => {
-						// Intercept logic here
-						return true; // or false if you want to block modal from closing
-					},
 				},
 			);
 		}
@@ -233,16 +238,19 @@ The `modalApi.open()` function has a second optional object parameter that offer
 {
 	// Modal will close when clicked outside of it - default false
 	closeOnClickOutside: boolean,
-	// function to run before modal is closed. If return value is false modal will not close.
-	beforeCloseHook: () => { return boolean },
 }
 ```
 
 To close a modal on ESC, use the `@window-esc` from the `MActionBarButton` component.
 
+To hook into the close function, add the `beforeClose` prop on the modal component.
+The function must return a boolean - true to close the modal or false to block closing.
+
 ```html
 <template>
-	<m-modal>
+	<m-modal
+		:before-close="beforeCloseHook"
+	>
 		Modal content
 
 		<!-- modalApi is provided by the injected the modalApi key below -->
@@ -267,6 +275,13 @@ export default {
 
 	inject: {
 		modalApi,
+	},
+
+	methods: {
+		beforeCloseHook() {
+			// intercept close here
+			return true; // or false if you want to block modal from closing
+		},
 	},
 };
 </script>

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -234,10 +234,10 @@ export default {
 ### Configurable options
 The `modalApi.open()` function has a second optional object parameter that offers configurable options. Current available options are:
 
-```html
+```ts
 {
 	// Modal will close when clicked outside of it - default false
-	closeOnClickOutside: boolean,
+	closeOnClickOutside: boolean;
 }
 ```
 
@@ -278,7 +278,7 @@ export default {
 	},
 
 	methods: {
-		beforeCloseHook() {
+		async beforeCloseHook() {
 			// intercept close here
 			return true; // or false if you want to block modal from closing
 		},

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -21,9 +21,10 @@ export default {
 		/**
 		 * Before close hook, can block closing
 		 */
-		beforeClose: { // eslint-disable-line vue/require-default-prop
+		beforeClose: {
 			type: Function,
 			required: false,
+			default: undefined,
 		},
 	},
 

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -7,6 +7,29 @@
 	</div>
 </template>
 
+<script>
+import modalApi from './modal-api';
+
+export default {
+	name: 'Modal',
+
+	inject: {
+		modalApi,
+	},
+
+	props: {
+		beforeClose: {
+			type: Function,
+			default: () => true,
+		},
+	},
+
+	mounted() {
+		this.modalApi.state.options.beforeCloseHook = this.beforeClose;
+	},
+};
+</script>
+
 <style module="$s">
 .Container {
 	position: relative;

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -18,14 +18,22 @@ export default {
 	},
 
 	props: {
-		beforeClose: {
+		/**
+		 * Before close hook, can block closing
+		 */
+		beforeClose: { // eslint-disable-line vue/require-default-prop
 			type: Function,
-			default: () => true,
+			required: false,
 		},
 	},
 
-	mounted() {
-		this.modalApi.state.options.beforeCloseHook = this.beforeClose;
+	watch: {
+		beforeClose: {
+			immediate: true,
+			handler(hook) {
+				this.modalApi.state.options.beforeCloseHook = hook;
+			},
+		},
 	},
 };
 </script>

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -14,7 +14,7 @@
 				v-if="currentLayer.state.vnode"
 				ref="baseModalLayer"
 				:class="$s.ModalLayer"
-				@click="closeOnOutsideClick"
+				@click="closeOnClickOutside"
 			>
 				<pseudo-window
 					body
@@ -80,10 +80,17 @@ const apiMixin = {
 				};
 			},
 
-			close() {
+			async close() {
 				const isModalActive = !this.state.vnode; // Verify there's no modal on top
+
 				if (isModalActive && vm.currentLayer) {
-					vm.currentLayer.state.vnode = undefined;
+					if (typeof vm.currentLayer.state.options.beforeCloseHook === 'function') {
+						if (!(await vm.currentLayer.state.options.beforeCloseHook())) {
+							return; // cancel
+						}
+					}
+
+					vm.currentLayer.state.vnode = undefined; // close modal
 				}
 			},
 		};
@@ -164,10 +171,10 @@ export default {
 	},
 
 	methods: {
-		closeOnOutsideClick(event) {
-			const { closeOnOutsideClick } = this.currentLayer.state.options;
+		closeOnClickOutside(event) {
+			const { closeOnClickOutside } = this.currentLayer.state.options;
 			const { modal } = this.$refs;
-			if (modal && closeOnOutsideClick && !modal.contains(event.target)) {
+			if (modal && closeOnClickOutside && !modal.contains(event.target)) {
 				this.modalApi.close();
 			}
 		},

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -84,8 +84,8 @@ const apiMixin = {
 				const isModalActive = !this.state.vnode; // Verify there's no modal on top
 
 				if (isModalActive && vm.currentLayer) {
-					if (typeof vm.currentLayer.state.options.beforeCloseHook === 'function') {
-						if (!(await vm.currentLayer.state.options.beforeCloseHook())) {
+					if (typeof this.state.options.beforeCloseHook === 'function') {
+						if (!(await this.state.options.beforeCloseHook())) {
 							return; // cancel
 						}
 					}

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -14,12 +14,17 @@
 				v-if="currentLayer.state.vnode"
 				ref="baseModalLayer"
 				:class="$s.ModalLayer"
+				@click="closeOnOutsideClick"
 			>
 				<pseudo-window
 					body
 					:class="$s.disableScroll"
 				/>
-				<v :nodes="currentLayer.state.vnode" />
+				<div
+					ref="modal"
+				>
+					<v :nodes="currentLayer.state.vnode" />
+				</div>
 			</div>
 		</m-transition-responsive>
 		<modal-layer v-if="currentLayer.state.vnode" />
@@ -59,12 +64,14 @@ const apiMixin = {
 		const api = {
 			state: Vue.observable({
 				vnode: undefined,
+				options: {},
 				isStacked: !!vm.currentLayer,
 			}),
 
-			open(renderFn) {
+			open(renderFn, options = {}) {
 				const vnode = renderFn(vm.$createElement);
 				this.state.vnode = vnode;
+				this.state.options = options;
 				// returned method only closes this specific modal
 				return () => {
 					if (this.state.vnode === vnode) {
@@ -154,6 +161,16 @@ export default {
 
 	destroyed() {
 		this.unwatchStackedModal();
+	},
+
+	methods: {
+		closeOnOutsideClick(event) {
+			const { closeOnOutsideClick } = this.currentLayer.state.options;
+			const { modal } = this.$refs;
+			if (modal && closeOnOutsideClick && !modal.contains(event.target)) {
+				this.modalApi.close();
+			}
+		},
 	},
 };
 </script>


### PR DESCRIPTION
## Describe the problem this PR addresses
Modals cannot be closed when you click outside of them.
## Describe the changes in this PR
Add the ability to pass in an options object on modal open, with a parameter to close modals when you click outside of them

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
