### PR TITLE
feat(Button): `text` variant

### DIFF
--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -671,18 +671,18 @@ body {
 
 Supports attributes from [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button).
 
-| Prop       | Type      | Default     | Possible values                    | Description                           |
-| ---------- | --------- | ----------- | ---------------------------------- | ------------------------------------- |
-| type       | `string`  | `'button'`  | —                                  | Type of the button                    |
-| size       | `string`  | `'medium'`  | `small`, `medium`, `large`         | Size of the button                    |
-| full-width | `boolean` | `false`     | —                                  | Whether to make the button full-width |
-| color      | `string`  | `'#000'`    | —                                  | Background color of button            |
-| text-color | `string`  | —           | —                                  | Text color of button                  |
+| Prop       | Type      | Default     | Possible values                    		| Description                           |
+| ---------- | --------- | ----------- | ------------------------------------------ | ------------------------------------- |
+| type       | `string`  | `'button'`  | —                                  		| Type of the button                    |
+| size       | `string`  | `'medium'`  | `small`, `medium`, `large`         		| Size of the button                    |
+| full-width | `boolean` | `false`     | —                                  		| Whether to make the button full-width |
+| color      | `string`  | `'#000'`    | —                                  		| Background color of button            |
+| text-color | `string`  | —           | —                                  		| Text color of button                  |
 | variant    | `string`  | `'primary'` | `primary`, `secondary`, `tertiary`, `text` | Semantic variant                      |
-| shape      | `string`  | `'rounded'` | `squared`, `rounded`, `pill`       | Shape of button                       |
-| disabled   | `boolean` | `false`     | —                                  | Toggles button disabled state         |
-| align      | `string`  | `'center'`  | `center`, `stack`, `space-between` | How to align button's contents        |
-| loading    | `boolean` | `false`     | —                                  | Toggles button loading state          |
+| shape      | `string`  | `'rounded'` | `squared`, `rounded`, `pill`       		| Shape of button                       |
+| disabled   | `boolean` | `false`     | —                                  		| Toggles button disabled state         |
+| align      | `string`  | `'center'`  | `center`, `stack`, `space-between` 		| How to align button's contents        |
+| loading    | `boolean` | `false`     | —                                  		| Toggles button loading state          |
 
 
 ## Slots
@@ -696,6 +696,7 @@ Supports attributes from [`<button>`](https://developer.mozilla.org/en-US/docs/W
 ## Events
 
 Supports events from [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button).
+<!-- api-tables:end -->
 
 ## * Notes About `Text` Button Variant
 
@@ -703,4 +704,3 @@ This variant is made to be used inside of other wrapper components, such as the 
 - No padding; the text is the only clickable area
 - Not made to be used for Icon Buttons
 - Only difference between `size` is text size
-<!-- api-tables:end -->

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -671,18 +671,18 @@ body {
 
 Supports attributes from [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button).
 
-| Prop       | Type      | Default     | Possible values                    		| Description                           |
+| Prop       | Type      | Default     | Possible values                            | Description                           |
 | ---------- | --------- | ----------- | ------------------------------------------ | ------------------------------------- |
-| type       | `string`  | `'button'`  | —                                  		| Type of the button                    |
-| size       | `string`  | `'medium'`  | `small`, `medium`, `large`         		| Size of the button                    |
-| full-width | `boolean` | `false`     | —                                  		| Whether to make the button full-width |
-| color      | `string`  | `'#000'`    | —                                  		| Background color of button            |
-| text-color | `string`  | —           | —                                  		| Text color of button                  |
+| type       | `string`  | `'button'`  | —                                          | Type of the button                    |
+| size       | `string`  | `'medium'`  | `small`, `medium`, `large`                 | Size of the button                    |
+| full-width | `boolean` | `false`     | —                                          | Whether to make the button full-width |
+| color      | `string`  | `'#000'`    | —                                          | Background color of button            |
+| text-color | `string`  | —           | —                                          | Text color of button                  |
 | variant    | `string`  | `'primary'` | `primary`, `secondary`, `tertiary`, `text` | Semantic variant                      |
-| shape      | `string`  | `'rounded'` | `squared`, `rounded`, `pill`       		| Shape of button                       |
-| disabled   | `boolean` | `false`     | —                                  		| Toggles button disabled state         |
-| align      | `string`  | `'center'`  | `center`, `stack`, `space-between` 		| How to align button's contents        |
-| loading    | `boolean` | `false`     | —                                  		| Toggles button loading state          |
+| shape      | `string`  | `'rounded'` | `squared`, `rounded`, `pill`               | Shape of button                       |
+| disabled   | `boolean` | `false`     | —                                          | Toggles button disabled state         |
+| align      | `string`  | `'center'`  | `center`, `stack`, `space-between`         | How to align button's contents        |
+| loading    | `boolean` | `false`     | —                                          | Toggles button loading state          |
 
 
 ## Slots

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -376,6 +376,54 @@
 							Loading
 						</m-button>
 					</td>
+					<td>
+						<m-button
+							variant="text"
+							size="medium"
+							:color="color"
+						>
+							Button
+						</m-button>
+						<m-button
+							variant="text"
+							size="medium"
+							:color="color"
+						>
+							<plus class="icon" />
+							Button
+						</m-button>
+						<m-button
+							variant="text"
+							size="medium"
+							:color="color"
+						>
+							Button
+							<plus class="icon" />
+						</m-button>
+						<m-button
+							variant="text"
+							size="medium"
+							:color="color"
+						>
+							<x class="icon" />
+						</m-button>
+						<m-button
+							variant="text"
+							size="medium"
+							:color="color"
+							disabled
+						>
+							Disabled button
+						</m-button>
+						<m-button
+							variant="text"
+							size="medium"
+							:color="color"
+							loading
+						>
+							Loading
+						</m-button>
+					</td>
 				</tr>
 				<tr>
 					<th>
@@ -525,6 +573,54 @@
 							Loading
 						</m-button>
 					</td>
+					<td>
+						<m-button
+							variant="text"
+							size="small"
+							:color="color"
+						>
+							Button
+						</m-button>
+						<m-button
+							variant="text"
+							size="small"
+							:color="color"
+						>
+							<plus class="icon" />
+							Button
+						</m-button>
+						<m-button
+							variant="text"
+							size="small"
+							:color="color"
+						>
+							Button
+							<plus class="icon" />
+						</m-button>
+						<m-button
+							variant="text"
+							size="small"
+							:color="color"
+						>
+							<plus class="icon" />
+						</m-button>
+						<m-button
+							variant="text"
+							size="small"
+							:color="color"
+							disabled
+						>
+							Disabled button
+						</m-button>
+						<m-button
+							variant="text"
+							size="small"
+							:color="color"
+							loading
+						>
+							Loading
+						</m-button>
+					</td>
 				</tr>
 			</tbody>
 		</table>
@@ -582,7 +678,7 @@ Supports attributes from [`<button>`](https://developer.mozilla.org/en-US/docs/W
 | full-width | `boolean` | `false`     | —                                  | Whether to make the button full-width |
 | color      | `string`  | `'#000'`    | —                                  | Background color of button            |
 | text-color | `string`  | —           | —                                  | Text color of button                  |
-| variant    | `string`  | `'primary'` | `primary`, `secondary`, `tertiary` | Semantic variant                      |
+| variant    | `string`  | `'primary'` | `primary`, `secondary`, `tertiary`, `text` | Semantic variant                      |
 | shape      | `string`  | `'rounded'` | `squared`, `rounded`, `pill`       | Shape of button                       |
 | disabled   | `boolean` | `false`     | —                                  | Toggles button disabled state         |
 | align      | `string`  | `'center'`  | `center`, `stack`, `space-between` | How to align button's contents        |

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -26,7 +26,7 @@
 						Tertiary / Ghost
 					</th>
 					<th>
-						Text Only
+						Text / Transparent *
 					</th>
 				</tr>
 			</thead>
@@ -696,4 +696,11 @@ Supports attributes from [`<button>`](https://developer.mozilla.org/en-US/docs/W
 ## Events
 
 Supports events from [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button).
+
+## * Notes About `Text` Button Variant
+
+This variant is made to be used inside of other wrapper components, such as the Notice and Card.
+- No padding; the text is the only clickable area
+- Not made to be used for Icon Buttons
+- Only difference between `size` is text size
 <!-- api-tables:end -->

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -25,6 +25,9 @@
 					<th>
 						Tertiary / Ghost
 					</th>
+					<th>
+						Text Only
+					</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -169,6 +172,54 @@
 						</m-button>
 						<m-button
 							variant="tertiary"
+							size="large"
+							:color="color"
+							loading
+						>
+							Loading
+						</m-button>
+					</td>
+					<td>
+						<m-button
+							variant="text"
+							size="large"
+							:color="color"
+						>
+							Button
+						</m-button>
+						<m-button
+							variant="text"
+							size="large"
+							:color="color"
+						>
+							<plus class="icon" />
+							Button
+						</m-button>
+						<m-button
+							variant="text"
+							size="large"
+							:color="color"
+						>
+							Button
+							<plus class="icon" />
+						</m-button>
+						<m-button
+							variant="text"
+							size="large"
+							:color="color"
+						>
+							<x class="icon" />
+						</m-button>
+						<m-button
+							variant="text"
+							size="large"
+							:color="color"
+							disabled
+						>
+							Disabled button
+						</m-button>
+						<m-button
+							variant="text"
 							size="large"
 							:color="color"
 							loading

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -132,10 +132,27 @@ function ghost(tokens) {
 	};
 }
 
+function text() {
+	const color = 'rgba(0, 0, 0, 0)';
+	return {
+		'--small-padding': '8px',
+		'--medium-padding': '12px',
+		'--large-padding': '20px',
+		'--color-main': 'transparent',
+		'--color-main-hover': 'rgba(0, 0, 0, 0.05)',
+		'--color-main-active': 'rgba(0, 0, 0, 0.1)',
+		'--color-contrast': color.hex(),
+		'--color-contrast-hover': color.hex(),
+		'--color-contrast-active': color.hex(),
+		'--color-focus': color.hex(),
+	};
+}
+
 const VARIANTS = {
 	primary: fill,
 	secondary: outline,
 	tertiary: ghost,
+	text,
 };
 
 /**

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -133,14 +133,14 @@ function ghost(tokens) {
 }
 
 function text() {
-	const color = 'rgba(0, 0, 0, 0)';
+	const color = chroma('rgba(0, 0, 0, 0)');
 	return {
 		'--small-padding': '8px',
 		'--medium-padding': '12px',
 		'--large-padding': '20px',
 		'--color-main': 'transparent',
-		'--color-main-hover': 'rgba(0, 0, 0, 0.05)',
-		'--color-main-active': 'rgba(0, 0, 0, 0.1)',
+		'--color-main-hover': 'transparent',
+		'--color-main-active': 'transparent',
 		'--color-contrast': color.hex(),
 		'--color-contrast-hover': color.hex(),
 		'--color-contrast-active': color.hex(),
@@ -212,7 +212,7 @@ export default {
 		variant: {
 			type: String,
 			default: 'primary',
-			validator: (variant) => ['primary', 'secondary', 'tertiary'].includes(variant),
+			validator: (variant) => ['primary', 'secondary', 'tertiary', 'text'].includes(variant),
 		},
 		/**
 		 * Shape of button

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -9,7 +9,7 @@
 				[$s.fullWidth]: fullWidth,
 				[$s.iconButton]: isSingleChild(),
 				[$s.loading]: loading,
-				[$s.textButton] : variant === 'text',
+				[$s.textVariant] : variant === 'text',
 			}
 		]"
 		:type="type"
@@ -380,18 +380,18 @@ export default {
 		}
 	}
 
-	&:focus:not(.textButton) {
+	&:focus:not(.textVariant) {
 		--focus-border:
 			0 0 0 1px #fff,
 			0 0 0 3px var(--color-focus);
 	}
 
-	&:hover:not(:disabled):not(.textButton) {
+	&:hover:not(:disabled):not(.textVariant) {
 		color: var(--color-contrast-hover);
 		background-color: var(--color-main-hover);
 	}
 
-	&:active:not(:disabled):not(.textButton) {
+	&:active:not(:disabled):not(.textVariant) {
 		color: var(--color-contrast-active);
 		background-color: var(--color-main-active);
 	}

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -132,19 +132,20 @@ function ghost(tokens) {
 	};
 }
 
-function text() {
-	const color = chroma('rgba(0, 0, 0, 0)');
+function text(tokens) {
+	const color = chroma(tokens.color);
+	const transparentHex = chroma('rgba(0, 0, 0, 0)').hex();
 	return {
 		'--small-padding': '8px',
 		'--medium-padding': '12px',
 		'--large-padding': '20px',
-		'--color-main': 'transparent',
+		'--color-main': 'color',
 		'--color-main-hover': 'transparent',
 		'--color-main-active': 'transparent',
 		'--color-contrast': color.hex(),
-		'--color-contrast-hover': color.hex(),
-		'--color-contrast-active': color.hex(),
-		'--color-focus': color.hex(),
+		'--color-contrast-hover': transparentHex,
+		'--color-contrast-active': transparentHex,
+		'--color-focus': transparentHex,
 	};
 }
 

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -137,9 +137,9 @@ function transparent(tokens) {
 	const color = chroma(tokens.color);
 	const transparentHex = chroma('rgba(0, 0, 0, 0)').hex();
 	return {
-		'--small-padding': '8px',
-		'--medium-padding': '12px',
-		'--large-padding': '20px',
+		'--small-padding': '0px',
+		'--medium-padding': '0px',
+		'--large-padding': '0px',
 		'--color-main': 'color',
 		'--color-main-hover': 'transparent',
 		'--color-main-active': 'transparent',

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -9,6 +9,7 @@
 				[$s.fullWidth]: fullWidth,
 				[$s.iconButton]: isSingleChild(),
 				[$s.loading]: loading,
+				[$s.textButton] : variant === 'text',
 			}
 		]"
 		:type="type"
@@ -132,7 +133,7 @@ function ghost(tokens) {
 	};
 }
 
-function text(tokens) {
+function transparent(tokens) {
 	const color = chroma(tokens.color);
 	const transparentHex = chroma('rgba(0, 0, 0, 0)').hex();
 	return {
@@ -153,7 +154,7 @@ const VARIANTS = {
 	primary: fill,
 	secondary: outline,
 	tertiary: ghost,
-	text,
+	text: transparent,
 };
 
 /**
@@ -379,18 +380,18 @@ export default {
 		}
 	}
 
-	&:focus {
+	&:focus:not(.textButton) {
 		--focus-border:
 			0 0 0 1px #fff,
 			0 0 0 3px var(--color-focus);
 	}
 
-	&:hover:not(:disabled) {
+	&:hover:not(:disabled):not(.textButton) {
 		color: var(--color-contrast-hover);
 		background-color: var(--color-main-hover);
 	}
 
-	&:active:not(:disabled) {
+	&:active:not(:disabled):not(.textButton) {
 		color: var(--color-contrast-active);
 		background-color: var(--color-main-active);
 	}

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -41,6 +41,7 @@
 
 <script>
 import chroma from 'chroma-js';
+import assert from '@square/maker/utils/assert';
 import { MLoading } from '@square/maker/components/Loading';
 
 function getContrast(chromaBg, targetChromaFg) {
@@ -255,6 +256,10 @@ export default {
 				textColor: this.textColor,
 			});
 		},
+	},
+
+	created() {
+		assert.warn(!(this.variant === 'text' && this.isSingleChild()), 'the text Button variant should not be used for icon buttons');
 	},
 
 	methods: {


### PR DESCRIPTION
## Describe the problem this PR addresses
A sort of inline, no-padding button was needed for use in the Card #120 component. See [designs](https://www.figma.com/file/Fz10ZinFDOWgXlukmJjXKm/Maker-playground?node-id=3495%3A20160)

## Describe the changes in this PR
Created a new `text` Button variant that is to be used within wrapping components, such as Notice or Card.

It has **no**:
- fill or border
- padding
- hover, focus, active styles

![Screen Shot 2021-09-07 at 5 00 57 PM](https://user-images.githubusercontent.com/20190589/132424841-352f1079-e891-48f5-92fb-bf2ddb6d0671.png)

![Screen Shot 2021-09-07 at 4 57 33 PM](https://user-images.githubusercontent.com/20190589/132424784-4eaf5e58-5e58-4229-99b4-7bb10ea36ea3.png)

## Other information
- i would like to remove the NoticeButton in another PR (#122), but i will need to check what feature it was created for / if it's being used, as it could potentially be a breaking change.
