### PR TITLE
Image Selector/Uploader

### DIFF
--- a/src/components/ImageSelector/README.md
+++ b/src/components/ImageSelector/README.md
@@ -39,6 +39,7 @@
 </template>
 
 <script>
+/* eslint-disable no-magic-numbers */
 import { MHeading } from '@square/maker/components/Heading';
 import { MImageSelector, IMAGE_SELECTOR_STATUSES } from '@square/maker/components/ImageSelector';
 
@@ -144,16 +145,16 @@ export default {
 <!-- api-tables:start -->
 ## Props
 
-| Prop          | Type            | Default     | Possible values | Description                                      |
-| ----------    | --------------- | ----------- | --------------- | ------------------------------------------------ |
-| v-model*      | `array`         | []          | —               | selector's current value                         |
-| uploadHandler | `Function`      | —           | —               | opt. callback function to upload selected images |
-| maxImages     | `number`        | —           | —               | maximum number of images selectable              |
+| Prop           | Type     | Default           | Possible values | Description |
+| -------------- | -------- | ----------------- | --------------- | ----------- |
+| model          | `array`  | `[]`              | —               | —           |
+| upload-handler | `func`   | `() => undefined` | —               | —           |
+| max-images     | `number` | `() => undefined` | —               | —           |
 
 
 ## Events
 
-| Event  | Type     | Description             |
-| ------ | -------- | ----------------------- |
-| input  | `Array`  | updated model of images |
+| Event | Type | Description |
+| ----- | ---- | ----------- |
+| input | -    | —           |
 <!-- api-tables:end -->

--- a/src/components/ImageSelector/README.md
+++ b/src/components/ImageSelector/README.md
@@ -1,5 +1,9 @@
 # ImageSelector
 
+Use ImageSelector to provide a visual wrapper for a file input. Use with an upload handler to track upload progress and trigger uploads on file selection.
+
+Allows JPEG, PNG, and GIF file formats. HEIC is converted to JPEG by iOS with this configuration.
+
 ```vue
 <template>
 	<div>
@@ -17,8 +21,6 @@
 					@input="setUploadedImages"
 				/>
 			</div>
-
-			<pre>{{ lowOverheadImages.uploaded }}</pre>
 		</div>
 
 		<div :class="$s.SelectorContainer">
@@ -32,8 +34,6 @@
 				:model="normalImages"
 				@input="setNormalImages"
 			/>
-
-			<pre>{{ lowOverheadImages.normal }}</pre>
 		</div>
 	</div>
 </template>
@@ -125,18 +125,12 @@ export default {
 </script>
 
 <style module="$s">
-.SelectorContainer {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	gap: 16px;
-}
-
 .SelectorContainer + .SelectorContainer {
 	margin-top: 32px;
 }
 
 .SelectorHeader {
-	grid-column: 1 / 3;
+	margin-bottom: 16px;
 }
 </style>
 
@@ -145,16 +139,37 @@ export default {
 <!-- api-tables:start -->
 ## Props
 
-| Prop           | Type     | Default           | Possible values | Description |
-| -------------- | -------- | ----------------- | --------------- | ----------- |
-| model          | `array`  | `[]`              | —               | —           |
-| upload-handler | `func`   | `() => undefined` | —               | —           |
-| max-images     | `number` | `() => undefined` | —               | —           |
+| Prop           | Type     | Default                                                                    | Possible values        | Description                                                                                                   |
+| -------------- | -------- | -------------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------- |
+| model          | `array`  | `[]`                                                                       | `[]`                   | An array of selected images. See below for interface details                                                  |
+| upload-handler | `func`   | `({ image, uploadProgressHandler }) => undefined` | `Function | undefined` | Function to trigger an upload on file selection, should be async. Argument is object with image file and a function to update progress |
+| max-images     | `number` | `undefined`                                                                | -                      | Maximum number of images allowed to be selected                                                               |
 
 
 ## Events
 
-| Event | Type | Description |
-| ----- | ---- | ----------- |
-| input | -    | —           |
+| Event | Type | Description                             |
+| ----- | ---- | --------------------------------------- |
+| input | `[]` | Array of images when a file is selected |
+
+## Image Selection Interface
+```typescript
+interface ImageSelectionWithUpload {
+	id: number;
+	file: File | Blob;
+	url: string; // base64 representation of image to display on UI
+	status: 'pending' | 'complete' | 'error';
+	progress: number; // progress of upload, should be value from 0-100
+	apiResponse?: any; // return value from upload handler, only present when status is 'complete'
+	apiError?: any; // error from upload handler if an error is thrown, only present when status is 'error'
+}
+
+interface ImageSelectionWithoutUpload {
+	id: number;
+	file: File | Blob;
+	url: string; // base64 representation of image to display on UI
+	status: 'complete';
+	progress: 100;
+}
+```
 <!-- api-tables:end -->

--- a/src/components/ImageSelector/README.md
+++ b/src/components/ImageSelector/README.md
@@ -1,0 +1,159 @@
+# ImageSelector
+
+```vue
+<template>
+	<div>
+		<div :class="$s.SelectorContainer">
+			<m-heading
+				:size="2"
+				:class="$s.SelectorHeader"
+			>
+				With Upload Handler
+			</m-heading>
+			<div>
+				<m-image-selector
+					:model="uploadedImages"
+					:upload-handler="selectImage"
+					@input="setUploadedImages"
+				/>
+			</div>
+
+			<pre>{{ lowOverheadImages.uploaded }}</pre>
+		</div>
+
+		<div :class="$s.SelectorContainer">
+			<m-heading
+				:size="2"
+				:class="$s.SelectorHeader"
+			>
+				Without Upload Handler
+			</m-heading>
+			<m-image-selector
+				:model="normalImages"
+				@input="setNormalImages"
+			/>
+
+			<pre>{{ lowOverheadImages.normal }}</pre>
+		</div>
+	</div>
+</template>
+
+<script>
+import { MHeading } from '@square/maker/components/Heading';
+import { MImageSelector, IMAGE_SELECTOR_STATUSES } from '@square/maker/components/ImageSelector';
+
+const nextStatuses = [
+	IMAGE_SELECTOR_STATUSES.PENDING,
+	IMAGE_SELECTOR_STATUSES.ERROR,
+	IMAGE_SELECTOR_STATUSES.COMPLETE,
+];
+
+export default {
+	components: {
+		MImageSelector,
+		MHeading,
+	},
+
+	data() {
+		return {
+			uploadedImages: [],
+			normalImages: [],
+		};
+	},
+
+	computed: {
+		lowOverheadImages() {
+			return {
+				uploaded: this.uploadedImages.map((image) => ({ ...image, url: 'hidden for performance' })),
+				normal: this.normalImages.map((image) => ({ ...image, url: 'hidden for performance' })),
+			};
+		},
+	},
+
+	methods: {
+		setUploadedImages(images) {
+			this.uploadedImages = images;
+		},
+
+		setNormalImages(images) {
+			this.normalImages = images;
+		},
+
+		async selectImage({ image, uploadProgressHandler }) {
+			return new Promise((resolve, reject) => {
+				this.uploadImage({
+					resolve,
+					reject,
+					uploadProgressHandler,
+					image,
+				});
+			});
+		},
+
+		uploadImage({
+			progress = 0,
+			resolve,
+			reject,
+			uploadProgressHandler,
+			image,
+		}) {
+			let newProgress;
+			const nextStatus = nextStatuses[Math.floor(Math.random() * 3)];
+			setTimeout(() => {
+				if (nextStatus === IMAGE_SELECTOR_STATUSES.PENDING || progress < 75) {
+					const remainingProgress = 100 - progress;
+					newProgress = progress + Math.min(10, Math.random() * remainingProgress);
+					uploadProgressHandler(newProgress);
+					this.uploadImage({
+						resolve,
+						reject,
+						uploadProgressHandler,
+						progress: newProgress,
+					});
+				} else if (nextStatus === IMAGE_SELECTOR_STATUSES.COMPLETE) {
+					uploadProgressHandler(100);
+					resolve({ data: { hello: 'world!', image } });
+				} else {
+					uploadProgressHandler(100);
+					reject(new Error('Some error'));
+				}
+			}, Math.random() * 500);
+		},
+	},
+};
+</script>
+
+<style module="$s">
+.SelectorContainer {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 16px;
+}
+
+.SelectorContainer + .SelectorContainer {
+	margin-top: 32px;
+}
+
+.SelectorHeader {
+	grid-column: 1 / 3;
+}
+</style>
+
+```
+
+<!-- api-tables:start -->
+## Props
+
+| Prop          | Type            | Default     | Possible values | Description                                      |
+| ----------    | --------------- | ----------- | --------------- | ------------------------------------------------ |
+| v-model*      | `array`         | []          | —               | selector's current value                         |
+| uploadHandler | `Function`      | —           | —               | opt. callback function to upload selected images |
+| maxImages     | `number`        | —           | —               | maximum number of images selectable              |
+
+
+## Events
+
+| Event  | Type     | Description             |
+| ------ | -------- | ----------------------- |
+| input  | `Array`  | updated model of images |
+<!-- api-tables:end -->

--- a/src/components/ImageSelector/README.md
+++ b/src/components/ImageSelector/README.md
@@ -18,6 +18,7 @@ Allows JPEG, PNG, and GIF file formats. HEIC is converted to JPEG by iOS with th
 				<m-image-selector
 					:model="uploadedImages"
 					:upload-handler="selectImage"
+					:max-size="2000000"
 					@input="setUploadedImages"
 				/>
 			</div>
@@ -144,6 +145,7 @@ export default {
 | model          | `array`  | `[]`                                                                       | `[]`                   | An array of selected images. See below for interface details                                                  |
 | upload-handler | `func`   | `({ image, uploadProgressHandler }) => undefined` | `Function | undefined` | Function to trigger an upload on file selection, should be async. Argument is object with image file and a function to update progress |
 | max-images     | `number` | `undefined`                                                                | -                      | Maximum number of images allowed to be selected                                                               |
+| max-size       | `number` | `undefined`                                                                | -                      | Maximum size of images allowed to be selected (in bytes)                                                      |
 
 
 ## Events

--- a/src/components/ImageSelector/index.js
+++ b/src/components/ImageSelector/index.js
@@ -1,0 +1,2 @@
+export { default as MImageSelector } from './src/ImageSelector.vue';
+export { IMAGE_SELECTOR_STATUSES } from './src/constants';

--- a/src/components/ImageSelector/src/ImagePicker.vue
+++ b/src/components/ImageSelector/src/ImagePicker.vue
@@ -1,0 +1,60 @@
+<template>
+	<div
+		:class="$s.ImagePickerInputContainer"
+		@click="$refs.input.click()"
+	>
+		<input
+			ref="input"
+			:class="$s.ImagePickerInput"
+			type="file"
+			multiple="true"
+			accept="image/jpeg, image/png"
+			@change="selectImages"
+		>
+		<plus-icon
+			inline
+			:class="$s.ImagePickerInputIcon"
+		/>
+	</div>
+</template>
+
+<script>
+import PlusIcon from '@square-icons/vue/16/UI/Add';
+
+export default {
+	name: 'MImagePicker',
+	components: {
+		PlusIcon,
+	},
+
+	methods: {
+		selectImages(fileEvent) {
+			this.$emit('selectImages', [...fileEvent.target.files]);
+		},
+	},
+};
+</script>
+
+<style module="$s">
+.ImagePickerInputContainer {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	box-sizing: border-box;
+	width: 96px;
+	height: 96px;
+	border: 1px solid rgba(0, 0, 0, 0.9);
+	border-radius: 8px;
+	cursor: pointer;
+	transition: background-color 150ms linear;
+}
+
+.ImagePickerInputIcon {
+	width: 15px;
+	height: 15px;
+}
+
+.ImagePickerInput {
+	display: none;
+}
+</style>

--- a/src/components/ImageSelector/src/ImagePicker.vue
+++ b/src/components/ImageSelector/src/ImagePicker.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script>
-import PlusIcon from '@square-icons/vue/16/UI/Add';
+import PlusIcon from '@square/maker-icons/Plus';
 
 export default {
 	name: 'MImagePicker',

--- a/src/components/ImageSelector/src/ImageSelection.vue
+++ b/src/components/ImageSelector/src/ImageSelection.vue
@@ -1,0 +1,162 @@
+<template>
+	<div
+		:class="{ [$s.ImageSelectionContainer]: true, [$s.ImageSelectionContainerError]: hasError }"
+		role="img"
+		:style="bgImageStyle"
+	>
+		<div
+			v-if="isUploading"
+			:class="$s.ImageSelectionLoaderContainer"
+		>
+			<m-loading :class="$s.ImageSelectionLoader" />
+		</div>
+
+		<div
+			:class="$s.ImageSelectionProgressContainer"
+			:style="progressContainerStyle"
+		>
+			<div
+				:class="$s.ImageSelectionProgress"
+				:style="progressStyle"
+			/>
+		</div>
+
+		<button
+			v-if="!isUploading"
+			type="button"
+			:class="$s.ImageSelectionRemoveButton"
+			@click="$emit('removeImage', image.id)"
+		>
+			<!-- TODO: Icon -->
+			<x-icon inline />
+		</button>
+	</div>
+</template>
+
+<script>
+import { MLoading } from '@square/maker/components/Loading';
+import XIcon from '@square-icons/vue/16/UI/X-Stroked';
+import { IMAGE_SELECTOR_STATUSES } from './constants';
+
+export default {
+	name: 'MImageSelection',
+
+	components: {
+		MLoading,
+		XIcon,
+	},
+
+	props: {
+		image: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	computed: {
+		bgImageStyle() {
+			return {
+				backgroundImage: `url("${this.image.url}")`,
+			};
+		},
+
+		showProgressBar() {
+			return this.image.progress < 100;
+		},
+
+		progressContainerStyle() {
+			return {
+				opacity: this.showProgressBar ? 1 : 0,
+			};
+		},
+
+		progressStyle() {
+			return {
+				width: `${this.image.progress}%`,
+			};
+		},
+
+		isUploading() {
+			return this.image.status === IMAGE_SELECTOR_STATUSES.PENDING;
+		},
+
+		hasError() {
+			return this.image.status === IMAGE_SELECTOR_STATUSES.ERROR;
+		},
+	},
+};
+</script>
+
+<style module="$s">
+.ImageSelectionContainer {
+	position: relative;
+	box-sizing: border-box;
+	width: 96px;
+	height: 96px;
+	overflow: hidden;
+	background-repeat: no-repeat;
+	background-size: cover;
+	border-radius: 8px;
+	transition: background-image linear 150ms;
+
+	/* these should later be pulled from
+	the ThemeProvider component */
+	--color-border: rgba(0, 0, 0, 0.3);
+	--color-border-active: rgba(0, 0, 0, 0.9);
+	--color-background: rgba(0, 0, 0, 0.9);
+	--color-foreground: rgba(255, 255, 255, 0.95);
+	--color-disabled: rgba(0, 0, 0, 0.05);
+	--color-disabled-checked: rgba(0, 0, 0, 0.15);
+	--color-error: #ff3b30;
+}
+
+.ImageSelectionLoaderContainer {
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-image: linear-gradient(0deg, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.5));
+}
+
+.ImageSelectionContainerError {
+	border: 2px solid var(--color-error);
+}
+
+.ImageSelectionRemoveButton {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 32px;
+	height: 32px;
+	background-color: #fff;
+	border: 0;
+	border-radius: 50%;
+	cursor: pointer;
+}
+
+.ImageSelectionProgressContainer {
+	position: absolute;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	height: 4px;
+	overflow: hidden;
+	background-color: #f5f4f4;
+	opacity: 1;
+	transition: opacity 250ms ease;
+}
+
+.ImageSelectionProgress {
+	height: 100%;
+	background-color: #000;
+	border-radius: 4px;
+	transition: width 150ms linear;
+}
+</style>

--- a/src/components/ImageSelector/src/ImageSelection.vue
+++ b/src/components/ImageSelector/src/ImageSelection.vue
@@ -101,6 +101,7 @@ export default {
 	height: 96px;
 	overflow: hidden;
 	background-repeat: no-repeat;
+	background-position: center;
 	background-size: cover;
 	border-radius: 8px;
 	transition: background-image linear 150ms;

--- a/src/components/ImageSelector/src/ImageSelection.vue
+++ b/src/components/ImageSelector/src/ImageSelection.vue
@@ -28,15 +28,20 @@
 			@click="$emit('removeImage', image.id)"
 		>
 			<!-- TODO: Icon -->
-			<x-icon inline />
+			<x-icon
+				inline
+				:class="$s.ImageSelectionRemoveIcon"
+			/>
 		</button>
 	</div>
 </template>
 
 <script>
 import { MLoading } from '@square/maker/components/Loading';
-import XIcon from '@square-icons/vue/16/UI/X-Stroked';
+import XIcon from '@square/maker-icons/X';
 import { IMAGE_SELECTOR_STATUSES } from './constants';
+
+const MAX_PROGRESS = 100;
 
 export default {
 	name: 'MImageSelection',
@@ -61,11 +66,12 @@ export default {
 		},
 
 		showProgressBar() {
-			return this.image.progress < 100;
+			return this.image.progress < MAX_PROGRESS;
 		},
 
 		progressContainerStyle() {
 			return {
+				// eslint-disable-next-line no-magic-numbers
 				opacity: this.showProgressBar ? 1 : 0,
 			};
 		},
@@ -139,6 +145,11 @@ export default {
 	border: 0;
 	border-radius: 50%;
 	cursor: pointer;
+}
+
+.ImageSelectionRemoveIcon {
+	width: 16px;
+	height: 16px;
 }
 
 .ImageSelectionProgressContainer {

--- a/src/components/ImageSelector/src/ImageSelector.vue
+++ b/src/components/ImageSelector/src/ImageSelector.vue
@@ -144,12 +144,11 @@ export default {
 .ImageUploaderContainer {
 	display: flex;
 	flex-wrap: wrap;
+	gap: 16px;
 	align-items: flex-start;
 }
 
 .ImageUploaderItem {
 	flex-shrink: 0;
-	margin-top: 16px;
-	margin-right: 16px;
 }
 </style>

--- a/src/components/ImageSelector/src/ImageSelector.vue
+++ b/src/components/ImageSelector/src/ImageSelector.vue
@@ -87,13 +87,16 @@ export default {
 
 		formatImages(images) {
 			const formattedImages = images
-				.map((image) => ({
-					id: this.nextID,
-					file: image,
-					status: IMAGE_SELECTOR_STATUSES.PENDING,
-				}));
+				.map((image) => {
+					this.nextID += ID_INCREMENT;
+
+					return {
+						id: this.nextID,
+						file: image,
+						status: IMAGE_SELECTOR_STATUSES.PENDING,
+					};
+				});
 			formattedImages.forEach((image) => this.buildImageURL(image));
-			this.nextID += ID_INCREMENT;
 
 			return formattedImages;
 		},

--- a/src/components/ImageSelector/src/ImageSelector.vue
+++ b/src/components/ImageSelector/src/ImageSelector.vue
@@ -1,0 +1,150 @@
+<template>
+	<div :class="$s.ImageUploaderContainer">
+		<m-image-picker
+			v-if="canUploadImage"
+			:class="$s.ImageUploaderItem"
+			@selectImages="selectImages"
+		/>
+		<m-image-selection
+			v-for="image of model"
+			:key="image.id"
+			:image="image"
+			:class="$s.ImageUploaderItem"
+			@removeImage="removeImage"
+		/>
+	</div>
+</template>
+
+<script>
+import Vue from 'vue';
+import uuid from 'uuid';
+import MImagePicker from './ImagePicker.vue';
+import MImageSelection from './ImageSelection.vue';
+import { IMAGE_SELECTOR_STATUSES } from './constants';
+
+export default {
+	name: 'MImageSelector',
+
+	components: {
+		MImagePicker,
+		MImageSelection,
+	},
+
+	props: {
+		model: {
+			type: Array,
+			default: () => [],
+		},
+		uploadHandler: {
+			type: Function,
+			default: () => undefined,
+		},
+		maxImages: {
+			type: Number,
+			default: () => undefined,
+		},
+	},
+
+	computed: {
+		canUploadImage() {
+			if (this.maxImages === undefined) {
+				return true;
+			}
+
+			return this.model.length < this.maxImages;
+		},
+		remainingImagesCount() {
+			if (!this.canUploadImage) {
+				return 0;
+			}
+
+			return this.maxImages - this.model.length;
+		},
+	},
+
+	methods: {
+		selectImages(images) {
+			if (!this.canUploadImage) {
+				return;
+			}
+
+			let imagesToUpload;
+			if (images.length > this.remainingImagesCount) {
+				// display error/warning
+				imagesToUpload = images.slice(0, this.remainingImagesCount);
+			} else {
+				imagesToUpload = images;
+			}
+
+			const formattedImages = this.formatImages(imagesToUpload);
+			this.$emit('input', [...this.model, ...formattedImages]);
+			formattedImages.forEach((image) => this.handleImageUpload(image));
+		},
+
+		formatImages(images) {
+			const formattedImages = images
+				.map((image) => ({
+					id: uuid(),
+					file: image,
+					status: IMAGE_SELECTOR_STATUSES.PENDING,
+				}));
+			formattedImages.forEach((image) => this.buildImageURL(image));
+
+			return formattedImages;
+		},
+
+		async handleImageUpload(image) {
+			if (!this.uploadHandler) {
+				Vue.set(image, 'progress', 100);
+				Vue.set(image, 'status', IMAGE_SELECTOR_STATUSES.COMPLETE);
+				return;
+			}
+
+			try {
+				const response = await this.uploadHandler({
+					image: image.file,
+					uploadProgressHandler: (progress) => Vue.set(image, 'progress', progress),
+				});
+				Vue.set(image, 'progress', 100);
+				Vue.set(image, 'apiResponse', response);
+				Vue.set(image, 'status', IMAGE_SELECTOR_STATUSES.COMPLETE);
+			} catch (error) {
+				Vue.set(image, 'progress', 100);
+				Vue.set(image, 'apiError', error);
+				Vue.set(image, 'status', IMAGE_SELECTOR_STATUSES.ERROR);
+			}
+		},
+
+		removeImage(imageID) {
+			this.$emit('input', this.model.filter(({ id }) => id !== imageID));
+		},
+
+		async buildImageURL(image) {
+			const url = await new Promise((resolve) => {
+				const reader = new FileReader();
+				reader.onloadend = () => resolve(reader.result);
+				// TODO: Add error logging
+				// eslint-disable-next-line unicorn/prefer-add-event-listener
+				reader.onerror = () => resolve('');
+				reader.readAsDataURL(image.file);
+			});
+
+			Vue.set(image, 'url', url);
+		},
+	},
+};
+</script>
+
+<style module="$s">
+.ImageUploaderContainer {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: flex-start;
+}
+
+.ImageUploaderItem {
+	flex-shrink: 0;
+	margin-top: 16px;
+	margin-right: 16px;
+}
+</style>

--- a/src/components/ImageSelector/src/ImageSelector.vue
+++ b/src/components/ImageSelector/src/ImageSelector.vue
@@ -46,6 +46,10 @@ export default {
 			type: Number,
 			default: () => undefined,
 		},
+		maxSize: {
+			type: Number,
+			default: () => undefined,
+		},
 	},
 
 	data: () => ({
@@ -102,6 +106,15 @@ export default {
 		},
 
 		async handleImageUpload(image) {
+			if (this.maxSize && image.file.size > this.maxSize) {
+				Vue.set(image, 'progress', MAX_PROGRESS);
+				Vue.set(image, 'status', IMAGE_SELECTOR_STATUSES.ERROR);
+				Vue.set(image, 'fileTooLarge', true);
+				return;
+			}
+
+			Vue.set(image, 'fileTooLarge', false);
+
 			if (!this.uploadHandler) {
 				Vue.set(image, 'progress', MAX_PROGRESS);
 				Vue.set(image, 'status', IMAGE_SELECTOR_STATUSES.COMPLETE);

--- a/src/components/ImageSelector/src/constants.js
+++ b/src/components/ImageSelector/src/constants.js
@@ -1,0 +1,5 @@
+export const IMAGE_SELECTOR_STATUSES = {
+	PENDING: 'pending',
+	ERROR: 'error',
+	COMPLETE: 'complete',
+};


### PR DESCRIPTION
## Describe the problem this PR addresses
This PR adds a new component for handle image selection (and uploading, if required). Closes #134.

## Describe the changes in this PR
The component wraps a single file input, and listens to changes in order to push images.

If given an upload handler, the component will attempt to call it with each image selected, and set the upload progress/status on completion or if an error is ecountered. If a handler is not provided, the file is pushed into the list immediately.

The component also allows setting a maximum number of images and a maximum size (in bytes).

![Screen Recording 2021-09-17 at 4 10 31 PM](https://user-images.githubusercontent.com/3402466/134206117-68e3baf0-c604-465e-bf9d-7492234ad1bf.gif)

## Other information
The progress bar within the selected image component will eventually be an MProgressBar when that component is built.
