### PR TITLE
build(dev): only lint new files and dont fail on error

### DIFF
--- a/build/webpack-development-config.js
+++ b/build/webpack-development-config.js
@@ -79,11 +79,13 @@ const config = merge({}, webpackBaseConfig, {
 		}),
 		clientOnly(new ESLintPlugin({
 			files: '**/*.{vue,js,md}',
-			emitWarning: true,
+			failOnError: false,
+			lintDirtyModulesOnly: true,
 		})),
 		clientOnly(new StylelintPlugin({
 			files: '**/*.{vue,css}',
-			emitWarning: true,
+			failOnError: false,
+			lintDirtyModulesOnly: true,
 		})),
 	],
 });


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
- Linting errors were failing and blocking Webpack development build iterations
- Every time dev build is initialized, it would lint all files and be slow

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
- Prevent linting errors from blocking builds. It will still error but not block build iterations.
- Only lint new files. This means it won't lint on startup.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
