### PR TITLE
feat(Card): add Card slots

### DIFF
--- a/src/components/ItemCard/README.md
+++ b/src/components/ItemCard/README.md
@@ -1,4 +1,60 @@
+# ItemCard
 
+
+
+## Examples
+```vue
+<template>
+	<div class="spaceout">
+		<m-item-card
+			label="this is my card label"
+		>
+			here is my card content
+		</m-item-card>
+		<div class="container">
+			<m-item-card
+				label="this is my card inside of a 300px wide container"
+			>
+				here is my card content
+				<template #actions>
+					<m-notice-button>button</m-notice-button>
+				</template>
+			</m-item-card>
+		</div>
+		<div style="width:400px;">
+			<m-item-card
+				label="this is my truncated label inside of a card with fixed width"
+				truncate-label
+			>
+				here is my card content
+			</m-item-card>
+		</div>
+	</div>
+</template>
+
+<script>
+import { MItemCard } from '@square/maker/components/ItemCard';
+import { MNoticeButton } from '@square/maker/components/Notice';
+
+export default {
+	components: {
+		MItemCard,
+		MNoticeButton,
+	},
+};
+</script>
+<style scoped>
+.spaceout > * {
+	margin-bottom: 16px;
+}
+.spaceout > *:last-child {
+	margin-bottom: 0;
+}
+.container {
+	width: 300px;
+}
+</style>
+```
 
 <!-- api-tables:start -->
 ## Props

--- a/src/components/ItemCard/README.md
+++ b/src/components/ItemCard/README.md
@@ -16,17 +16,17 @@
 				label="this is my card inside of a 300px wide container"
 			>
 				here is my card content
-				<template #actions>
-					<m-notice-button>button</m-notice-button>
-				</template>
 			</m-item-card>
 		</div>
 		<div style="width:400px;">
 			<m-item-card
 				label="this is my truncated label inside of a card with fixed width"
-				truncate-label
+				price="$999.99"
 			>
 				here is my card content
+				<template #actions>
+					<m-notice-button>button</m-notice-button>
+				</template>
 			</m-item-card>
 		</div>
 	</div>
@@ -63,7 +63,8 @@ Supports attributes from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/
 
 | Prop    | Type     | Default     | Possible values | Description      |
 | ------- | -------- | ----------- | --------------- | ---------------- |
-| label   | `string` | `''`        | —               | Card label       |
+| label   | `string` | `''`        | —               | Item Card label  |
+| price   | `string` | `''`        | —               | Item price label |
 | variant | `string` | `'reorder'` | `reorder`       | Semantic variant |
 
 

--- a/src/components/ItemCard/README.md
+++ b/src/components/ItemCard/README.md
@@ -1,0 +1,25 @@
+
+
+<!-- api-tables:start -->
+## Props
+
+Supports attributes from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div).
+
+| Prop           | Type      | Default | Possible values | Description |
+| -------------- | --------- | ------- | --------------- | ----------- |
+| label          | `string`  | `''`    | —               | Card label  |
+| truncate-label | `boolean` | `false` | —               | —           |
+
+
+## Slots
+
+| Slot    | Description             |
+| ------- | ----------------------- |
+| default | card content            |
+| actions | put notice buttons here |
+
+
+## Events
+
+Supports events from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div).
+<!-- api-tables:end -->

--- a/src/components/ItemCard/README.md
+++ b/src/components/ItemCard/README.md
@@ -61,10 +61,10 @@ export default {
 
 Supports attributes from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div).
 
-| Prop           | Type      | Default | Possible values | Description |
-| -------------- | --------- | ------- | --------------- | ----------- |
-| label          | `string`  | `''`    | —               | Card label  |
-| truncate-label | `boolean` | `false` | —               | —           |
+| Prop    | Type     | Default     | Possible values | Description      |
+| ------- | -------- | ----------- | --------------- | ---------------- |
+| label   | `string` | `''`        | —               | Card label       |
+| variant | `string` | `'reorder'` | `reorder`       | Semantic variant |
 
 
 ## Slots

--- a/src/components/ItemCard/README.md
+++ b/src/components/ItemCard/README.md
@@ -1,31 +1,22 @@
 # ItemCard
