### PR TITLE
build: sort deploy versions using semver sort

### DIFF
--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -3,7 +3,6 @@
 const path = require('path');
 const fs = require('fs');
 const semverSort = require('semver/functions/sort');
-const semverCompare = require('semver/functions/compare');
 const semverValid = require('semver/functions/valid');
 
 const DIST = path.resolve(process.cwd(), '.dist');
@@ -39,7 +38,7 @@ function isntVersion(deployName) {
 function sort(items, isNumeric) {
 	if (isNumeric) {
 		items = items.filter((item) => semverValid(item));
-		items.sort(semverCompare);
+		semverSort(items);
 		items.push(additionalVersions);
 		return items;
 	}

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -38,12 +38,14 @@ function isVersion(deployName) {
 function isntVersion(deployName) {
 	return !isVersion(deployName);
 }
-
 function sortVersions(items, isNumeric) {
+	let versions;
+
 	if (isNumeric) {
-		items = items.filter((item) => isNumericVersion(item));
-		rsort(items);
-		items.push('latest', 'latest-preview');
+		versions = items.filter((item) => isNumericVersion(item));
+		rsort(versions);
+		versions.push('latest', 'latest-preview');
+		items = versions;
 		return;
 	}
 

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const fs = require('fs');
 const rsort = require('semver/functions/rsort');
+const { sort } = require('semver');
 
 const DIST = path.resolve(process.cwd(), '.dist');
 const DIST_INDEX = path.resolve(DIST, 'index.html');
@@ -28,15 +29,29 @@ const STYLEGUIDE_DEPLOYS = getDirectories(STYLEGUIDE_DIST).filter((d) => d !== '
 const LAB_DEPLOYS = getDirectories(LAB_DIST);
 
 const VERSION_REGEX = /^\d+\.\d+\.\d+/;
+function isNumericVersion(deployName) {
+	return VERSION_REGEX.test(deployName);
+}
 function isVersion(deployName) {
-	return ['latest', 'latest-preview'].includes(deployName) || VERSION_REGEX.test(deployName);
+	return ['latest', 'latest-preview'].includes(deployName) || isNumericVersion(deployName);
 }
 function isntVersion(deployName) {
 	return !isVersion(deployName);
 }
 
-function toDeployLinks(prefix, suffix, items) {
-	rsort(items);
+function sortVersions(items, isNumeric) {
+	if (isNumeric) {
+		items = items.filter((item) => isNumericVersion(item));
+		rsort(items);
+		items.push('latest', 'latest-preview');
+		return;
+	}
+
+	sort(items);
+}
+
+function toDeployLinks(prefix, suffix, items, isNumeric) {
+	sortVersions(items, isNumeric);
 	return items.map((item) => `<li><a href="${prefix}${item}${suffix}">${item}</a></li>`).join('\n');
 }
 
@@ -54,11 +69,11 @@ const BUILT_INDEX = `
 	<h2>Styleguide Deploys</h2>
 	<h3>Versioned Releases</h3>
 	<ul>
-		${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isVersion))}
+		${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isVersion), true)}
 	</ul>
 	<h3>WIP Branches</h3>
 	<ul>
-		${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isntVersion))}
+		${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isntVersion), false)}
 	</ul>
 	<h2>Lab Deploys</h2>
 	<ul>

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const fs = require('fs');
-const semverSort = require('semver/functions/sort');
+const semverSort = require('semver/functions/rsort');
 const semverValid = require('semver/functions/valid');
 
 const DIST = path.resolve(process.cwd(), '.dist');
@@ -27,7 +27,7 @@ ensureDirectory(STYLEGUIDE_DIST);
 
 const STYLEGUIDE_DEPLOYS = getDirectories(STYLEGUIDE_DIST).filter((d) => d !== '0.0.0-semantic-release');
 const LAB_DEPLOYS = getDirectories(LAB_DIST);
-const additionalVersions = ['latest', 'latest-preview'];
+const additionalVersions = ['latest-preview', 'latest'];
 
 function isVersion(deployName) {
 	return additionalVersions.includes(deployName) || semverValid(deployName);
@@ -41,7 +41,7 @@ function sort(items, isNumericVersions) {
 		semverSort(items);
 
 		additionalVersions.forEach((version) => {
-			items.push(version);
+			items.unshift(version);
 		});
 
 		return items;

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -38,7 +38,7 @@ function isVersion(deployName) {
 function isntVersion(deployName) {
 	return !isVersion(deployName);
 }
-function sortVersions(items, isNumeric) {
+function sort(items, isNumeric) {
 	if (isNumeric) {
 		items = items.filter((item) => isNumericVersion(item));
 		vSort(items);
@@ -50,7 +50,7 @@ function sortVersions(items, isNumeric) {
 }
 
 function toDeployLinks(prefix, suffix, items, isNumeric) {
-	sortVersions(items, isNumeric);
+	sort(items, isNumeric);
 	return items.map((item) => `<li><a href="${prefix}${item}${suffix}">${item}</a></li>`).join('\n');
 }
 

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -3,7 +3,6 @@
 const path = require('path');
 const fs = require('fs');
 const rsort = require('semver/functions/rsort');
-const { sort } = require('semver');
 
 const DIST = path.resolve(process.cwd(), '.dist');
 const DIST_INDEX = path.resolve(DIST, 'index.html');
@@ -49,7 +48,7 @@ function sortVersions(items, isNumeric) {
 		return;
 	}
 
-	sort(items);
+	items.sort();
 }
 
 function toDeployLinks(prefix, suffix, items, isNumeric) {

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -72,7 +72,7 @@ const BUILT_INDEX = `
 	</ul>
 	<h3>WIP Branches</h3>
 	<ul>
-		${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isntVersion), false)}
+		${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isntVersion))}
 	</ul>
 	<h2>Lab Deploys</h2>
 	<ul>

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -26,13 +26,14 @@ ensureDirectory(STYLEGUIDE_DIST);
 
 const STYLEGUIDE_DEPLOYS = getDirectories(STYLEGUIDE_DIST).filter((d) => d !== '0.0.0-semantic-release');
 const LAB_DEPLOYS = getDirectories(LAB_DIST);
+const additionalVersions = ['latest', 'latest-preview'];
 
 const VERSION_REGEX = /^\d+\.\d+\.\d+/;
 function isNumericVersion(deployName) {
 	return VERSION_REGEX.test(deployName);
 }
 function isVersion(deployName) {
-	return ['latest', 'latest-preview'].includes(deployName) || isNumericVersion(deployName);
+	return additionalVersions.includes(deployName) || isNumericVersion(deployName);
 }
 function isntVersion(deployName) {
 	return !isVersion(deployName);
@@ -41,7 +42,7 @@ function sortVersions(items, isNumeric) {
 	if (isNumeric) {
 		items = items.filter((item) => isNumericVersion(item));
 		vSort(items);
-		items.push('latest', 'latest-preview');
+		items.push(additionalVersions);
 		return;
 	}
 

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -38,13 +38,10 @@ function isntVersion(deployName) {
 	return !isVersion(deployName);
 }
 function sortVersions(items, isNumeric) {
-	let versions;
-
 	if (isNumeric) {
-		versions = items.filter((item) => isNumericVersion(item));
-		rsort(versions);
-		versions.push('latest', 'latest-preview');
-		items = versions;
+		items = items.filter((item) => isNumericVersion(item));
+		rsort(items);
+		items.push('latest', 'latest-preview');
 		return;
 	}
 

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const fs = require('fs');
+const rsort = require('semver/functions/rsort');
 
 const DIST = path.resolve(process.cwd(), '.dist');
 const DIST_INDEX = path.resolve(DIST, 'index.html');
@@ -35,7 +36,7 @@ function isntVersion(deployName) {
 }
 
 function toDeployLinks(prefix, suffix, items) {
-	items.sort();
+	rsort(items);
 	return items.map((item) => `<li><a href="${prefix}${item}${suffix}">${item}</a></li>`).join('\n');
 }
 

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -39,7 +39,11 @@ function sort(items, isNumeric) {
 	if (isNumeric) {
 		items = items.filter((item) => semverValid(item));
 		semverSort(items);
-		items.push(additionalVersions);
+
+		additionalVersions.forEach((version) => {
+			items.push(version);
+		});
+
 		return items;
 	}
 

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -35,8 +35,8 @@ function isVersion(deployName) {
 function isntVersion(deployName) {
 	return !isVersion(deployName);
 }
-function sort(items, isNumeric) {
-	if (isNumeric) {
+function sort(items, isNumericVersions) {
+	if (isNumericVersions) {
 		items = items.filter((item) => semverValid(item));
 		semverSort(items);
 
@@ -50,8 +50,8 @@ function sort(items, isNumeric) {
 	return items.sort();
 }
 
-function toDeployLinks(prefix, suffix, items, isNumeric) {
-	items = sort(items, isNumeric);
+function toDeployLinks(prefix, suffix, items, isNumericVersions) {
+	items = sort(items, isNumericVersions);
 	return items.map((item) => `<li><a href="${prefix}${item}${suffix}">${item}</a></li>`).join('\n');
 }
 

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const fs = require('fs');
 const semverSort = require('semver/functions/sort');
+const semverCompare = require('semver/functions/compare');
 const semverValid = require('semver/functions/valid');
 
 const DIST = path.resolve(process.cwd(), '.dist');
@@ -38,16 +39,16 @@ function isntVersion(deployName) {
 function sort(items, isNumeric) {
 	if (isNumeric) {
 		items = items.filter((item) => semverValid(item));
-		semverSort(items);
+		items.sort(semverCompare);
 		items.push(additionalVersions);
-		return;
+		return items;
 	}
 
-	items.sort();
+	return items.sort();
 }
 
 function toDeployLinks(prefix, suffix, items, isNumeric) {
-	sort(items, isNumeric);
+	items = sort(items, isNumeric);
 	return items.map((item) => `<li><a href="${prefix}${item}${suffix}">${item}</a></li>`).join('\n');
 }
 

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -2,7 +2,8 @@
 
 const path = require('path');
 const fs = require('fs');
-const vSort = require('semver/functions/sort');
+const semverSort = require('semver/functions/sort');
+const semverValid = require('semver/functions/valid');
 
 const DIST = path.resolve(process.cwd(), '.dist');
 const DIST_INDEX = path.resolve(DIST, 'index.html');
@@ -28,20 +29,16 @@ const STYLEGUIDE_DEPLOYS = getDirectories(STYLEGUIDE_DIST).filter((d) => d !== '
 const LAB_DEPLOYS = getDirectories(LAB_DIST);
 const additionalVersions = ['latest', 'latest-preview'];
 
-const VERSION_REGEX = /^\d+\.\d+\.\d+/;
-function isNumericVersion(deployName) {
-	return VERSION_REGEX.test(deployName);
-}
 function isVersion(deployName) {
-	return additionalVersions.includes(deployName) || isNumericVersion(deployName);
+	return additionalVersions.includes(deployName) || semverValid(deployName);
 }
 function isntVersion(deployName) {
 	return !isVersion(deployName);
 }
 function sort(items, isNumeric) {
 	if (isNumeric) {
-		items = items.filter((item) => isNumericVersion(item));
-		vSort(items);
+		items = items.filter((item) => semverValid(item));
+		semverSort(items);
 		items.push(additionalVersions);
 		return;
 	}

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const fs = require('fs');
-const rsort = require('semver/functions/rsort');
+const vSort = require('semver/functions/sort');
 
 const DIST = path.resolve(process.cwd(), '.dist');
 const DIST_INDEX = path.resolve(DIST, 'index.html');
@@ -40,7 +40,7 @@ function isntVersion(deployName) {
 function sortVersions(items, isNumeric) {
 	if (isNumeric) {
 		items = items.filter((item) => isNumericVersion(item));
-		rsort(items);
+		vSort(items);
 		items.push('latest', 'latest-preview');
 		return;
 	}


### PR DESCRIPTION
## Describe the problem this PR addresses
See #124

## Describe the changes in this PR
- use [semver `sort`](https://github.com/npm/node-semver/blob/master/functions/sort.js) to sort version numbers
- replace regex check with semver `valid` to check version numbers

## Other information
