### PR TITLE
fix(container): increase sub/requirement label opacity

### DIFF
--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -98,7 +98,7 @@ export default {
 
 <style module="$s">
 .Container {
-	--opacity-sublabel: 0.55;
+	--opacity-sublabel: 0.7;
 
 	padding: 16px 24px;
 	color: var(--color, inherit);


### PR DESCRIPTION
## Describe the problem this PR addresses
The requirement label was too light. See #112
Before:
![image](https://user-images.githubusercontent.com/20190589/129792350-41ffa935-200a-4d81-8c06-a070da0d425d.png)

## Describe the changes in this PR
After:
<img width="227" alt="Screen Shot 2021-08-17 at 12 54 54 PM" src="https://user-images.githubusercontent.com/20190589/129792491-4939cf92-a6ad-4660-bc15-cf37fdb1ef40.png">

bumped the opacity from 0.55 -> 0.7 as a temporary fix before theming is available.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
