### PR TITLE
feat(container): move section component to new container component

### DIFF
--- a/src/components/Container/README.md
+++ b/src/components/Container/README.md
@@ -1,0 +1,96 @@
+# Container
+
+```vue
+<template>
+	<div style="background-color: #F8F7F7;">
+		<m-container>
+			container content
+		</m-container>
+
+		<h4>label + content</h4>
+		<m-container label="container label">
+			container content
+		</m-container>
+
+		<h4>label + sublabel + content</h4>
+		<m-container
+			label="container label"
+			sublabel="container sublabel"
+		>
+			container content
+		</m-container>
+
+		<h4>label + sublabel + requirement label + content</h4>
+		<m-container
+			label="container label"
+			sublabel="container sublabel"
+		>
+			container content
+			<template #requirement-label>
+				container requirement label
+			</template>
+		</m-container>
+
+		<h4>size small</h4>
+		<m-container
+			label="container label"
+			sublabel="container sublabel"
+			size="small"
+		>
+			container content
+			<template #requirement-label>
+				container requirement label
+			</template>
+		</m-container>
+
+		<h4>size large</h4>
+		<m-container
+			label="container label"
+			sublabel="container sublabel"
+			size="large"
+		>
+			container content
+			<template #requirement-label>
+				container requirement label
+			</template>
+		</m-container>
+	</div>
+</template>
+
+<script>
+import { MContainer } from '@square/maker/components/Container';
+
+export default {
+	components: {
+		MContainer,
+	},
+};
+</script>
+```
+
+<!-- api-tables:start -->
+## Props
+
+Supports attributes from [`<section>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section).
+
+| Prop     | Type     | Default    | Possible values            | Description                 |
+| -------- | -------- | ---------- | -------------------------- | --------------------------- |
+| label    | `string` | —          | —                          | Section label               |
+| sublabel | `string` | —          | —                          | Section sublabel            |
+| size     | `string` | `'medium'` | `small`, `medium`, `large` | Section size                |
+| bg-color | `string` | —          | Valid CSS color or 'transparent'                          | Background color of section |
+| color    | `string` | —          | Valid CSS color                          | Text color of section       |
+
+
+## Slots
+
+| Slot              | Description            |
+| ----------------- | ---------------------- |
+| requirement-label | requirement label slot |
+| default           | section content        |
+
+
+## Events
+
+Supports events from [`<section>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section).
+<!-- api-tables:end -->

--- a/src/components/Container/index.js
+++ b/src/components/Container/index.js
@@ -1,0 +1,1 @@
+export { default as MContainer } from './src/Container.vue';

--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -1,10 +1,11 @@
 <template>
 	<section
 		:class="[
-			$s.Section,
+			$s.Container,
 			$s[`size_${size}`],
 		]"
 		v-bind="$attrs"
+		:style="style"
 		v-on="$listeners"
 	>
 		<header :class="$s.Header">
@@ -34,7 +35,7 @@
 </template>
 
 <script>
-import assert from '@square/maker/utils/assert';
+import chroma from 'chroma-js';
 
 /**
  * @inheritAttrs section
@@ -66,24 +67,41 @@ export default {
 			default: 'medium',
 			validator: (size) => ['small', 'medium', 'large'].includes(size),
 		},
+		/**
+		 * Background color of section
+		 */
+		bgColor: {
+			type: String,
+			default: undefined,
+			validator: (color) => chroma.valid(color) || color === 'transparent',
+		},
+		/**
+		 * Text color of section
+		 */
+		color: {
+			type: String,
+			default: undefined,
+			validator: (color) => chroma.valid(color),
+		},
 	},
 
-	created() {
-		assert.warn('This component will change dramatically in a future release. Consider changing to Container component.');
+	computed: {
+		style() {
+			return {
+				'--bg-color': this.bgColor,
+				'--color': this.color,
+			};
+		},
 	},
 };
 </script>
 
 <style module="$s">
-.Section {
-	--color-white: #fff;
-	--color-black-90: rgba(0, 0, 0, 0.9);
-	--color-black-55: rgba(0, 0, 0, 0.55);
-
+.Container {
 	padding: 16px 24px;
-	color: var(--color-black-90);
+	color: var(--color, #000);
 	font-family: inherit;
-	background-color: var(--color-white);
+	background-color: var(--bg-color, #fff);
 }
 
 .Label {

--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -99,9 +99,9 @@ export default {
 <style module="$s">
 .Container {
 	padding: 16px 24px;
-	color: var(--color, #000);
+	color: var(--color, inherit);
 	font-family: inherit;
-	background-color: var(--bg-color, #fff);
+	background-color: var(--bg-color, inherit);
 }
 
 .Label {

--- a/src/components/Section/README.md
+++ b/src/components/Section/README.md
@@ -2,7 +2,7 @@
 
 ```vue
 <template>
-	<div>
+	<div style="background-color: #F8F7F7">
 		<h4>content</h4>
 		<m-section>
 			section content

--- a/src/components/Section/src/Section.vue
+++ b/src/components/Section/src/Section.vue
@@ -69,7 +69,7 @@ export default {
 	},
 
 	created() {
-		assert.warn('This component will change dramatically in a future release. Consider changing to Container component.');
+		assert.warn(false, 'The Section component will change dramatically in a future release. Consider changing to Container component.');
 	},
 };
 </script>

--- a/src/components/Section/src/Section.vue
+++ b/src/components/Section/src/Section.vue
@@ -78,7 +78,6 @@ export default {
 	color: var(--color-black-90);
 	font-family: inherit;
 	background-color: var(--color-white);
-	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
 }
 
 .Label {


### PR DESCRIPTION
## Describe the problem this PR addresses
- Simplify design of Section component to remove dropshadow
- Provide a transition for existing scenarios with Section and move to a new component called Container

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
- [x] Remove drop shadow on Section component. Design request to simplify output as it only looked good in a narrow set of circumstances.
- [x] Duplicate Section component to new Container component
- [x] Add warning about Section component changing in the future (https://github.com/square/maker/pull/82) with suggestion to use new Container component instead.
- [x] Add `bg-color` and `color` props to Container to provide some more flexibility with output.


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
