### PR TITLE
fix(modal): use better logic to decide whether a click is inside of a modal or not

### DIFF
--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -187,6 +187,8 @@ export default {
 
 		isClickInsideModal(modal, event) {
 			const pos = modal.getBoundingClientRect();
+			console.log(pos); // eslint-disable-line no-console
+			console.log(`Event x: ${event.clientX} and Event y: ${event.clientY}`); // eslint-disable-line no-console
 			const containsX = event.clientX > pos.left && event.clientX < pos.right;
 			const containsY = event.clientY > pos.top && event.clientY < pos.bottom;
 			return containsX && containsY;

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -178,7 +178,8 @@ export default {
 			if (
 				modal
 				&& closeOnClickOutside
-				&& modal.compareDocumentPosition(event.target) === 10
+				&& modal.compareDocumentPosition(event.target)
+					=== (Node.DOCUMENT_POSITION_PRECEDING + Node.DOCUMENT_POSITION_CONTAINS)
 			) {
 				this.modalApi.close();
 			}

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -175,7 +175,11 @@ export default {
 		closeOnClickOutside(event) {
 			const { closeOnClickOutside } = this.currentLayer.state.options;
 			const { modal } = this.$refs;
-			if (modal && closeOnClickOutside && !modal.contains(event.target)) {
+			if (
+				modal
+				&& closeOnClickOutside
+				&& modal.compareDocumentPosition(event.target) !== 20
+			) {
 				this.modalApi.close();
 			}
 		},

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -14,7 +14,7 @@
 				v-if="currentLayer.state.vnode"
 				ref="baseModalLayer"
 				:class="$s.ModalLayer"
-				@click="closeOnClickOutside"
+				@click.capture="closeOnClickOutside"
 			>
 				<pseudo-window
 					body
@@ -175,12 +175,7 @@ export default {
 		closeOnClickOutside(event) {
 			const { closeOnClickOutside } = this.currentLayer.state.options;
 			const { modal } = this.$refs;
-			if (
-				modal
-				&& closeOnClickOutside
-				&& modal.compareDocumentPosition(event.target)
-					=== (Node.DOCUMENT_POSITION_PRECEDING + Node.DOCUMENT_POSITION_CONTAINS)
-			) {
+			if (modal && closeOnClickOutside && !modal.contains(event.target)) {
 				this.modalApi.close();
 			}
 		},

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -175,23 +175,13 @@ export default {
 		closeOnClickOutside(event) {
 			const { closeOnClickOutside } = this.currentLayer.state.options;
 			const { modal } = this.$refs;
-
 			if (
 				modal
 				&& closeOnClickOutside
-				&& !this.isClickInsideModal(modal, event)
+				&& modal.compareDocumentPosition(event.target) === 10
 			) {
 				this.modalApi.close();
 			}
-		},
-
-		isClickInsideModal(modal, event) {
-			const pos = modal.getBoundingClientRect();
-			console.log(pos); // eslint-disable-line no-console
-			console.log(`Event x: ${event.clientX} and Event y: ${event.clientY}`); // eslint-disable-line no-console
-			const containsX = event.clientX > pos.left && event.clientX < pos.right;
-			const containsY = event.clientY > pos.top && event.clientY < pos.bottom;
-			return containsX && containsY;
 		},
 	},
 };

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -175,13 +175,21 @@ export default {
 		closeOnClickOutside(event) {
 			const { closeOnClickOutside } = this.currentLayer.state.options;
 			const { modal } = this.$refs;
+
 			if (
 				modal
 				&& closeOnClickOutside
-				&& modal.compareDocumentPosition(event.target) !== 20
+				&& !this.isClickInsideModal(modal, event)
 			) {
 				this.modalApi.close();
 			}
+		},
+
+		isClickInsideModal(modal, event) {
+			const pos = modal.getBoundingClientRect();
+			const containsX = event.clientX > pos.left && event.clientX < pos.right;
+			const containsY = event.clientY > pos.top && event.clientY < pos.bottom;
+			return containsX && containsY;
 		},
 	},
 };


### PR DESCRIPTION
## Describe the problem this PR addresses
Certain child elements of modals were incorrectly triggering modals to close.

`Node.contains` relies on the fact that the element that was clicked is contained within the DOM of the modal. If the following example of code were to be inside of a modal:
```
<span
	v-if="display"
	@click="display = !display"
>
	testing
</span>
```
Whenever the span is clicked, it toggles itself off of the DOM. The click event propagates up to the ModalLayer and the `.contains` logic checks if the span is inside or outside of the modal. Given that the element is no longer in the DOM the modal layer closes the current modal.

While this kind of issue can be stopped at the source using `click.stop` or `v-show` instead of a v-if, I believe that it is easy to imagine more complex implementations of this logic that could cause the modal to close frustrate Maker developers. We should be able to handle this type of situation from the maker side, and developers should not need to worry about their event propagation.

## Describe the changes in this PR
Instead of using `Node.contains` I used `Node.documentPositionContains` which consistently returns the value of 10 or `Node.DOCUMENT_POSITION_PRECEDING + Node.DOCUMENT_POSITION_CONTAINS` whenever a click is registered outside of the modal. By explicitly checking for a click outside of the modal, instead of checking for a click inside and then using a `! NOT` operator, we also have a more redundant solution.

 I have tested this change across multiple contexts, including the style-guide docs, stacked modals, and in our website repo using an `npm link`.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
