### PR TITLE
feat(action-bar): allow clicking through action bar container

### DIFF
--- a/src/components/ActionBar/README.md
+++ b/src/components/ActionBar/README.md
@@ -15,9 +15,6 @@ There are 2 versions of ActionBar:
 		<button @click="showClose = !showClose">
 			toggle close button
 		</button>
-		<button @click="showPrimary = !showPrimary">
-			toggle primary button
-		</button>
 		<div class="container">
 			<div class="card">
 				<div class="content">
@@ -29,9 +26,6 @@ There are 2 versions of ActionBar:
 							content content content
 						</li>
 					</ol>
-					<button>
-						I should be clickable through action bar container
-					</button>
 					<m-inline-action-bar>
 						<m-action-bar-button
 							v-if="showClose"
@@ -68,7 +62,6 @@ export default {
 	data() {
 		return {
 			showClose: true,
-			showPrimary: true,
 		};
 	},
 };

--- a/src/components/ActionBar/README.md
+++ b/src/components/ActionBar/README.md
@@ -35,7 +35,6 @@ There are 2 versions of ActionBar:
 							<x-icon class="icon" />
 						</m-action-bar-button>
 						<m-action-bar-button
-							v-if="showPrimary"
 							key="confirm"
 							full-width
 						>

--- a/src/components/ActionBar/README.md
+++ b/src/components/ActionBar/README.md
@@ -15,6 +15,9 @@ There are 2 versions of ActionBar:
 		<button @click="showClose = !showClose">
 			toggle close button
 		</button>
+		<button @click="showPrimary = !showPrimary">
+			toggle primary button
+		</button>
 		<div class="container">
 			<div class="card">
 				<div class="content">
@@ -26,6 +29,9 @@ There are 2 versions of ActionBar:
 							content content content
 						</li>
 					</ol>
+					<button>
+						I should be clickable through action bar container
+					</button>
 					<m-inline-action-bar>
 						<m-action-bar-button
 							v-if="showClose"
@@ -35,6 +41,7 @@ There are 2 versions of ActionBar:
 							<x-icon class="icon" />
 						</m-action-bar-button>
 						<m-action-bar-button
+							v-if="showPrimary"
 							key="confirm"
 							full-width
 						>
@@ -61,6 +68,7 @@ export default {
 	data() {
 		return {
 			showClose: true,
+			showPrimary: true,
 		};
 	},
 };

--- a/src/components/ActionBar/src/AtomicActionBar.vue
+++ b/src/components/ActionBar/src/AtomicActionBar.vue
@@ -47,6 +47,7 @@ export default {
 	justify-content: space-between;
 	box-sizing: border-box;
 	padding: 24px 24px var(--action-bar-bottom-padding) 24px;
+	pointer-events: none;
 }
 
 @media screen and (max-width: 839px) {
@@ -101,6 +102,7 @@ export default {
 	margin-right: 8px;
 	-webkit-transform: translate3d(0, 0, 0);  /* Fixes buttons flickering on mobile devices */
 	filter: drop-shadow(0 15px 10px rgb(0 0 0 / 20%));
+	pointer-events: auto;
 
 	&:last-child {
 		margin-right: 0;


### PR DESCRIPTION

## Describe the changes in this PR
The action bar container does not let pointer events through to the layer behind. This is particularly noticeable in situations where the primary action is not visible. This PR allows for pointer events to go through the container but not the buttons.
## Other information

