### PR TITLE
feat(progress-bar): add progress bar component

### DIFF
--- a/src/components/ProgressBar/README.md
+++ b/src/components/ProgressBar/README.md
@@ -1,0 +1,106 @@
+# Progress Bar
+
+```vue
+<template>
+	<div :class="$s.Container">
+		<div :class="$s.Section">
+			<label>
+				Color picker
+				<input
+					v-model="color"
+					type="color"
+				>
+			</label>
+		</div>
+
+		<div :class="$s.Section">
+			<label>
+				Progress ({{ progress }}%)
+				<input
+					v-model="progress"
+					type="range"
+					step="1"
+					min="0"
+					max="100"
+				>
+			</label>
+		</div>
+
+		<div
+			v-for="shape in ['pill', 'rounded', 'squared']"
+			:key="shape"
+			:class="$s.Sizes"
+		>
+			<m-heading :size="2">
+				{{ shape }} shape
+			</m-heading>
+
+			<div
+				v-for="size in ['xsmall', 'small', 'medium', 'large']"
+				:key="size"
+			>
+				<m-heading :size="0">
+					{{ size }}
+				</m-heading>
+				<m-progress-bar
+					:shape="shape"
+					:size="size"
+					:color="color"
+					:progress="progress"
+				/>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { MProgressBar } from '@square/maker/components/ProgressBar';
+import { MHeading } from '@square/maker/components/Heading';
+
+export default {
+	components: {
+		MProgressBar,
+		MHeading,
+	},
+
+	data() {
+		return {
+			color: '#000',
+			progress: 50,
+		};
+	},
+
+	computed: {},
+
+	methods: {},
+};
+</script>
+
+<style module="$s">
+.Container {
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
+	max-width: 500px;
+}
+
+.Sizes {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+</style>
+
+```
+
+<!-- api-tables:start -->
+## Props
+
+| Prop     | Type     | Default     | Possible values                      | Description |
+| -------- | -------- | ----------- | ------------------------------------ | ----------- |
+| size     | `string` | `'medium'`  | `xsmall`, `small`, `medium`, `large` | —           |
+| shape    | `string` | `'rounded'` | `squared`, `rounded`, `pill`         | —           |
+| color    | `string` | `'#000'`    | —                                    | —           |
+| progress | `number` | `0`         | —                                    | —           |
+<!-- api-tables:end -->

