### PR TITLE
fix: actionbar bottom padding on ios 15.0

### DIFF
--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -83,13 +83,15 @@ export default {
 .ActionBarLayer {
 	--regular-bottom-padding: 32px;
 	--extra-bottom-padding-for-deadclick: 32px;
+	--safe-area-inset-padding: env(safe-area-inset-bottom, 0);
 	--actionbar-bottom-padding:
 		calc(
 			var(--regular-bottom-padding)
 			+ var(--extra-bottom-padding-for-deadclick)
+			+ var(--safe-area-inset-padding)
 		);
 	--actionbar-size: 64px;
-	--actionbar-top-padding: 24px;
+	--actionbar-top-padding: 32px;
 
 	padding-bottom:
 		calc(

--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -81,44 +81,31 @@ export default {
 
 <style module="$s">
 .ActionBarLayer {
-	--action-bar-bottom-padding: 64px;
+	--regular-bottom-padding: 32px;
+	--extra-bottom-padding-for-deadclick: 32px;
+	--actionbar-bottom-padding:
+		calc(
+			var(--regular-bottom-padding)
+			+ var(--extra-bottom-padding-for-deadclick)
+		);
+	--actionbar-size: 64px;
+	--actionbar-top-padding: 24px;
 
-	padding-bottom: calc(88px + var(--action-bar-bottom-padding));
+	padding-bottom:
+		calc(
+			var(--actionbar-top-padding)
+			+ var(--actionbar-size)
+			+ var(--actionbar-bottom-padding)
+		);
 
 	&.NoActionBar {
 		padding-bottom: 0;
 	}
 }
 
-.ActionBar {
-	position: fixed;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	z-index: 10;
-	display: flex;
-	justify-content: space-between;
-	box-sizing: border-box;
-	padding: 24px 24px var(--action-bar-bottom-padding) 24px;
-}
-
 @media screen and (min-width: 840px) {
-	.ActionBar {
-		display: none;
-	}
-
 	.ActionBarLayer {
 		padding-bottom: 0;
-	}
-}
-
-.Action {
-	margin-right: 8px;
-	-webkit-transform: translate3d(0, 0, 0); /* Fixes buttons flickering on mobile devices */
-	filter: drop-shadow(0 15px 10px rgb(0 0 0 / 20%));
-
-	&:last-child {
-		margin-right: 0;
 	}
 }
 </style>

--- a/src/components/ActionBar/src/AtomicActionBar.vue
+++ b/src/components/ActionBar/src/AtomicActionBar.vue
@@ -41,12 +41,20 @@ export default {
 
 <style module="$s">
 .ActionBar {
-	--action-bar-bottom-padding: 64px;
+	--regular-bottom-padding: 32px;
+	--extra-bottom-padding-for-deadclick: 32px;
+	--safe-area-inset-padding: env(safe-area-inset-bottom, 0);
+	--mobile-bottom-padding:
+		calc(
+			var(--regular-bottom-padding)
+			+ var(--extra-bottom-padding-for-deadclick)
+			+ var(--safe-area-inset-padding)
+		);
 
 	display: flex;
 	justify-content: space-between;
 	box-sizing: border-box;
-	padding: 24px 24px var(--action-bar-bottom-padding) 24px;
+	padding: 24px 24px var(--mobile-bottom-padding) 24px;
 	pointer-events: none;
 }
 
@@ -62,7 +70,7 @@ export default {
 	}
 
 	.ActionBar {
-		padding: 24px 24px 32px 24px;
+		padding: 24px 24px var(--regular-bottom-padding) 24px;
 	}
 }
 
@@ -100,7 +108,7 @@ export default {
 
 .Action {
 	margin-right: 8px;
-	-webkit-transform: translate3d(0, 0, 0);  /* Fixes buttons flickering on mobile devices */
+	transform: translate3d(0, 0, 0);  /* Fixes buttons flickering on mobile devices */
 	filter: drop-shadow(0 15px 10px rgb(0 0 0 / 20%));
 	pointer-events: auto;
 

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -29,14 +29,33 @@ export default {
 
 <style module="$s">
 .ActionBarWrapper {
-	padding-bottom: 120px;
+	--regular-bottom-padding: 32px;
+	--extra-bottom-padding-for-deadclick: 32px;
+	--safe-area-inset-padding: env(safe-area-inset-bottom, 0);
+	--actionbar-bottom-padding:
+		calc(
+			var(--regular-bottom-padding)
+			+ var(--extra-bottom-padding-for-deadclick)
+			+ var(--safe-area-inset-padding)
+		);
+	--actionbar-size: 64px;
+	--actionbar-top-padding: 32px;
+
+	padding-bottom:
+		calc(
+			var(--actionbar-top-padding)
+			+ var(--actionbar-size)
+			+ var(--actionbar-bottom-padding)
+		);
 }
 
 @media screen and (min-width: 840px) {
 	.ActionBarWrapper {
-		--action-bar-bottom-padding: 64px;
+		--actionbar-size: 48px;
+		--actionbar-top-padding: 24px;
 
-		padding-bottom: calc(72px + var(--action-bar-bottom-padding));
+		/* no safe-area or deadclick issues on non-mobile resolutions */
+		--actionbar-bottom-padding: var(--regular-bottom-padding);
 	}
 }
 </style>

--- a/src/components/Heading/README.md
+++ b/src/components/Heading/README.md
@@ -36,10 +36,10 @@ export default {
 
 Supports attributes from [`<h1>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h1).
 
-| Prop    | Type     | Default | Possible values                           | Description                                                             |
-| ------- | -------- | ------- | ----------------------------------------- | ----------------------------------------------------------------------- |
-| size    | `number` | `0`     | —                                         | Size of heading. Influences which element is used.                      |
-| element | `string` | —       | `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `div` | Override Heading element. By default, the element is derived from size. |
+| Prop    | Type     | Default        | Possible values                           | Description                                                             |
+| ------- | -------- | -------------- | ----------------------------------------- | ----------------------------------------------------------------------- |
+| size    | `number` | `DEFAULT_SIZE` | —                                         | Size of heading. Influences which element is used.                      |
+| element | `string` | —              | `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `div` | Override Heading element. By default, the element is derived from size. |
 
 
 ## Slots

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -29,10 +29,10 @@ export default {
 
 Supports attributes from [`<span>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span).
 
-| Prop    | Type     | Default | Possible values | Description                              |
-| ------- | -------- | ------- | --------------- | ---------------------------------------- |
-| element | `string` | `'p'`   | `p`, `span`     | which HTML element to wrap the text with |
-| size    | `number` | `0`     | —               | size of text                             |
+| Prop    | Type     | Default        | Possible values | Description                              |
+| ------- | -------- | -------------- | --------------- | ---------------------------------------- |
+| element | `string` | `'p'`          | `p`, `span`     | which HTML element to wrap the text with |
+| size    | `number` | `DEFAULT_SIZE` | —               | size of text                             |
 
 
 ## Slots


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
ios 15.0 adds an erratic address bar in mobile safari that constantly changes window height as user scrolls up or down the page

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
implements apple's recommended fix, which is to use the `env(safe-area-inset-bottom)` CSS variable.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
I haven't actually tested this yet... I don't have a physical device which runs iOS 15.0 and I don't have iOS 15.0 as an option in any of the available supported devices inside Simulator. I think to be able to emulate a iOS 15.0 device in Simulator you would need to download and install Xcode 13+ (currently in beta?), which also requires macOS 11..3+. I'm still on macOS 10.x and prefer not to switch to 11.x yet so maybe someone else can test this for me? 🙃 