### PR TITLE
refactor(lab): removed redundant nested root app

### DIFF
--- a/lab/App.vue
+++ b/lab/App.vue
@@ -1,7 +1,5 @@
 <template>
-	<div>
-		<router-view />
-	</div>
+	<router-view />
 </template>
 
 <script>

--- a/lab/create-router.js
+++ b/lab/create-router.js
@@ -2,7 +2,6 @@
 import Vue from 'vue';
 import Router from 'vue-router';
 import Meta from 'vue-meta';
-import App from './App.vue';
 
 Vue.use(Router);
 Vue.use(Meta);
@@ -13,13 +12,7 @@ const importExperiment = (experiment) => () => import(`./experiments/${experimen
 function createRouter() {
 	return new Router({
 		mode: isProduction ? 'hash' : 'history',
-		routes: [
-			{
-				path: '',
-				component: App,
-				children: LAB_EXPERIMENTS,
-			},
-		],
+		routes: LAB_EXPERIMENTS,
 	});
 }
 

--- a/lab/experiments/index.vue
+++ b/lab/experiments/index.vue
@@ -36,8 +36,7 @@ export default {
 
 	methods: {
 		getExperiments() {
-			const routerEntries = this.$router.options.routes[0].children;
-			const experiments = routerEntries
+			const experiments = this.$router.options.routes
 				.map((routerEntry) => {
 					const entry = (
 						routerEntry.name

--- a/lab/webpack-lab-config.js
+++ b/lab/webpack-lab-config.js
@@ -17,7 +17,7 @@ const branchName = branch.sync();
 
 const labDirectory = path.resolve('./lab/experiments/');
 
-function generateRoutes(directoryPath = './') {
+function generateRoutes(directoryPath = './', isNested) {
 	const fullDirectoryPath = path.join(labDirectory, directoryPath);
 	const files = fs.readdirSync(fullDirectoryPath).filter((file) => !file.startsWith('.'));
 	const routes = [];
@@ -41,17 +41,17 @@ function generateRoutes(directoryPath = './') {
 
 		const fullFilePath = path.join(fullDirectoryPath, file);
 		if (fs.statSync(fullFilePath).isDirectory()) {
-			const children = generateRoutes(filePath);
+			const children = generateRoutes(filePath, true);
 			const hasIndex = children.find((route) => !route.path);
 			Object.assign(routeEntry, {
-				path: file,
+				path: (isNested ? '' : '/') + file,
 				children,
 				name: hasIndex ? undefined : routeEntry.name,
 			});
 		} else {
 			const [fileName] = file.split('.');
 			Object.assign(routeEntry, {
-				path: fileName === 'index' ? '' : fileName,
+				path: (isNested ? '' : '/') + (fileName === 'index' ? '' : fileName),
 				component: `|importExperiment('${filePath}')|`,
 			});
 		}


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
The lab app root was being nested (eg, another app instance was being inserted into the root app). This isn't a big deal, just created an unnecessary double-`div`.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
- Removed App.vue nesting
- Made `router-view` a root component
- Made all routes root-routes (since it's no longer nested)


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