-
+The ItemCard has more of a header / content / footer structure to be used for different Item displays.
 
 
 ## Examples
 ```vue
 <template>
 	<div class="spaceout">
-		<m-item-card
-			label="this is my card label"
-		>
-			here is my card content
-		</m-item-card>
-		<div class="container">
-			<m-item-card
-				label="this is my card inside of a 300px wide container"
-			>
-				here is my card content
-			</m-item-card>
-		</div>
 		<div style="width:400px;">
 			<m-item-card
-				label="this is my truncated label inside of a card with fixed width"
-				price="$999.99"
+				label="this is my card label. the text is truncated when wrapping"
 			>
 				here is my card content
+				<template #footer>
+					$999.99
+				</template>
 				<template #actions>
 					<m-notice-button>button</m-notice-button>
+					<m-notice-button>button2</m-notice-button>
 				</template>
 			</m-item-card>
 		</div>

--- a/src/components/ItemCard/index.js
+++ b/src/components/ItemCard/index.js
@@ -1,0 +1,1 @@
+export { default as MItemCard } from './src/ItemCard.vue';

--- a/src/components/ItemCard/src/ItemCard.vue
+++ b/src/components/ItemCard/src/ItemCard.vue
@@ -1,0 +1,89 @@
+<template>
+	<div
+		:class="[
+			$s.Card,
+		]"
+		v-bind="$attrs"
+		v-on="$listeners"
+	>
+		<header>
+			<div
+				v-if="label"
+				:class="[$s.Label, truncateLabel ? $s.TruncateLabel : '']"
+			>
+				{{ label }}
+			</div>
+		</header>
+
+		<div>
+			<!-- @slot card content -->
+			<slot />
+		</div>
+		<div
+			v-if="showActions"
+			:class="$s.ActionsWrapper"
+		>
+			<!-- @slot put notice buttons here -->
+			<slot name="actions" />
+		</div>
+	</div>
+</template>
+
+<script>
+
+/**
+ * @inheritAttrs div
+ * @inheritListeners div
+ */
+export default {
+	inheritAttrs: false,
+
+	props: {
+		/**
+		 * Card label
+		 */
+		label: {
+			type: String,
+			default: '',
+		},
+		truncateLabel: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	computed: {
+		showActions() {
+			return this.$slots.actions;
+		},
+	},
+};
+</script>
+
+<style module="$s">
+.Card {
+	padding: 16px 24px;
+	background-color: white;
+	border: 1px solid #eaeaea;
+	border-radius: 8px;
+}
+
+.Label {
+	margin-bottom: 16px;
+	font-weight: 500;
+	font-size: 14px;
+	line-height: 20px;
+}
+
+.TruncateLabel {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.ActionsWrapper {
+	display: flex;
+	justify-content: flex-end;
+	margin-top: 16px;
+}
+</style>

--- a/src/components/ItemCard/src/ItemCard.vue
+++ b/src/components/ItemCard/src/ItemCard.vue
@@ -70,14 +70,6 @@ export default {
 			type: String,
 			default: '',
 		},
-		/**
-		 * Semantic variant
-		 */
-		variant: {
-			type: String,
-			default: 'reorder',
-			validator: (variant) => ['reorder'].includes(variant),
-		},
 	},
 
 	computed: {

--- a/src/components/ItemCard/src/ItemCard.vue
+++ b/src/components/ItemCard/src/ItemCard.vue
@@ -9,7 +9,7 @@
 					v-if="label"
 					:class="[
 						$s.Label,
-						variant === 'reorder' ? $s.TruncateLabel : ''
+						$s.TruncateLabel,
 					]"
 				>
 					{{ label }}
@@ -106,5 +106,13 @@ export default {
 	display: flex;
 	justify-content: space-between;
 	margin-top: 16px;
+}
+
+.ActionsWrapper > * {
+	margin-right: 24px;
+}
+
+.ActionsWrapper > *:last-child {
+	margin-right: 0;
 }
 </style>

--- a/src/components/ItemCard/src/ItemCard.vue
+++ b/src/components/ItemCard/src/ItemCard.vue
@@ -17,17 +17,16 @@
 			</header>
 
 			<div>
-				<!-- @slot card content -->
+				<!-- @slot itemcard content -->
 				<slot />
 			</div>
 
 			<footer
 				:class="$s.Footer"
 			>
-				<div
-					:class="$s.Price"
-				>
-					{{ price }}
+				<div>
+					<!-- @slot footer content -->
+					<slot name="footer" />
 				</div>
 				<div
 					v-if="showActions"
@@ -60,13 +59,6 @@ export default {
 		 * Item Card label
 		 */
 		label: {
-			type: String,
-			default: '',
-		},
-		/**
-		 * Item price label
-		 */
-		price: {
 			type: String,
 			default: '',
 		},

--- a/src/components/ItemCard/src/ItemCard.vue
+++ b/src/components/ItemCard/src/ItemCard.vue
@@ -1,41 +1,47 @@
 <template>
-	<div
-		:class="[
-			$s.Card,
-		]"
-		v-bind="$attrs"
-		v-on="$listeners"
-	>
-		<header>
-			<div
-				v-if="label"
-				:class="[$s.Label, truncateLabel ? $s.TruncateLabel : '']"
-			>
-				{{ label }}
-			</div>
-		</header>
-
-		<div>
-			<!-- @slot card content -->
-			<slot />
-		</div>
+	<m-card>
 		<div
-			v-if="showActions"
-			:class="$s.ActionsWrapper"
+			v-bind="$attrs"
+			v-on="$listeners"
 		>
-			<!-- @slot put notice buttons here -->
-			<slot name="actions" />
+			<header>
+				<div
+					v-if="label"
+					:class="[$s.Label, truncateLabel ? $s.TruncateLabel : '']"
+				>
+					{{ label }}
+				</div>
+			</header>
+
+			<div>
+				<!-- @slot card content -->
+				<slot />
+			</div>
+			<footer>
+				<div
+					v-if="showActions"
+					:class="$s.ActionsWrapper"
+				>
+					<!-- @slot put notice buttons here -->
+					<slot name="actions" />
+				</div>
+			</footer>
 		</div>
-	</div>
+	</m-card>
 </template>
 
 <script>
+import { MCard } from '@square/maker/components/Card';
 
 /**
  * @inheritAttrs div
  * @inheritListeners div
  */
 export default {
+	components: {
+		MCard,
+	},
+
 	inheritAttrs: false,
 
 	props: {
@@ -61,13 +67,6 @@ export default {
 </script>
 
 <style module="$s">
-.Card {
-	padding: 16px 24px;
-	background-color: white;
-	border: 1px solid #eaeaea;
-	border-radius: 8px;
-}
-
 .Label {
 	margin-bottom: 16px;
 	font-weight: 500;

--- a/src/components/ItemCard/src/ItemCard.vue
+++ b/src/components/ItemCard/src/ItemCard.vue
@@ -20,7 +20,15 @@
 				<!-- @slot card content -->
 				<slot />
 			</div>
-			<footer>
+
+			<footer
+				:class="$s.Footer"
+			>
+				<div
+					:class="$s.Price"
+				>
+					{{ price }}
+				</div>
 				<div
 					v-if="showActions"
 					:class="$s.ActionsWrapper"
@@ -49,9 +57,16 @@ export default {
 
 	props: {
 		/**
-		 * Card label
+		 * Item Card label
 		 */
 		label: {
+			type: String,
+			default: '',
+		},
+		/**
+		 * Item price label
+		 */
+		price: {
 			type: String,
 			default: '',
 		},
@@ -87,12 +102,9 @@ export default {
 	text-overflow: ellipsis;
 }
 
-.footer {
+.Footer {
 	display: flex;
+	justify-content: space-between;
 	margin-top: 16px;
-}
-
-.ActionsWrapper {
-	justify-content: flex-end;
 }
 </style>

--- a/src/components/ItemCard/src/ItemCard.vue
+++ b/src/components/ItemCard/src/ItemCard.vue
@@ -7,7 +7,10 @@
 			<header>
 				<div
 					v-if="label"
-					:class="[$s.Label, truncateLabel ? $s.TruncateLabel : '']"
+					:class="[
+						$s.Label,
+						variant === 'reorder' ? $s.TruncateLabel : ''
+					]"
 				>
 					{{ label }}
 				</div>
@@ -52,9 +55,13 @@ export default {
 			type: String,
 			default: '',
 		},
-		truncateLabel: {
-			type: Boolean,
-			default: false,
+		/**
+		 * Semantic variant
+		 */
+		variant: {
+			type: String,
+			default: 'reorder',
+			validator: (variant) => ['reorder'].includes(variant),
 		},
 	},
 
@@ -80,9 +87,12 @@ export default {
 	text-overflow: ellipsis;
 }
 
-.ActionsWrapper {
+.footer {
 	display: flex;
-	justify-content: flex-end;
 	margin-top: 16px;
+}
+
+.ActionsWrapper {
+	justify-content: flex-end;
 }
 </style>


### PR DESCRIPTION
Creating a draft of potential future slot additions for the Card. 

## Describe the problem this PR addresses

## Describe the changes in this PR
Added `footer` and `action` slots. 

<img width="419" alt="Screen Shot 2021-09-08 at 3 11 55 PM" src="https://user-images.githubusercontent.com/20190589/132756612-71d2aecb-61eb-49e5-a066-0e5552bb7f0e.png">


## Other information
If this were implemented, the label would probably be replaced with a generic `header` slot as well.
Right now this is in a separate ItemCard component, but this work would actually just update the Card component (ItemCard will not exist).