### PR TITLE
fix(modal): mobile modals not styled correctly

### DIFF
--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -634,6 +634,13 @@ export default {
 ```
 
 <!-- api-tables:start -->
+## Modal Props
+
+| Prop         | Type   | Default | Possible values | Description                          |
+| ------------ | ------ | ------- | --------------- | ------------------------------------ |
+| before-close | `func` | —       | —               | Before close hook, can block closing |
+
+
 ## Modal Slots
 
 | Slot    | Description   |

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -1,9 +1,7 @@
 <template>
-	<div :class="$s.Container">
-		<div :class="$s.Modal">
-			<!-- @slot Modal content -->
-			<slot />
-		</div>
+	<div :class="$s.Modal">
+		<!-- @slot Modal content -->
+		<slot />
 	</div>
 </template>
 
@@ -40,13 +38,6 @@ export default {
 </script>
 
 <style module="$s">
-.Container {
-	position: relative;
-	width: 100%;
-	height: 100%;
-	overflow: hidden;
-}
-
 .Modal {
 	height: 100%;
 	overflow: scroll;
@@ -54,14 +45,6 @@ export default {
 }
 
 @media screen and (min-width: 840px) {
-	.Container {
-		display: inline-block;
-		width: auto;
-		height: auto;
-		border-radius: 8px;
-		box-shadow: 0 0 24px 8px rgba(0, 0, 0, 0.3);
-	}
-
 	.Modal {
 		width: 600px;
 		min-height: 180px;

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -22,6 +22,7 @@
 				/>
 				<div
 					ref="modal"
+					:class="$s.Container"
 				>
 					<v :nodes="currentLayer.state.vnode" />
 				</div>
@@ -214,5 +215,22 @@ export default {
 
 .disableScroll {
 	overflow: hidden;
+}
+
+.Container {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+}
+
+@media screen and (min-width: 840px) {
+	.Container {
+		display: inline-block;
+		width: auto;
+		height: auto;
+		border-radius: 8px;
+		box-shadow: 0 0 24px 8px rgba(0, 0, 0, 0.3);
+	}
 }
 </style>


### PR DESCRIPTION
## Describe the problem this PR addresses
With the latest changes to modals there was another container div introduced in the modal layer component, this container was not styled and therefor causes issues on mobile.

## Describe the changes in this PR
Added styling to the modal layer container.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
