### PR TITLE
feat(form-controls): inherit text color

### DIFF
--- a/src/utils/InlineFormControlLayout/src/InlineFormControlLayout.vue
+++ b/src/utils/InlineFormControlLayout/src/InlineFormControlLayout.vue
@@ -27,11 +27,10 @@ export default {
 
 <style module="$s">
 .LayoutContainer {
-	--color-foreground: rgba(0, 0, 0, 0.9);
-	--color-sublabel: rgba(0, 0, 0, 0.55);
+	--opacity-sublabel: 0.55
 
 	display: inline-flex;
-	color: var(--color-foreground);
+	color: inherit;
 	font-size: 14px;
 	font-family: inherit;
 	line-height: 24px;
@@ -46,6 +45,6 @@ export default {
 }
 
 .SubLabel {
-	color: var(--color-sublabel);
+	opacity: var(--opacity-sublabel);
 }
 </style>

--- a/src/utils/InlineFormControlLayout/src/InlineFormControlLayout.vue
+++ b/src/utils/InlineFormControlLayout/src/InlineFormControlLayout.vue
@@ -27,7 +27,7 @@ export default {
 
 <style module="$s">
 .LayoutContainer {
-	--opacity-sublabel: 0.55
+	--opacity-sublabel: 0.55;
 
 	display: inline-flex;
 	color: inherit;


### PR DESCRIPTION
## Describe the problem this PR addresses
Same as #96 but rebased off of master.

Form controls (e.g. Radio, Checkbox) have a hardcoded `color` attribute (previously `rgba(0, 0, 0, 0.9)`), making labels and sublabels difficult to see on dark backgrounds.

## Describe the changes in this PR
Form controls now inherit the `color` attribute.

When placed in `<div style="background-color:black; color:white">`:
![Screen Shot 2021-07-15 at 2 22 25 PM](https://user-images.githubusercontent.com/20190589/125860706-f9c1d227-ef9d-4cd4-a80c-736de69ab357.png)
![Screen Shot 2021-07-15 at 2 23 12 PM](https://user-images.githubusercontent.com/20190589/125860718-20b992f7-7816-41fb-8b35-7d5e355f72b3.png)