--- a/src/components/ProgressBar/README.md
+++ b/src/components/ProgressBar/README.md
@@ -97,10 +97,10 @@ export default {
 <!-- api-tables:start -->
 ## Props
 
-| Prop     | Type     | Default     | Possible values                      | Description |
-| -------- | -------- | ----------- | ------------------------------------ | ----------- |
-| size     | `string` | `'medium'`  | `xsmall`, `small`, `medium`, `large` | —           |
-| shape    | `string` | `'rounded'` | `squared`, `rounded`, `pill`         | —           |
-| color    | `string` | `'#000'`    | —                                    | —           |
-| progress | `number` | `0`         | —                                    | —           |
+| Prop     | Type     | Default     | Possible values                      | Description                                |
+| -------- | -------- | ----------- | ------------------------------------ | ------------------------------------------ |
+| size     | `string` | `'medium'`  | `xsmall`, `small`, `medium`, `large` | Size (height) of the progress bar          |
+| shape    | `string` | `'rounded'` | `squared`, `rounded`, `pill`         | Shape of the progress bar                  |
+| color    | `string` | `'#000'`    | —                                    | Color of the progress bar (not background) |
+| progress | `number` | `0`         | —                                    | Progress/width of the bar (0-100)          |
 <!-- api-tables:end -->

--- a/src/components/ProgressBar/index.js
+++ b/src/components/ProgressBar/index.js
@@ -1,0 +1,1 @@
+export { default as MProgressBar } from './src/ProgressBar.vue';

--- a/src/components/ProgressBar/src/ProgressBar.vue
+++ b/src/components/ProgressBar/src/ProgressBar.vue
@@ -29,21 +29,33 @@ export default {
 	name: 'ProgressBar',
 
 	props: {
+		/**
+		 * Size (height) of the progress bar
+		 */
 		size: {
 			type: String,
 			default: 'medium',
 			validator: (size) => ['xsmall', 'small', 'medium', 'large'].includes(size),
 		},
+		/**
+		 * Shape of the progress bar
+		 */
 		shape: {
 			type: String,
 			default: 'rounded',
 			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
 		},
+		/**
+		 * Color of the progress bar (not background)
+		 */
 		color: {
 			type: String,
 			default: '#000',
 			validator: (color) => chroma.valid(color),
 		},
+		/**
+		 * Progress/width of the bar (0-100)
+		 */
 		progress: {
 			type: Number,
 			default: 0,
@@ -93,10 +105,7 @@ export default {
 }
 
 .ProgressBarContainer.shape_rounded,
-.ProgressBar.shape_rounded {
-	border-radius: 8px;
-}
-
+.ProgressBar.shape_rounded,
 .ProgressBarContainer.shape_pill,
 .ProgressBar.shape_pill {
 	border-radius: 16px;

--- a/src/components/ProgressBar/src/ProgressBar.vue
+++ b/src/components/ProgressBar/src/ProgressBar.vue
@@ -1,0 +1,104 @@
+<template>
+	<div
+		:class="[
+			$s.ProgressBarContainer,
+			$s[`size_${size}`],
+			$s[`shape_${shape}`],
+		]"
+	>
+		<div
+			:class="[
+				$s.ProgressBar,
+				$s[`shape_${shape}`],
+			]"
+			:style="{
+				backgroundColor: color,
+				transform: `translateX(-${progressTranslate}%)`
+			}"
+		/>
+	</div>
+</template>
+
+<script>
+import chroma from 'chroma-js';
+
+const MIN_PROGRESS = 0;
+const MAX_PROGRESS = 100;
+
+export default {
+	name: 'ProgressBar',
+
+	props: {
+		size: {
+			type: String,
+			default: 'medium',
+			validator: (size) => ['xsmall', 'small', 'medium', 'large'].includes(size),
+		},
+		shape: {
+			type: String,
+			default: 'rounded',
+			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
+		},
+		color: {
+			type: String,
+			default: '#000',
+			validator: (color) => chroma.valid(color),
+		},
+		progress: {
+			type: Number,
+			default: 0,
+			validator: (progress) => progress >= MIN_PROGRESS && progress <= MAX_PROGRESS,
+		},
+	},
+
+	computed: {
+		progressTranslate() {
+			return MAX_PROGRESS - this.progress;
+		},
+	},
+};
+</script>
+
+<style module="$s">
+.ProgressBarContainer {
+	width: 100%;
+	overflow: hidden;
+	background-color: #f5f4f4;
+}
+
+.ProgressBar {
+	height: 100%;
+	transition: transform 100ms linear;
+}
+
+.ProgressBarContainer.size_xsmall {
+	height: 4px;
+}
+
+.ProgressBarContainer.size_small {
+	height: 8px;
+}
+
+.ProgressBarContainer.size_medium {
+	height: 12px;
+}
+
+.ProgressBarContainer.size_large {
+	height: 16px;
+}
+
+.ProgressBarContainer.shape_squared,
+.ProgressBar.shape_squared {
+	border-radius: 0;
+}
+
+.ProgressBarContainer.shape_rounded,
+.ProgressBar.shape_rounded {
+	border-radius: 8px;
+}
+
+.ProgressBarContainer.shape_pill,
+.ProgressBar.shape_pill {
+	border-radius: 16px;
+}
+</style>

--- a/src/components/ProgressBar/src/ProgressBar.vue
+++ b/src/components/ProgressBar/src/ProgressBar.vue
@@ -7,14 +7,8 @@
 		]"
 	>
 		<div
-			:class="[
-				$s.ProgressBar,
-				$s[`shape_${shape}`],
-			]"
-			:style="{
-				backgroundColor: color,
-				transform: `translateX(-${progressTranslate}%)`
-			}"
+			:class="$s.ProgressBar"
+			:style="barStyles"
 		/>
 	</div>
 </template>
@@ -64,8 +58,11 @@ export default {
 	},
 
 	computed: {
-		progressTranslate() {
-			return MAX_PROGRESS - this.progress;
+		barStyles() {
+			return {
+				'--bar-color': this.color,
+				'--fill-percent': `${this.progress}%`,
+			};
 		},
 	},
 };
@@ -79,8 +76,10 @@ export default {
 }
 
 .ProgressBar {
+	width: var(--fill-percent, 0);
 	height: 100%;
-	transition: transform 100ms linear;
+	background-color: var(--bar-color);
+	transition: width 100ms linear;
 }
 
 .ProgressBarContainer.size_xsmall {
@@ -100,14 +99,14 @@ export default {
 }
 
 .ProgressBarContainer.shape_squared,
-.ProgressBar.shape_squared {
+.ProgressBarContainer.shape_squared .ProgressBar {
 	border-radius: 0;
 }
 
 .ProgressBarContainer.shape_rounded,
-.ProgressBar.shape_rounded,
+.ProgressBarContainer.shape_rounded .ProgressBar,
 .ProgressBarContainer.shape_pill,
-.ProgressBar.shape_pill {
+.ProgressBarContainer.shape_pill .ProgressBar {
 	border-radius: 16px;
 }
 </style>


### PR DESCRIPTION
## Describe the problem this PR addresses
Closes #136 

This PR introduces a reusable progress bar component. It has 2 styles (square and rounded/pill), is colour configurable, and 4 different sizes.

## Describe the changes in this PR
The `ProgressBar` component has 4 main inputs:
- `shape`: is either square or rounded/pill (sites that have rounded or pill designs will have the same progress bar shape)
- `color`: controls the color of the inner bar
- `size`: xsmall (4px), small (8px), medium (12px), or large (16px)
- `progress`: a 0-100 number that controls the display of the inner bar

The inner progress bar is a full width bar that uses a transform to match the progress input. It does this instead of a width for performance reasons, as animating width is not nearly as performant.

![Screen Recording 2021-09-22 at 11 52 26 AM](https://user-images.githubusercontent.com/3402466/134378418-1036a277-14c2-4000-b470-e2c84694374c.gif)