### PR TITLE
refactor(section)!: change name of section component to box

### DIFF
--- a/src/components/Box/README.md
+++ b/src/components/Box/README.md
@@ -1,69 +1,69 @@
-# Section
+# Box
 
 ```vue
 <template>
 	<div>
 		<h4>content</h4>
-		<m-section>
-			section content
-		</m-section>
+		<m-box>
+			box content
+		</m-box>
 
 		<h4>label + content</h4>
-		<m-section label="section label">
-			section content
-		</m-section>
+		<m-box label="box label">
+			box content
+		</m-box>
 
 		<h4>label + sublabel + content</h4>
-		<m-section
-			label="section label"
-			sublabel="section sublabel"
+		<m-box
+			label="box label"
+			sublabel="box sublabel"
 		>
-			section content
-		</m-section>
+			box content
+		</m-box>
 
 		<h4>label + sublabel + requirement label + content</h4>
-		<m-section
-			label="section label"
-			sublabel="section sublabel"
+		<m-box
+			label="box label"
+			sublabel="box sublabel"
 		>
-			section content
+			box content
 			<template #requirement-label>
-				section requirement label
+				box requirement label
 			</template>
-		</m-section>
+		</m-box>
 
 		<h4>size small</h4>
-		<m-section
-			label="section label"
-			sublabel="section sublabel"
+		<m-box
+			label="box label"
+			sublabel="box sublabel"
 			size="small"
 		>
-			section content
+			box content
 			<template #requirement-label>
-				section requirement label
+				box requirement label
 			</template>
-		</m-section>
+		</m-box>
 
 		<h4>size large</h4>
-		<m-section
-			label="section label"
-			sublabel="section sublabel"
+		<m-box
+			label="box label"
+			sublabel="box sublabel"
 			size="large"
 		>
-			section content
+			box content
 			<template #requirement-label>
-				section requirement label
+				box requirement label
 			</template>
-		</m-section>
+		</m-box>
 	</div>
 </template>
 
 <script>
-import { MSection } from '@square/maker/components/Section';
+import { MBox } from '@square/maker/components/Box';
 
 export default {
 	components: {
-		MSection,
+		MBox,
 	},
 };
 </script>

--- a/src/components/Box/index.js
+++ b/src/components/Box/index.js
@@ -1,0 +1,1 @@
+export { default as MBox } from './src/Box.vue';

--- a/src/components/Box/src/Box.vue
+++ b/src/components/Box/src/Box.vue
@@ -1,7 +1,7 @@
 <template>
 	<section
 		:class="[
-			$s.Section,
+			$s.Box,
 			$s[`size_${size}`],
 		]"
 		v-bind="$attrs"
@@ -28,7 +28,7 @@
 			</div>
 		</header>
 
-		<!-- @slot section content -->
+		<!-- @slot box content -->
 		<slot />
 	</section>
 </template>
@@ -43,21 +43,21 @@ export default {
 
 	props: {
 		/**
-		 * Section label
+		 * Box label
 		 */
 		label: {
 			type: String,
 			default: undefined,
 		},
 		/**
-		 * Section sublabel
+		 * Box sublabel
 		 */
 		sublabel: {
 			type: String,
 			default: undefined,
 		},
 		/**
-		 * Section size
+		 * Box size
 		 */
 		size: {
 			type: String,
@@ -69,7 +69,7 @@ export default {
 </script>
 
 <style module="$s">
-.Section {
+.Box {
 	--color-white: #fff;
 	--color-black-90: rgba(0, 0, 0, 0.9);
 	--color-black-55: rgba(0, 0, 0, 0.55);

--- a/src/components/Section/index.js
+++ b/src/components/Section/index.js
@@ -1,1 +1,0 @@
-export { default as MSection } from './src/Section.vue';


### PR DESCRIPTION
**Breaking Change**

We'd like to create a new component called Section for standardizing the logic we have for our website sections. The current section component is very limited in scope and value. While we should look at refactoring the patterns we've established with the current section component to be more composable styles to replace their current use cases, the simplest change right now is to change the component name to something more generic.

Section component is dead, long live the section component (in a future PR).