### PR TITLE
fix(action-bar): Improve device / browser behavior

### DIFF
--- a/src/components/ActionBar/README.md
+++ b/src/components/ActionBar/README.md
@@ -38,7 +38,7 @@ There are 2 versions of ActionBar:
 							key="confirm"
 							full-width
 						>
-							Confirm or whatever
+							Primary action
 						</m-action-bar-button>
 					</m-inline-action-bar>
 				</div>
@@ -164,7 +164,7 @@ _DemoActionBar.vue_
 				key="confirm"
 				full-width
 			>
-				Confirm or whatever
+				Primary action
 			</m-action-bar-button>
 		</m-action-bar>
 	</div>

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -47,15 +47,18 @@ import { MLoading } from '@square/maker/components/Loading';
 // TODO: refactor the code below so it's shared with Button component
 
 function getContrast(chromaBg, targetChromaFg) {
-	if (!targetChromaFg || chroma.contrast(chromaBg, targetChromaFg) < 4.5) {
-		const isLight = chromaBg.luminance() > 0.32;
+	const accessibleContrast = 4.5;
+	const lightLuminance = 0.32;
+	if (!targetChromaFg || chroma.contrast(chromaBg, targetChromaFg) < accessibleContrast) {
+		const isLight = chromaBg.luminance() > lightLuminance;
 		return chroma(isLight ? '#000' : '#fff');
 	}
 	return targetChromaFg;
 }
 
 function getFocus(chromaColor) {
-	return chromaColor.alpha(0.8);
+	const colorAdjust = 0.8;
+	return chromaColor.alpha(colorAdjust);
 }
 
 function fill(tokens) {
@@ -153,8 +156,10 @@ export default {
 				return false;
 			}
 			const children = (this.$slots.default || []).filter(
+				// eslint-disable-next-line no-magic-numbers
 				(vnode) => vnode.tag || vnode.text.trim().length > 0,
 			);
+			// eslint-disable-next-line no-magic-numbers
 			return children.length === 1 && children[0].tag;
 		},
 
@@ -171,20 +176,17 @@ export default {
 
 <style module="$s">
 .Button {
-	--button-large: 64px;
 	--button-medium: 48px;
 
 	position: relative;
 	display: inline-flex;
 	align-items: center;
 	min-width: 0;
-	height: var(--button-large);
-
-	/* large size */
-	padding: 0 32px;
+	height: var(--button-medium);
+	padding: 0 24px;
 	color: var(--text-color);
 	font-weight: 500;
-	font-size: 16px;
+	font-size: 14px;
 	font-family: inherit;
 	vertical-align: middle;
 	background-color: var(--color-main);
@@ -203,15 +205,15 @@ export default {
 	fill: currentColor;
 
 	& > * {
-		line-height: 1.5;
+		line-height: 1.77;
 	}
 
 	&.iconButton {
 		display: inline-flex;
 		flex: 0 0 auto;
 		align-items: center;
-		width: var(--button-large);
-		height: var(--button-large);
+		width: var(--button-medium);
+		height: var(--button-medium);
 		padding: 0;
 	}
 
@@ -267,26 +269,6 @@ export default {
 
 	&.loading {
 		color: transparent;
-	}
-}
-
-@media screen and (min-width: 840px) {
-	.Button {
-		height: var(--button-medium);
-
-		/* medium size */
-		padding: 0 24px;
-		font-size: 14px;
-
-		& > * {
-			line-height: 1.77;
-		}
-
-		&.iconButton {
-			flex: 0 0 auto;
-			width: var(--button-medium);
-			height: var(--button-medium);
-		}
 	}
 }
 

--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -67,7 +67,8 @@ export default {
 	},
 
 	created() {
-		this.setActionbar = throttle(this.setActionbar, 50, { leading: false });
+		const waitTimeMs = 50;
+		this.setActionbar = throttle(this.setActionbar, waitTimeMs, { leading: false });
 	},
 
 	methods: {
@@ -80,9 +81,9 @@ export default {
 
 <style module="$s">
 .ActionBarLayer {
-	--action-bar-bottom-padding: 64px;
+	--action-bar-height: 96px; /* button + padding */
 
-	padding-bottom: calc(88px + var(--action-bar-bottom-padding));
+	padding-bottom: var(--action-bar-height);
 
 	&.NoActionBar {
 		padding-bottom: 0;
@@ -98,7 +99,7 @@ export default {
 	display: flex;
 	justify-content: space-between;
 	box-sizing: border-box;
-	padding: 24px 24px var(--action-bar-bottom-padding) 24px;
+	padding: 24px;
 }
 
 @media screen and (min-width: 840px) {
@@ -113,7 +114,7 @@ export default {
 
 .Action {
 	margin-right: 8px;
-	-webkit-transform: translate3d(0, 0, 0); /* Fixes buttons flickering on mobile devices */
+	transform: translate3d(0, 0, 0); /* Fixes buttons flickering on mobile devices */
 	filter: drop-shadow(0 15px 10px rgb(0 0 0 / 20%));
 
 	&:last-child {

--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -67,7 +67,7 @@ export default {
 			return !!this.actionBarVnodes;
 		},
 		hasSafariAdjustment() {
-			return isMobileSafari;
+			return isMobileSafari();
 		},
 	},
 
@@ -86,8 +86,12 @@ export default {
 
 <style module="$s">
 .ActionBarLayer {
+	/*
+	* The action bar layer injects space in the dom
+	* to ensure the content behind the actions remain visible
+	*/
 	--action-bar-height: 96px; /* button + padding */
-	--safari-padding: 44px;
+	--safari-padding: 116px; /* action bar height + safari offset */
 
 	padding-bottom: var(--action-bar-height);
 
@@ -95,40 +99,8 @@ export default {
 		padding-bottom: 0;
 	}
 
-	&.hasSafariAdjustment {
-		padding-bottom: calc(var(--action-bar-height) + var(--safari-padding));
-	}
-}
-
-.ActionBar {
-	position: fixed;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	z-index: 10;
-	display: flex;
-	justify-content: space-between;
-	box-sizing: border-box;
-	padding: 24px;
-}
-
-@media screen and (min-width: 840px) {
-	.ActionBar {
-		display: none;
-	}
-
-	.ActionBarLayer {
-		padding-bottom: 0;
-	}
-}
-
-.Action {
-	margin-right: 8px;
-	transform: translate3d(0, 0, 0); /* Fixes buttons flickering on mobile devices */
-	filter: drop-shadow(0 15px 10px rgb(0 0 0 / 20%));
-
-	&:last-child {
-		margin-right: 0;
+	&.safariAdjustment {
+		padding-bottom: var(--safari-padding);
 	}
 }
 </style>

--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -3,6 +3,7 @@
 		:class="[
 			$s.ActionBarLayer,
 			{ [$s.NoActionBar]: !hasActionBar },
+			{ [$s.safariAdjustment]: hasSafariAdjustment },
 		]"
 		v-bind="$attrs"
 		v-on="$listeners"
@@ -25,6 +26,7 @@
 import { throttle } from 'lodash';
 import V from 'vue-v';
 import { MTransitionSpringUp } from '@square/maker/components/TransitionSpringUp';
+import { isMobileSafari } from '@square/maker/utils/browser';
 import AtomicActionBar from './AtomicActionBar.vue';
 
 export default {
@@ -64,6 +66,9 @@ export default {
 		hasActionBar() {
 			return !!this.actionBarVnodes;
 		},
+		hasSafariAdjustment() {
+			return isMobileSafari;
+		},
 	},
 
 	created() {
@@ -82,11 +87,16 @@ export default {
 <style module="$s">
 .ActionBarLayer {
 	--action-bar-height: 96px; /* button + padding */
+	--safari-padding: 44px;
 
 	padding-bottom: var(--action-bar-height);
 
 	&.NoActionBar {
 		padding-bottom: 0;
+	}
+
+	&.hasSafariAdjustment {
+		padding-bottom: calc(var(--action-bar-height) + var(--safari-padding));
 	}
 }
 

--- a/src/components/ActionBar/src/AtomicActionBar.vue
+++ b/src/components/ActionBar/src/AtomicActionBar.vue
@@ -4,6 +4,7 @@
 			$s.ActionBar,
 			$s[`position_${position}`],
 			$s[`hide-on_${hideOn}`],
+			{ [$s.safariAdjustment]: hasSafariAdjustment },
 		]"
 		tag="div"
 	>
@@ -16,6 +17,7 @@
 
 <script>
 import vnodeSyringe from 'vue-vnode-syringe';
+import { isMobileSafari } from '@square/maker/utils/browser';
 import TransitionActionBarItems from './TransitionActionBarItems.vue';
 
 export default {
@@ -36,15 +38,28 @@ export default {
 			validator: (hideOn) => ['none', 'mobile', 'tablet', 'desktop'].includes(hideOn),
 		},
 	},
+
+	computed: {
+		hasSafariAdjustment() {
+			return isMobileSafari();
+		},
+	},
 };
 </script>
 
 <style module="$s">
 .ActionBar {
+	--action-bar-padding: 24px;
+	--safari-padding: 64px; /* 44px safari deadzone + some additional spacing */
+
 	display: flex;
 	justify-content: space-between;
 	box-sizing: border-box;
-	padding: 24px;
+	padding: var(--action-bar-padding);
+
+	&.safariAdjustment {
+		padding-bottom: var(--safari-padding);
+	}
 }
 
 @media screen and (max-width: 839px) {

--- a/src/components/ActionBar/src/AtomicActionBar.vue
+++ b/src/components/ActionBar/src/AtomicActionBar.vue
@@ -41,12 +41,10 @@ export default {
 
 <style module="$s">
 .ActionBar {
-	--action-bar-bottom-padding: 64px;
-
 	display: flex;
 	justify-content: space-between;
 	box-sizing: border-box;
-	padding: 24px 24px var(--action-bar-bottom-padding) 24px;
+	padding: 24px;
 }
 
 @media screen and (max-width: 839px) {
@@ -58,10 +56,6 @@ export default {
 @media screen and (min-width: 840px) {
 	.hide-on_tablet {
 		display: none;
-	}
-
-	.ActionBar {
-		padding: 24px 24px 32px 24px;
 	}
 }
 
@@ -99,7 +93,7 @@ export default {
 
 .Action {
 	margin-right: 8px;
-	-webkit-transform: translate3d(0, 0, 0);  /* Fixes buttons flickering on mobile devices */
+	transform: translate3d(0, 0, 0);  /* Fixes buttons flickering on mobile devices */
 	filter: drop-shadow(0 15px 10px rgb(0 0 0 / 20%));
 
 	&:last-child {

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -1,5 +1,10 @@
 <template>
-	<div :class="$s.ActionBarWrapper">
+	<div
+		:class="[
+			$s.ActionBarWrapper,
+			{ [$s.safariAdjustment]: hasSafariAdjustment },
+		]"
+	>
 		<atomic-action-bar
 			v-bind="$attrs"
 			v-on="$listeners"
@@ -11,6 +16,7 @@
 </template>
 
 <script>
+import { isMobileSafari } from '@square/maker/utils/browser';
 import AtomicActionBar from './AtomicActionBar.vue';
 
 /**
@@ -24,11 +30,24 @@ export default {
 	},
 
 	inheritAttrs: false,
+
+	computed: {
+		hasSafariAdjustment() {
+			return isMobileSafari;
+		},
+	},
 };
 </script>
 
 <style module="$s">
 .ActionBarWrapper {
-	padding-bottom: 96px; /* action bar height */
+	--action-bar-height: 96px; /* button + padding */
+	--safari-padding: 44px;
+
+	padding-bottom: var(--action-bar-height);
+
+	&.hasSafariAdjustment {
+		padding-bottom: calc(var(--action-bar-height) + var(--safari-padding));
+	}
 }
 </style>

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -33,7 +33,7 @@ export default {
 
 	computed: {
 		hasSafariAdjustment() {
-			return isMobileSafari;
+			return isMobileSafari();
 		},
 	},
 };
@@ -41,13 +41,17 @@ export default {
 
 <style module="$s">
 .ActionBarWrapper {
+	/*
+	* The action bar wrapper injects space in the dom
+	* to ensure the content behind the actions remain visible
+	*/
 	--action-bar-height: 96px; /* button + padding */
-	--safari-padding: 44px;
+	--safari-padding: 116px; /* padding + button + safari offset + additional padding */
 
 	padding-bottom: var(--action-bar-height);
 
-	&.hasSafariAdjustment {
-		padding-bottom: calc(var(--action-bar-height) + var(--safari-padding));
+	&.safariAdjustment {
+		padding-bottom: var(--safari-padding);
 	}
 }
 </style>

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -29,14 +29,6 @@ export default {
 
 <style module="$s">
 .ActionBarWrapper {
-	padding-bottom: 120px;
-}
-
-@media screen and (min-width: 840px) {
-	.ActionBarWrapper {
-		--action-bar-bottom-padding: 64px;
-
-		padding-bottom: calc(72px + var(--action-bar-bottom-padding));
-	}
+	padding-bottom: 96px; /* action bar height */
 }
 </style>

--- a/src/utils/browser.js
+++ b/src/utils/browser.js
@@ -1,0 +1,7 @@
+/* eslint-env browser */
+export function isMobileSafari() {
+	const ua = window.navigator.userAgent;
+	const iOS = !!ua.match(/ipad/i) || !!ua.match(/iphone/i);
+	const webkit = !!ua.match(/webkit/i);
+	return iOS && webkit && !ua.match(/crios/i);
+}

--- a/src/utils/browser.js
+++ b/src/utils/browser.js
@@ -1,7 +1,10 @@
 /* eslint-env browser */
 export function isMobileSafari() {
-	const ua = window.navigator.userAgent;
-	const iOS = !!ua.match(/ipad/i) || !!ua.match(/iphone/i);
-	const webkit = !!ua.match(/webkit/i);
-	return iOS && webkit && !ua.match(/crios/i);
+	if (typeof window !== 'undefined') {
+		const ua = window && window.navigator.userAgent;
+		const iOS = !!ua.match(/ipad/i) || !!ua.match(/iphone/i);
+		const webkit = !!ua.match(/webkit/i);
+		return iOS && webkit && !ua.match(/crios/i);
+	}
+	return false;
 }


### PR DESCRIPTION
## Describe the problem this PR addresses
The original design for the ActionBar intended the padding to be the same all the way around the buttons and anchored to the bottom. Over time we adjusted the bottom padding to be much higher to address the invisible container that Mobile Safari adds to toggle the browser toolbar (details: https://bugs.webkit.org/show_bug.cgi?id=194235) 

I've updated the behavior so that rather than degrading the design intent for all browsers that we target Mobile Safari and then add the repositioning for that browser.


## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
![mobile-action-bar](https://user-images.githubusercontent.com/129122/121107908-a5d6db80-c7bd-11eb-9add-60745eb054e7.jpg)

- Design: Update padding to be consistent 24px.
- Design: Remove responsive button sizing. While this was the original design, we'd like to move to a simpler and more consistent default. Now using default medium button sizes regardless of screen size.
- Utility added to determine if browser is Mobile Safari (iphone / ipad)
- Target actionbar positioning to be higher only for Mobile Safari.
- Fix some linting issues


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
We've already discussed these changes with product / design, so no additional need to align further.