### PR TITLE
fix(container): make requirement label no-wrap

### DIFF
--- a/src/components/Container/README.md
+++ b/src/components/Container/README.md
@@ -73,14 +73,13 @@ export default {
 
 Supports attributes from [`<section>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section).
 
-| Prop     | Type      | Default    | Possible values            | Description                           |
-| -------- | --------- | ---------- | -------------------------- | ------------------------------------- |
-| label    | `string`  | —          | —                          | Section label                         |
-| sublabel | `string`  | —          | —                          | Section sublabel                      |
-| size     | `string`  | `'medium'` | `small`, `medium`, `large` | Section size                          |
-| bg-color | `string`  | —          | —                          | Background color of section           |
-| color    | `string`  | —          | —                          | Text color of section                 |
-| no-wrap  | `boolean` | `false`    | —                          | Whether requirement label should wrap |
+| Prop     | Type     | Default    | Possible values            | Description                 |
+| -------- | -------- | ---------- | -------------------------- | --------------------------- |
+| label    | `string` | —          | —                          | Section label               |
+| sublabel | `string` | —          | —                          | Section sublabel            |
+| size     | `string` | `'medium'` | `small`, `medium`, `large` | Section size                |
+| bg-color | `string` | —          | —                          | Background color of section |
+| color    | `string` | —          | —                          | Text color of section       |
 
 
 ## Slots

--- a/src/components/Container/README.md
+++ b/src/components/Container/README.md
@@ -73,13 +73,14 @@ export default {
 
 Supports attributes from [`<section>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section).
 
-| Prop     | Type     | Default    | Possible values            | Description                 |
-| -------- | -------- | ---------- | -------------------------- | --------------------------- |
-| label    | `string` | —          | —                          | Section label               |
-| sublabel | `string` | —          | —                          | Section sublabel            |
-| size     | `string` | `'medium'` | `small`, `medium`, `large` | Section size                |
-| bg-color | `string` | —          | —                          | Background color of section |
-| color    | `string` | —          | —                          | Text color of section       |
+| Prop     | Type      | Default    | Possible values            | Description                           |
+| -------- | --------- | ---------- | -------------------------- | ------------------------------------- |
+| label    | `string`  | —          | —                          | Section label                         |
+| sublabel | `string`  | —          | —                          | Section sublabel                      |
+| size     | `string`  | `'medium'` | `small`, `medium`, `large` | Section size                          |
+| bg-color | `string`  | —          | —                          | Background color of section           |
+| color    | `string`  | —          | —                          | Text color of section                 |
+| no-wrap  | `boolean` | `false`    | —                          | Whether requirement label should wrap |
 
 
 ## Slots

--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -23,12 +23,7 @@
 				</div>
 			</div>
 
-			<div
-				:class="[
-					$s.RequirementLabel,
-					noWrap ? $s.noWrap : ''
-				]"
-			>
+			<div :class="$s.RequirementLabel">
 				<!-- @slot requirement label slot -->
 				<slot name="requirement-label" />
 			</div>
@@ -87,13 +82,6 @@ export default {
 			type: String,
 			default: undefined,
 			validator: (color) => chroma.valid(color),
-		},
-		/**
-		 * Whether requirement label should wrap
-		 */
-		noWrap: {
-			type: Boolean,
-			default: false,
 		},
 	},
 
@@ -161,11 +149,8 @@ export default {
 	padding-left: 8px;
 	font-size: 14px;
 	line-height: 24px;
-	opacity: var(--opacity-sublabel);
-}
-
-.RequirementLabel.noWrap {
 	white-space: nowrap;
+	opacity: var(--opacity-sublabel);
 }
 
 .Header {

--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -23,7 +23,12 @@
 				</div>
 			</div>
 
-			<div :class="$s.RequirementLabel">
+			<div
+				:class="[
+					$s.RequirementLabel,
+					noWrap ? 'no-wrap' : ''
+				]"
+			>
 				<!-- @slot requirement label slot -->
 				<slot name="requirement-label" />
 			</div>
@@ -82,6 +87,13 @@ export default {
 			type: String,
 			default: undefined,
 			validator: (color) => chroma.valid(color),
+		},
+		/**
+		 * Whether requirement label should wrap
+		 */
+		noWrap: {
+			type: Boolean,
+			default: false,
 		},
 	},
 
@@ -149,6 +161,10 @@ export default {
 	font-size: 14px;
 	line-height: 24px;
 	opacity: var(--opacity-sublabel);
+}
+
+.RequirementLabel .no-wrap {
+	white-space: nowrap;
 }
 
 .Header {

--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -158,6 +158,7 @@ export default {
 }
 
 .RequirementLabel {
+	padding-left: 8px;
 	font-size: 14px;
 	line-height: 24px;
 	opacity: var(--opacity-sublabel);

--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -26,7 +26,7 @@
 			<div
 				:class="[
 					$s.RequirementLabel,
-					noWrap ? 'no-wrap' : ''
+					noWrap ? $s.noWrap : ''
 				]"
 			>
 				<!-- @slot requirement label slot -->
@@ -163,7 +163,7 @@ export default {
 	opacity: var(--opacity-sublabel);
 }
 
-.RequirementLabel .no-wrap {
+.RequirementLabel.noWrap {
 	white-space: nowrap;
 }
 


### PR DESCRIPTION
## Describe the problem this PR addresses
On website, the `requirement label` was wrapping on overflow. However, it is typically pretty short, so we want it not to wrap, and to have the the `label` accommodate to that size instead.

![image-2021-08-18-13-38-20-317](https://user-images.githubusercontent.com/20190589/129965733-e045befc-1e30-4ee0-8548-759fea52bf90.png)

## Describe the changes in this PR

- ~~Added a `no-wrap` prop that would~~ make the `requirement label` not wrap ~~for its usage in website~~.
- Added `--space` between the `label` and `requirement-label` so that they are not touching

Before:
<img width="362" alt="Screen Shot 2021-08-18 at 1 08 56 PM" src="https://user-images.githubusercontent.com/20190589/129965942-84a67b0b-8e6c-4235-9a84-98e76223a811.png">

After:
<img width="348" alt="Screen Shot 2021-08-18 at 1 08 20 PM" src="https://user-images.githubusercontent.com/20190589/129965949-429d5168-ee89-4d7d-a42d-c19fbed93f4a.png">

## Other information

