### PR TITLE
Themeable heading and text

### DIFF
--- a/src/components/Heading/src/Heading.vue
+++ b/src/components/Heading/src/Heading.vue
@@ -1,5 +1,7 @@
 <script>
-const DEFAULT_SIZE = 0;
+import chroma from 'chroma-js';
+import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
+
 const MAX_SIZE = 7;
 const MIN_SIZE = -2;
 
@@ -9,6 +11,13 @@ const MIN_SIZE = -2;
  * @inheritListeners h1
  */
 export default {
+	inject: {
+		theme: {
+			default: defaultTheme(),
+			from: MThemeKey,
+		},
+	},
+
 	inheritAttrs: false,
 
 	props: {
@@ -17,7 +26,7 @@ export default {
 		 */
 		size: {
 			type: Number,
-			default: DEFAULT_SIZE,
+			default: undefined,
 			validator: (size) => size >= MIN_SIZE && size <= MAX_SIZE,
 		},
 		/**
@@ -28,9 +37,25 @@ export default {
 			default: undefined,
 			validator: (element) => ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div'].includes(element),
 		},
+		/**
+		 * Heading font family
+		 */
+		fontFamily: {
+			type: String,
+			default: undefined,
+		},
+		/**
+		 * Heading text color
+		 */
+		textColor: {
+			type: String,
+			default: undefined,
+			validator: (color) => chroma.valid(color),
+		},
 	},
 
 	computed: {
+		...resolveThemeableProps('heading', ['size', 'fontFamily', 'textColor']),
 		tag() {
 			if (this.element) {
 				return this.element;
@@ -40,39 +65,55 @@ export default {
 			const h3Threshold = 2;
 			const h4Threshold = 1;
 			const h5Threshold = 0;
-			if (this.size >= h1Threshold) {
+			if (this.resolvedSize >= h1Threshold) {
 				return 'h1';
 			}
-			if (this.size >= h2Threshold) {
+			if (this.resolvedSize >= h2Threshold) {
 				return 'h2';
 			}
-			if (this.size >= h3Threshold) {
+			if (this.resolvedSize >= h3Threshold) {
 				return 'h3';
 			}
-			if (this.size >= h4Threshold) {
+			if (this.resolvedSize >= h4Threshold) {
 				return 'h4';
 			}
-			if (this.size >= h5Threshold) {
+			if (this.resolvedSize >= h5Threshold) {
 				return 'h5';
 			}
 			return 'h6';
 		},
-		stringSize() {
+		sizeClass() {
 			const minNonNegativeSize = 0;
-			if (this.size >= minNonNegativeSize) {
-				return this.size.toString();
+			if (this.resolvedSize >= minNonNegativeSize) {
+				return this.resolvedSize.toString();
 			}
-			return `minus-${Math.abs(this.size)}`;
+			return `minus-${Math.abs(this.resolvedSize)}`;
+		},
+		inlineStyles() {
+			return {
+				fontFamily: this.resolvedFontFamily,
+				color: this.resolvedTextColor,
+			};
 		},
 	},
 
 	render(createElement) {
-		const { $s, stringSize, tag } = this;
+		const {
+			$s,
+			sizeClass,
+			tag,
+			inlineStyles,
+		} = this;
+		/**
+		 * @slot heading content
+		 */
+		const defaultSlot = this.$slots.default;
 		return createElement(tag, {
-			class: [$s.Heading, $s[`size_${stringSize}`]],
+			class: [$s.Heading, $s[`size_${sizeClass}`]],
+			style: inlineStyles,
 			attrs: this.$attrs,
 			on: this.$listeners,
-		}, this.$slots.default);
+		}, defaultSlot);
 	},
 };
 </script>

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -1,5 +1,7 @@
 <script>
-const DEFAULT_SIZE = 0;
+import chroma from 'chroma-js';
+import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
+
 const MIN_SIZE = -1;
 const MAX_SIZE = 1;
 
@@ -8,6 +10,13 @@ const MAX_SIZE = 1;
  * @inheritListeners span
  */
 export default {
+	inject: {
+		theme: {
+			default: defaultTheme(),
+			from: MThemeKey,
+		},
+	},
+
 	inheritAttrs: false,
 
 	props: {
@@ -24,30 +33,58 @@ export default {
 		 */
 		size: {
 			type: Number,
-			default: DEFAULT_SIZE,
+			default: undefined,
 			validator: (size) => size >= MIN_SIZE && size <= MAX_SIZE,
+		},
+		/**
+		 * text font family
+		 */
+		fontFamily: {
+			type: String,
+			default: undefined,
+		},
+		/**
+		 * text color
+		 */
+		textColor: {
+			type: String,
+			default: undefined,
+			validator: (color) => chroma.valid(color),
 		},
 	},
 
 	computed: {
-		stringSize() {
+		...resolveThemeableProps('text', ['size', 'fontFamily', 'textColor']),
+		sizeClass() {
 			const minNonNegativeSize = 0;
-			if (this.size >= minNonNegativeSize) {
-				return this.size.toString();
+			if (this.resolvedSize >= minNonNegativeSize) {
+				return this.resolvedSize.toString();
 			}
-			return `minus-${Math.abs(this.size)}`;
+			return `minus-${Math.abs(this.resolvedSize)}`;
+		},
+		inlineStyles() {
+			return {
+				fontFamily: this.resolvedFontFamily,
+				color: this.resolvedTextColor,
+			};
 		},
 	},
 
 	render(createElement) {
-		const { $s, stringSize, element } = this;
+		const {
+			$s,
+			sizeClass,
+			element,
+			inlineStyles,
+		} = this;
 		/**
 		 * @slot text content
 		 */
 		const defaultSlot = this.$slots.default;
 		return createElement(element, {
-			class: [$s.Paragraph, $s[`size_${stringSize}`]],
+			class: [$s.Paragraph, $s[`size_${sizeClass}`]],
 			attrs: this.$attrs,
+			style: inlineStyles,
 			on: this.$listeners,
 		}, defaultSlot);
 	},

--- a/src/components/Theme/README.md
+++ b/src/components/Theme/README.md
@@ -374,6 +374,82 @@ export default {
 ```vue
 <template>
 	<m-theme :theme="theme">
+		pick default heading color
+		<br>
+		<input
+			v-model="theme.colors.text"
+			type="color"
+		>
+		<br>
+
+		pick default heading font family
+		<br>
+		<select v-model="theme.heading.fontFamily">
+			<option value="inherit">
+				inherit
+			</option>
+			<option value="arial">
+				arial
+			</option>
+			<option value="serif">
+				serif
+			</option>
+			<option value="sans-serif">
+				sans-serif
+			</option>
+			<option value="monospace">
+				monospace
+			</option>
+		</select>
+		<br>
+
+		pick default heading size
+		<br>
+		<input
+			v-model="theme.heading.size"
+			type="number"
+			min="-2"
+			max="7"
+		>
+		<br>
+
+		<m-heading>
+			heading content
+		</m-heading>
+	</m-theme>
+</template>
+
+<script>
+import { MTheme } from '@square/maker/components/Theme';
+import { MHeading } from '@square/maker/components/Heading';
+
+export default {
+	components: {
+		MTheme,
+		MHeading,
+	},
+	data() {
+		return {
+			theme: {
+				colors: {
+					text: '#000000',
+				},
+				heading: {
+					fontFamily: 'inherit',
+					size: 2,
+				},
+			},
+		};
+	},
+};
+</script>
+```
+
+<br>
+
+```vue
+<template>
+	<m-theme :theme="theme">
 		pick default text color
 		<br>
 		<input
@@ -414,7 +490,7 @@ export default {
 		<br>
 
 		<m-text>
-			{{ JSON.stringify($data) }} text content
+			text content
 		</m-text>
 	</m-theme>
 </template>

--- a/src/components/Theme/README.md
+++ b/src/components/Theme/README.md
@@ -369,6 +369,82 @@ export default {
 </style>
 ```
 
+## Theming Headings & Texts
+
+```vue
+<template>
+	<m-theme :theme="theme">
+		pick default text color
+		<br>
+		<input
+			v-model="theme.colors.text"
+			type="color"
+		>
+		<br>
+
+		pick default text font family
+		<br>
+		<select v-model="theme.text.fontFamily">
+			<option value="inherit">
+				inherit
+			</option>
+			<option value="arial">
+				arial
+			</option>
+			<option value="serif">
+				serif
+			</option>
+			<option value="sans-serif">
+				sans-serif
+			</option>
+			<option value="monospace">
+				monospace
+			</option>
+		</select>
+		<br>
+
+		pick default text size
+		<br>
+		<input
+			v-model="theme.text.size"
+			type="number"
+			min="-1"
+			max="1"
+		>
+		<br>
+
+		<m-text>
+			{{ JSON.stringify($data) }} text content
+		</m-text>
+	</m-theme>
+</template>
+
+<script>
+import { MTheme } from '@square/maker/components/Theme';
+import { MText } from '@square/maker/components/Text';
+
+export default {
+	components: {
+		MTheme,
+		MText,
+	},
+	data() {
+		return {
+			theme: {
+				colors: {
+					text: '#000000',
+				},
+				text: {
+					fontFamily: 'inherit',
+					size: 0,
+				},
+			},
+		};
+	},
+};
+</script>
+```
+
 ## Customizing the theme within subsets of the app
 
 Theme components can be nested, and when nested the child Theme can override its parent Theme in two ways:

--- a/src/components/Theme/src/Theme.vue
+++ b/src/components/Theme/src/Theme.vue
@@ -34,7 +34,7 @@ export default {
 	props: {
 		theme: {
 			type: Object,
-			required: true,
+			default: () => ({}),
 		},
 		profile: {
 			type: String,

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -4,6 +4,7 @@ export default function defaultTheme() {
 	return {
 		colors: {
 			primary: '#000000',
+			text: '#000000',
 		},
 		profiles: [
 			{
@@ -25,6 +26,11 @@ export default function defaultTheme() {
 			textColor: undefined,
 			fullWidth: false,
 			align: 'center',
+		},
+		text: {
+			textColor: '@colors.text',
+			fontFamily: 'inherit',
+			size: 0,
 		},
 		resolve,
 		getPath,

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -32,6 +32,11 @@ export default function defaultTheme() {
 			fontFamily: 'inherit',
 			size: 0,
 		},
+		heading: {
+			textColor: '@colors.text',
+			fontFamily: 'inherit',
+			size: 0,
+		},
 		resolve,
 		getPath,
 	};


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
MHeading and MText are not very themeable.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
Adds `textColor` and `fontFamily` to MHeading and MText components as themeable props. Also makes the existing `size`  prop on those components themeable.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
nope