### PR TITLE
feat(stepper): makes color & textColor props themeable

### DIFF
--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -6,8 +6,8 @@
 			shape="pill"
 			variant="primary"
 			size="small"
-			:color="color"
-			:text-color="textColor"
+			:color="resolvedColor"
+			:text-color="resolvedTextColor"
 			:disabled="value === minVal"
 			@click="decrement"
 		>
@@ -20,8 +20,8 @@
 			shape="pill"
 			variant="primary"
 			size="small"
-			:color="color"
-			:text-color="textColor"
+			:color="resolvedColor"
+			:text-color="resolvedTextColor"
 			:disabled="value === maxVal"
 			@click="increment"
 		>
@@ -31,6 +31,8 @@
 </template>
 
 <script>
+import chroma from 'chroma-js';
+import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
 import { MButton } from '@square/maker/components/Button';
 import Plus from '@square/maker-icons/Plus';
 import Minus from '@square/maker-icons/Minus';
@@ -40,6 +42,13 @@ export default {
 		MButton,
 		Plus,
 		Minus,
+	},
+
+	inject: {
+		theme: {
+			default: defaultTheme(),
+			from: MThemeKey,
+		},
 	},
 
 	inheritAttrs: false,
@@ -76,18 +85,22 @@ export default {
 		 */
 		color: {
 			type: String,
-			default: '#cccccc',
+			default: undefined,
+			validator: (color) => chroma.valid(color),
 		},
 		/**
 		 * stepper button text color
 		 */
 		textColor: {
 			type: String,
-			default: '#000000',
+			default: undefined,
+			validator: (color) => chroma.valid(color),
 		},
 	},
 
 	computed: {
+		...resolveThemeableProps('stepper', ['color', 'textColor']),
+
 		maxVal() {
 			return Number.parseInt(this.max, 10);
 		},

--- a/src/components/Theme/README.md
+++ b/src/components/Theme/README.md
@@ -521,6 +521,60 @@ export default {
 </script>
 ```
 
+## Theming Steppers
+
+```vue
+<template>
+	<m-theme :theme="theme">
+		pick default stepper color
+		<br>
+		<input
+			v-model="theme.stepper.color"
+			type="color"
+		>
+		<br>
+
+		pick default stepper text color
+		<br>
+		<input
+			v-model="theme.stepper.textColor"
+			type="color"
+		>
+		<br>
+
+		<m-stepper
+			v-model="number"
+			min="0"
+			max="10"
+		/>
+		stepper number: {{ number }}
+	</m-theme>
+</template>
+
+<script>
+import { MTheme } from '@square/maker/components/Theme';
+import { MStepper } from '@square/maker/components/Stepper';
+
+export default {
+	components: {
+		MTheme,
+		MStepper,
+	},
+	data() {
+		return {
+			number: 5,
+			theme: {
+				stepper: {
+					color: '#cccccc',
+					textColor: '#000000',
+				},
+			},
+		};
+	},
+};
+</script>
+```
+
 ## Customizing the theme within subsets of the app
 
 Theme components can be nested, and when nested the child Theme can override its parent Theme in two ways:

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -38,6 +38,10 @@ export default function defaultTheme() {
 			fontFamily: 'inherit',
 			size: 2,
 		},
+		stepper: {
+			color: '#cccccc',
+			textColor: '#000000',
+		},
 		resolve,
 		getPath,
 	};


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
stepper was not themeable

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
makes `color` and `textColor` prop on stepper themeable

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
nope