### PR TITLE
fix(stepper): inherit text color

### DIFF
--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -136,8 +136,6 @@ export default {
 
 <style module="$s">
 .Stepper {
-	--text-color: #4f2d52;
-
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -146,7 +144,7 @@ export default {
 
 .Quantity {
 	margin: 0 16px;
-	color: var(--text-color);
+	color: inherit;
 	font-weight: 500;
 	font-family: inherit;
 	font-feature-settings: "tnum";


### PR DESCRIPTION
## Describe the problem this PR addresses
The quantity inside the Stepper currently has a hardcoded text color. It is not very visible on darker backgrounds.
![Screen Shot 2021-07-20 at 1 41 54 PM](https://user-images.githubusercontent.com/20190589/126400722-08657512-d669-4d64-afca-d067e188e9f4.png)

## Describe the changes in this PR
The Stepper inherits the text color.
<img width="167" alt="Screen Shot 2021-07-20 at 2 58 47 PM" src="https://user-images.githubusercontent.com/20190589/126400864-9de79a19-4abf-4a53-9c2a-29f7e77ebc2a.png">

## Other information
Other similar changes may be needed on other Form controls when theming is introduced.
