### PR TITLE
fix(controls): changed background color from low-opacity black

### DIFF
--- a/src/components/Input/src/InputControl.vue
+++ b/src/components/Input/src/InputControl.vue
@@ -121,7 +121,7 @@ export default {
 	until we get a Theme Context component
 */
 .variant_fill {
-	--color-background: rgba(0, 0, 0, 0.05);
+	--color-background: #f6f7f9;
 	--color-background-focus: rgb(255, 255, 255, 0.95);
 	--color-placeholder: rgba(0, 0, 0, 0.55);
 	--color-foreground: rgba(0, 0, 0, 0.9);

--- a/src/components/SegmentedControl/src/SegmentedControl.vue
+++ b/src/components/SegmentedControl/src/SegmentedControl.vue
@@ -71,7 +71,7 @@ export default {
 	padding: 4px;
 	font-size: 14px;
 	line-height: 24px;
-	background-color: rgba(0, 0, 0, 0.05);
+	background-color: #f6f7f9;
 	border-radius: 4px;
 }
 

--- a/src/components/Textarea/src/TextareaControl.vue
+++ b/src/components/Textarea/src/TextareaControl.vue
@@ -98,7 +98,7 @@ export default {
 	until we get a Theme Context component
 */
 .variant_fill {
-	--color-background: rgba(0, 0, 0, 0.05);
+	--color-background: #f6f7f9;
 	--color-background-focus: rgba(255, 255, 255, 0.95);
 	--color-foreground: rgba(0, 0, 0, 0.9);
 	--color-placeholder: rgba(0, 0, 0, 0.55);


### PR DESCRIPTION
## Describe the problem this PR addresses
The Input, SegementedControl, and Textarea components' fill variant all used a low-opacity black `rgba(0, 0, 0, 0.05)` as the fill color. This does not show up on black backgrounds.

## Describe the changes in this PR
Before
![Screen Shot 2021-07-23 at 2 46 13 PM](https://user-images.githubusercontent.com/20190589/126844844-af88ab03-4a02-4986-bb0c-fab5bcd29416.png)

After
![Screen Shot 2021-07-23 at 2 46 22 PM](https://user-images.githubusercontent.com/20190589/126844857-ead361f5-6f06-483a-b4bd-265f6da0c045.png)

## Other information
There are still a couple of instances of `rgba(0, 0, 0, 0.05)` used in maker, particularly for disabled variants. I didn't want to go ahead and change all of these, since I wanted design to weigh in on it first. However, I went ahead and changed default state colors since we made this change already for Select. #103 