### PR TITLE
feat(container): label & sublabel slots

### DIFF
--- a/src/components/Button/src/TextButton.vue
+++ b/src/components/Button/src/TextButton.vue
@@ -98,7 +98,7 @@ export default {
 	},
 
 	created() {
-		assert.warn(this.$slots.default, 'TextButton should only be used with a label');
+		assert.warn(this.$slots.default, 'TextButton should be used with a label');
 	},
 
 };

--- a/src/components/Container/README.md
+++ b/src/components/Container/README.md
@@ -1,5 +1,169 @@
 # Container
 
+Container contains content.
+
+```vue
+<template>
+	<m-container>
+		container content
+	</m-container>
+</template>
+
+<script>
+import { MContainer } from '@square/maker/components/Container';
+
+export default {
+	components: {
+		MContainer,
+	},
+};
+</script>
+```
+
+## Labels
+
+Labels can be set via props.
+
+```vue
+<template>
+	<m-container
+		label="container label"
+		sublabel="container sublabel"
+		requirement-label="container requirement label"
+	>
+		container content
+	</m-container>
+</template>
+
+<script>
+import { MContainer } from '@square/maker/components/Container';
+
+export default {
+	components: {
+		MContainer,
+	},
+};
+</script>
+```
+
+Labels can also be set via slots.
+
+```vue
+<template>
+	<m-container
+		label="container label"
+		sublabel="container sublabel"
+		requirement-label="container requirement label"
+	>
+		<template
+			#label
+		>
+			<div
+				class="icon-label-wrapper"
+			>
+				<user-icon class="icon" /> container label
+			</div>
+		</template>
+		<template
+			#sublabel
+		>
+			<div
+				class="icon-label-wrapper"
+			>
+				<info-icon class="icon" /> container sublabel
+			</div>
+		</template>
+		<template
+			#requirement-label
+		>
+			<div
+				class="icon-label-wrapper"
+			>
+				<alert-triangle-icon class="icon" /> container requirement label
+			</div>
+		</template>
+		container content
+	</m-container>
+</template>
+
+<script>
+import { MContainer } from '@square/maker/components/Container';
+import AlertTriangleIcon from '@square/maker-icons/AlertTriangle';
+import InfoIcon from '@square/maker-icons/Info';
+import UserIcon from '@square/maker-icons/User';
+
+export default {
+	components: {
+		MContainer,
+		UserIcon,
+		InfoIcon,
+		AlertTriangleIcon,
+	},
+};
+</script>
+
+<style scoped>
+.icon {
+	width: 16px;
+	height: 16px;
+	margin-right: 8px;
+}
+
+.icon-label-wrapper {
+	display: flex;
+	align-items: center;
+}
+</style>
+```
+
+## Sizes
+
+Containers can be small, medium, or large, which affects the default typography styles within the container.
+
+
+```vue
+<template>
+	<div>
+		<m-container
+			label="small container label"
+			sublabel="small container sublabel"
+			requirement-label="small container requirement label"
+			size="small"
+		>
+			small container content
+		</m-container>
+		<m-container
+			label="medium container label"
+			sublabel="medium container sublabel"
+			requirement-label="medium container requirement label"
+			size="medium"
+		>
+			medium container content
+		</m-container>
+		<m-container
+			label="large container label"
+			sublabel="large container sublabel"
+			requirement-label="large container requirement label"
+			size="large"
+		>
+			large container content
+		</m-container>
+	</div>
+</template>
+
+<script>
+import { MContainer } from '@square/maker/components/Container';
+
+export default {
+	components: {
+		MContainer,
+	},
+};
+</script>
+```
+
+<!--
+
 ```vue
 <template>
 	<div style="background-color: #F8F7F7;">
@@ -66,28 +230,40 @@ export default {
 	},
 };
 </script>
+
+<style scoped>
+.icon {
+	width: 16px;
+	height: 16px;
+}
+</style>
 ```
