### PR TITLE
fix(container): sub/requirement labels missing opacity

### DIFF
--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -98,6 +98,8 @@ export default {
 
 <style module="$s">
 .Container {
+	--opacity-sublabel: 0.55;
+
 	padding: 16px 24px;
 	color: var(--color, inherit);
 	font-family: inherit;
@@ -135,18 +137,18 @@ export default {
 }
 
 .Sublabel {
-	color: var(--color-black-55);
 	font-weight: 400;
 	font-size: 14px;
 	line-height: 24px;
 	letter-spacing: normal;
 	text-transform: none;
+	opacity: var(--opacity-sublabel);
 }
 
 .RequirementLabel {
-	color: var(--color-black-55);
 	font-size: 14px;
 	line-height: 24px;
+	opacity: var(--opacity-sublabel);
 }
 
 .Header {


### PR DESCRIPTION
## Describe the problem this PR addresses
The Container component's sublabel and requirement label styles were using `var(--color-black-55)` which would not match non-black text colors. Additionally, the var was not redefined when moving from the previous iteration, the Section component, so the text color was just black.

## Describe the changes in this PR
The sublabel and requirement label now match the Section's text color. They also work with passed-in text colors (not black).
