### PR TITLE
ci: bash to exit on error

### DIFF
--- a/.github/workflows/deploy-styleguide.yml
+++ b/.github/workflows/deploy-styleguide.yml
@@ -21,7 +21,7 @@ jobs:
           ref: deploys
           path: .dist
       - name: Build & deploy
-        shell: bash -l {0}
+        shell: bash -e -l {0}
         run: |
           cd .dist
           git config user.name github-actions

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Lint code
-        shell: bash -l {0}
+        shell: bash -e -l {0}
         run: |
           nvm i
           npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Release
-      shell: bash -l {0}
+      shell: bash -e -l {0}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -28,7 +28,7 @@ jobs:
         ref: deploys
         path: .dist
     - name: Build & deploy styleguide
-      shell: bash -l {0}
+      shell: bash -e -l {0}
       run: |
         cd .dist
         git config user.name github-actions

--- a/build/deploys/pull.js
+++ b/build/deploys/pull.js
@@ -3,8 +3,8 @@ const exec = promisify(require('child_process').exec);
 const ensureDeployDirectory = require('./ensure');
 
 (async function pullDeploys() {
-	const deployDir = await ensureDeployDirectory();
-	process.chdir(deployDir);
+	const deployDirectory = await ensureDeployDirectory();
+	process.chdir(deployDirectory);
 
 	// pull
 	await exec('git pull');

--- a/build/deploys/push.js
+++ b/build/deploys/push.js
@@ -3,8 +3,8 @@ const exec = promisify(require('child_process').exec);
 const ensureDeployDirectory = require('./ensure');
 
 (async function pushDeploys() {
-	const deployDir = await ensureDeployDirectory();
-	process.chdir(deployDir);
+	const deployDirectory = await ensureDeployDirectory();
+	process.chdir(deployDirectory);
 
 	// add all changes
 	await exec('git add --all');

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -23,7 +23,7 @@ function getDirectories(baseDirectory) {
 ensureDirectory(LAB_DIST);
 ensureDirectory(STYLEGUIDE_DIST);
 
-const STYLEGUIDE_DEPLOYS = getDirectories(STYLEGUIDE_DIST).filter(d => d !== '0.0.0-semantic-release');
+const STYLEGUIDE_DEPLOYS = getDirectories(STYLEGUIDE_DIST).filter((d) => d !== '0.0.0-semantic-release');
 const LAB_DEPLOYS = getDirectories(LAB_DIST);
 
 const VERSION_REGEX = /^\d+\.\d+\.\d+/;

--- a/build/sync-to-latest/index.js
+++ b/build/sync-to-latest/index.js
@@ -1,11 +1,13 @@
 const path = require('path');
 const fse = require('fs-extra');
 const semver = require('semver');
-const { getCurrentBranch, getLibVersion, isStableRelease, isPreviewRelease } = require('../utils');
+const {
+ getCurrentBranch, isStableRelease, isPreviewRelease,
+} = require('../utils');
 
-let branchName = getCurrentBranch();
-let isStable = isStableRelease(branchName);
-let isPreview = isPreviewRelease(branchName);
+const branchName = getCurrentBranch();
+const isStable = isStableRelease(branchName);
+const isPreview = isPreviewRelease(branchName);
 
 if (!isStable && !isPreview) {
 	// only sync versioned releases to latest or latest-preview directories
@@ -23,7 +25,10 @@ function getDirectories(baseDirectory) {
 
 const DIST = path.resolve(process.cwd(), '.dist');
 const STYLEGUIDE_DIST = path.resolve(DIST, 'styleguide');
-const STYLEGUIDE_SEMVER_DEPLOYS = getDirectories(STYLEGUIDE_DIST).filter(deploy => semver.valid(deploy));
+const STYLEGUIDE_SEMVER_DEPLOYS = getDirectories(STYLEGUIDE_DIST).filter(
+	(deploy) => semver.valid(deploy),
+);
+
 STYLEGUIDE_SEMVER_DEPLOYS.sort((semverA, semverB) => {
 	if (semver.gt(semverA, semverB)) {
 		return -1;

--- a/build/utils.js
+++ b/build/utils.js
@@ -1,8 +1,8 @@
 const _ = require('lodash');
 const branch = require('git-branch');
-const { version } = require('../package.json');
 const { execSync } = require('child_process');
-const semver = require("semver");
+const semver = require('semver');
+const { version } = require('../package.json');
 
 function merge(...objects) {
 	return _.mergeWith(...objects, (objectValue, sourceValue) => {
@@ -35,17 +35,17 @@ function isPreviewRelease(branchName) {
 	return ['next', 'next-major', 'beta', 'alpha'].includes(branchName);
 }
 
-function getLibVersion() {
-	let libVersion = version;
-	if (libVersion === '0.0.0-semantic-release') {
+function getLibraryVersion() {
+	let libraryVersion = version;
+	if (libraryVersion === '0.0.0-semantic-release') {
 		let tagsOutput = execSync('git tag --points-at HEAD'); // returns byte buffer
 		tagsOutput = tagsOutput.toString(); // converts byte buffer to string
-		let semverTags = tagsOutput
+		const semverTags = tagsOutput
 			.trim()
 			.split(/(\s+)/)
-			.filter(tag => tag.trim().length > 0)
-			.map(tag => semver.clean(tag)) // may return null
-			.filter(tag => !!tag); // null check
+			.filter((tag) => tag.trim().length > 0)
+			.map((tag) => semver.clean(tag)) // may return null
+			.filter((tag) => !!tag); // null check
 		semverTags.sort((tagA, tagB) => {
 			if (semver.gt(tagA, tagB)) {
 				return -1;
@@ -53,16 +53,16 @@ function getLibVersion() {
 			return 1;
 		});
 		if (semverTags.length > 0) {
-			libVersion = semverTags[0]; // latest semver tag
+			[libraryVersion] = semverTags; // latest semver tag
 		}
 	}
-	return libVersion;
+	return libraryVersion;
 }
 
 module.exports = {
 	merge,
 	getCurrentBranch,
-	getLibVersion,
+	getLibraryVersion,
 	isSemanticReleaseBranch,
 	isStableRelease,
 	isPreviewRelease,

--- a/styleguide/webpack-styleguide-config.js
+++ b/styleguide/webpack-styleguide-config.js
@@ -6,11 +6,10 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ent = require('ent');
 const { merge } = require('../build/utils');
 const webpackBaseConfig = require('../build/webpack-base-config');
-const { version } = require('../package.json');
-const { getCurrentBranch, isSemanticReleaseBranch, getLibVersion } = require('../build/utils');
+const { getCurrentBranch, isSemanticReleaseBranch, getLibraryVersion } = require('../build/utils');
 
-let branchName = getCurrentBranch();
-const deploy = isSemanticReleaseBranch(branchName) ? getLibVersion() : branchName;
+const branchName = getCurrentBranch();
+const deploy = isSemanticReleaseBranch(branchName) ? getLibraryVersion() : branchName;
 
 // console.log(`branchName: ${branchName}, version: ${version}, deploy: ${deploy}`);
 // console.log('ENV VARS:', JSON.stringify(process.env, undefined, 4));


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
The bash session was not existing when a command failed

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->

Set the [`-e` flag](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html#:~:text=exit%20immediately%20if%20a%20pipeline%20(see%20pipelines)%2C%20which%20may%20consist%20of%20a%20single%20simple%20command%20(see%20simple%20commands)%2C%20a%20list%20(see%20lists)%2C%20or%20a%20compound%20command%20(see%20compound%20commands)%20returns%20a%20non-zero%20status.) so that errors thrown in the bash session are propagated.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