+
+-->
 
 <!-- api-tables:start -->
 ## Props
 
 Supports attributes from [`<section>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section).
 
-| Prop     | Type     | Default    | Possible values            | Description                   |
-| -------- | -------- | ---------- | -------------------------- | ----------------------------- |
-| label    | `string` | —          | —                          | Container label               |
-| sublabel | `string` | —          | —                          | Container sublabel            |
-| size     | `string` | `'medium'` | `small`, `medium`, `large` | Container size                |
-| bg-color | `string` | —          | —                          | Background color of container |
-| color    | `string` | —          | —                          | Text color of container       |
+| Prop              | Type     | Default    | Possible values            | Description                   |
+| ----------------- | -------- | ---------- | -------------------------- | ----------------------------- |
+| label             | `string` | —          | —                          | Container label               |
+| sublabel          | `string` | —          | —                          | Container sublabel            |
+| requirement-label | `string` | —          | —                          | Container requirement label   |
+| size              | `string` | `'medium'` | `small`, `medium`, `large` | Container size                |
+| bg-color          | `string` | —          | —                          | Background color of container |
+| color             | `string` | —          | —                          | Text color of container       |
 
 
 ## Slots
 
-| Slot              | Description            |
-| ----------------- | ---------------------- |
-| requirement-label | requirement label slot |
-| default           | container content      |
+| Slot              | Description                 |
+| ----------------- | --------------------------- |
+| label             | container label             |
+| sublabel          | container sublabel          |
+| requirement-label | container requirement label |
+| default           | container content           |
 
 
 ## Events

--- a/src/components/Container/README.md
+++ b/src/components/Container/README.md
@@ -46,15 +46,12 @@ export default {
 </script>
 ```
 
+<br>
 Labels can also be set via slots.
 
 ```vue
 <template>
-	<m-container
-		label="container label"
-		sublabel="container sublabel"
-		requirement-label="container requirement label"
-	>
+	<m-container>
 		<template
 			#label
 		>
@@ -120,7 +117,6 @@ export default {
 
 Containers can be small, medium, or large, which affects the default typography styles within the container.
 
-
 ```vue
 <template>
 	<div>
@@ -161,85 +157,6 @@ export default {
 };
 </script>
 ```
-
-<!--
-
-```vue
-<template>
-	<div style="background-color: #F8F7F7;">
-		<m-container>
-			container content
-		</m-container>
-
-		<h4>label + content</h4>
-		<m-container label="container label">
-			container content
-		</m-container>
-
-		<h4>label + sublabel + content</h4>
-		<m-container
-			label="container label"
-			sublabel="container sublabel"
-		>
-			container content
-		</m-container>
-
-		<h4>label + sublabel + requirement label + content</h4>
-		<m-container
-			label="container label"
-			sublabel="container sublabel"
-		>
-			container content
-			<template #requirement-label>
-				container requirement label
-			</template>
-		</m-container>
-
-		<h4>size small</h4>
-		<m-container
-			label="container label"
-			sublabel="container sublabel"
-			size="small"
-		>
-			container content
-			<template #requirement-label>
-				container requirement label
-			</template>
-		</m-container>
-
-		<h4>size large</h4>
-		<m-container
-			label="container label"
-			sublabel="container sublabel"
-			size="large"
-		>
-			container content
-			<template #requirement-label>
-				container requirement label
-			</template>
-		</m-container>
-	</div>
-</template>
-
-<script>
-import { MContainer } from '@square/maker/components/Container';
-
-export default {
-	components: {
-		MContainer,
-	},
-};
-</script>
-
-<style scoped>
-.icon {
-	width: 16px;
-	height: 16px;
-}
-</style>
-```
-
--->
 
 <!-- api-tables:start -->
 ## Props

--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -10,22 +10,29 @@
 	>
 		<header :class="$s.Header">
 			<div
-				v-if="label"
+				v-if="hasLabel"
 				:class="$s.Label"
 			>
-				{{ label }}
-
+				<!-- @slot container label -->
+				<slot name="label">
+					{{ label }}
+				</slot>
 				<div
-					v-if="sublabel"
+					v-if="hasSublabel"
 					:class="$s.Sublabel"
 				>
-					{{ sublabel }}
+					<!-- @slot container sublabel -->
+					<slot name="sublabel">
+						{{ sublabel }}
+					</slot>
 				</div>
 			</div>
 
 			<div :class="$s.RequirementLabel">
-				<!-- @slot requirement label slot -->
-				<slot name="requirement-label" />
+				<!-- @slot container requirement label -->
+				<slot name="requirement-label">
+					{{ requirementLabel }}
+				</slot>
 			</div>
 		</header>
 
@@ -36,6 +43,7 @@
 
 <script>
 import chroma from 'chroma-js';
+import assert from '@square/maker/utils/assert';
 
 /**
  * @inheritAttrs section
@@ -56,6 +64,13 @@ export default {
 		 * Container sublabel
 		 */
 		sublabel: {
+			type: String,
+			default: undefined,
+		},
+		/**
+		 * Container requirement label
+		 */
+		requirementLabel: {
 			type: String,
 			default: undefined,
 		},
@@ -92,6 +107,18 @@ export default {
 				'--color': this.color,
 			};
 		},
+		hasLabel() {
+			return this.$slots.label || this.label;
+		},
+		hasSublabel() {
+			return this.$slots.sublabel || this.sublabel;
+		},
+	},
+
+	mounted() {
+		assert.warn(!(this.$slots.label && this.label), 'Label slot cannot be used together with label prop, former overrides the latter.');
+		assert.warn(!(this.$slots.sublabel && this.sublabel), 'Sublabel slot cannot be used together with sublabel prop, former overrides the latter.');
+		assert.warn(!((this.$slots.requirementLabel || this.$slots['requirement-label']) && this.requirementLabel), 'Requirement Label slot cannot be used together with requirement label prop, former overrides the latter.');
 	},
 };
 </script>

--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -28,7 +28,10 @@
 				</div>
 			</div>
 
-			<div :class="$s.RequirementLabel">
+			<div
+				v-if="hasRequirementLabel"
+				:class="$s.RequirementLabel"
+			>
 				<!-- @slot container requirement label -->
 				<slot name="requirement-label">
 					{{ requirementLabel }}
@@ -112,6 +115,9 @@ export default {
 		},
 		hasSublabel() {
 			return this.$slots.sublabel || this.sublabel;
+		},
+		hasRequirementLabel() {
+			return this.$slots.requirementLabel || this.$slots['requirement-label'] || this.requirementLabel;
 		},
 	},
 


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
closes https://github.com/square/maker/issues/88
TL;DR: people can now put icons into the labels and sublabels of containers

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
described in issue above, also view here: https://square.github.io/maker/styleguide/mcontainer-slots/#/Container

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
no
