### PR TITLE
feat(modal): add drag/swipe to dismiss on mobile modals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
 			ignoreArrayIndexes: true,
 			ignoreDefaultValues: true,
 			enforceConst: true,
+			ignore: [0],
 		}],
 
 		// As a library, dependencies are packaged in and can be in devDeps

--- a/lab/experiments/ActionBarTest.vue
+++ b/lab/experiments/ActionBarTest.vue
@@ -1,8 +1,10 @@
 <template>
-	<m-action-bar-layer>
-		<router-view />
+	<div>
+		<m-action-bar-layer>
+			<router-view />
+		</m-action-bar-layer>
 		<m-modal-layer />
-	</m-action-bar-layer>
+	</div>
 </template>
 
 <script>

--- a/lab/experiments/ActionBarTest/CartModal.vue
+++ b/lab/experiments/ActionBarTest/CartModal.vue
@@ -1,10 +1,14 @@
 <template>
 	<m-modal>
-		<div class="cover-photo">
-			<m-image
-				src="https://i.picsum.photos/id/507/900/900.jpg?hmac=NDltE7xXtFlZjUoyDqGjehzY5ORPtj4-d42qbFgAFkk"
-			/>
-		</div>
+		<template
+			#dismiss
+		>
+			<div class="cover-photo">
+				<m-image
+					src="https://i.picsum.photos/id/507/900/900.jpg?hmac=NDltE7xXtFlZjUoyDqGjehzY5ORPtj4-d42qbFgAFkk"
+				/>
+			</div>
+		</template>
 
 		<div>
 			<h1>Cart modal content</h1>

--- a/lab/experiments/ActionBarTest/CartModal.vue
+++ b/lab/experiments/ActionBarTest/CartModal.vue
@@ -3,23 +3,36 @@
 		<template
 			#dismiss
 		>
-			<div class="cover-photo">
+			<div
+				v-if="showImage"
+				class="cover-photo"
+			>
 				<m-image
 					src="https://i.picsum.photos/id/507/900/900.jpg?hmac=NDltE7xXtFlZjUoyDqGjehzY5ORPtj4-d42qbFgAFkk"
 				/>
 			</div>
-		</template>
-
-		<div>
-			<h1>Cart modal content</h1>
-			<div
-				v-for="i in 100"
-				:key="i"
+			<m-segmented-control
+				v-else
+				v-model="selected"
 			>
-				Long text {{ i }}
-			</div>
+				<m-segment value="short">
+					Local Delivery
+				</m-segment>
+				<m-segment value="medium">
+					Pickup
+				</m-segment>
+				<m-segment value="long">
+					Ship
+				</m-segment>
+			</m-segmented-control>
+			<h2>Cart modal content</h2>
+		</template>
+		<div
+			v-for="i in 100"
+			:key="i"
+		>
+			Long text {{ i }}
 		</div>
-
 		<m-inline-action-bar>
 			<m-action-bar-button
 				key="close"
@@ -47,6 +60,7 @@
 import { MModal, modalApi } from '@square/maker/components/Modal';
 import { MInlineActionBar, MActionBarButton } from '@square/maker/components/ActionBar';
 import { MImage } from '@square/maker/components/Image';
+import { MSegmentedControl, MSegment } from '@square/maker/components/SegmentedControl';
 import X from '@square/maker-icons/X';
 
 export default {
@@ -54,11 +68,27 @@ export default {
 		MModal,
 		MInlineActionBar,
 		MActionBarButton,
+		MSegmentedControl,
+		MSegment,
 		MImage,
 		X,
 	},
+
 	inject: {
 		modalApi,
+	},
+
+	props: {
+		showImage: {
+			type: Boolean,
+			default: true,
+		},
+	},
+
+	data() {
+		return {
+			selected: 'short',
+		};
 	},
 };
 </script>

--- a/lab/experiments/ActionBarTest/index.vue
+++ b/lab/experiments/ActionBarTest/index.vue
@@ -1,12 +1,15 @@
 <template>
 	<div>
 		<h1>root index</h1>
+		<button @click="openCart(false)">
+			Open modal without image
+		</button>
 		<m-action-bar>
 			<m-action-bar-button
 				key="primary"
 				align="center"
 				full-width
-				@click="openCart"
+				@click="openCart(true)"
 			>
 				View Cart
 				<template #information>
@@ -33,8 +36,12 @@ export default {
 	},
 
 	methods: {
-		openCart() {
-			this.modalApi.open(() => <CartModal />);
+		openCart(showImage) {
+			this.modalApi.open((h) => h(CartModal, {
+				props: {
+					showImage,
+				},
+			}));
 		},
 	},
 };

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -1,15 +1,43 @@
 <template>
-	<div :class="$s.Modal">
+	<div
+		:class="$s.Modal"
+		:style="modalStyles"
+	>
+		<template v-if="$slots.dismiss">
+			<m-touch-capture
+				:class="$s.DismissMobile"
+				@on-drag-down="onDragDown"
+				@on-drag-end="onDragEnd"
+				@on-swipe-down="onSwipeDown"
+			>
+				<slot name="dismiss" />
+			</m-touch-capture>
+			<div :class="$s.DismissDesktop">
+				<slot name="dismiss" />
+			</div>
+		</template>
 		<!-- @slot Modal content -->
 		<slot />
+		<m-touch-capture
+			v-if="!$slots.dismiss"
+			:class="$s.Dismiss"
+			@on-drag-down="onDragDown"
+			@on-drag-end="onDragEnd"
+			@on-swipe-down="onSwipeDown"
+		/>
 	</div>
 </template>
 
 <script>
+import { MTouchCapture } from '@square/maker/components/TouchCapture';
 import modalApi from './modal-api';
 
 export default {
 	name: 'Modal',
+
+	components: {
+		MTouchCapture,
+	},
 
 	inject: {
 		modalApi,
@@ -26,12 +54,42 @@ export default {
 		},
 	},
 
+	data() {
+		return {
+			modalStyles: {},
+		};
+	},
+
 	watch: {
 		beforeClose: {
 			immediate: true,
 			handler(hook) {
 				this.modalApi.state.options.beforeCloseHook = hook;
 			},
+		},
+	},
+
+	methods: {
+		onSwipeDown() {
+			this.modalApi.close();
+		},
+
+		onDragDown(gesture) {
+			const transform = `translateY(${gesture.changeY}px)`;
+			this.modalStyles = {
+				transform,
+				'backface-visibility': 'hidden',
+				overflow: 'hidden',
+			};
+		},
+
+		onDragEnd(gesture) {
+			const minDragCloseDistance = 100;
+			if (gesture.changeY > minDragCloseDistance) {
+				this.modalApi.close();
+			} else {
+				this.modalStyles = {};
+			}
 		},
 	},
 };
@@ -42,6 +100,21 @@ export default {
 	height: 100%;
 	overflow: scroll;
 	background: #f5f6f7;
+	transition: transform 0.2s linear;
+}
+
+@media screen and (max-width: 839px) {
+	.Dismiss {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100px;
+	}
+
+	.DismissDesktop {
+		display: none;
+	}
 }
 
 @media screen and (min-width: 840px) {
@@ -49,6 +122,10 @@ export default {
 		width: 600px;
 		min-height: 180px;
 		max-height: calc(100vh - 64px);
+	}
+
+	.DismissMobile {
+		display: none;
 	}
 }
 </style>

--- a/src/components/TouchCapture/index.js
+++ b/src/components/TouchCapture/index.js
@@ -1,0 +1,1 @@
+export { default as MTouchCapture } from './src/TouchCapture.vue';

--- a/src/components/TouchCapture/src/TouchCapture.vue
+++ b/src/components/TouchCapture/src/TouchCapture.vue
@@ -1,0 +1,158 @@
+<template>
+	<div
+		@touchstart="touchEvent"
+		@touchmove="touchEvent"
+		@touchend="touchEvent"
+	>
+		<slot />
+	</div>
+</template>
+
+<script>
+import { throttle } from 'lodash';
+
+const eventThrottle = 50;
+const touchPointsDrag = 1;
+const touchPointsSwipe = 1;
+const initialValues = {
+	touchStarted: false,
+	touchEnded: false,
+	touchPoints: 0,
+	timeStart: 0,
+	clientXStart: 0,
+	clientYStart: 0,
+	clientXCurrent: 0,
+	clientYCurrent: 0,
+	timeCurrent: 0,
+};
+
+export default {
+	name: 'TouchCapture',
+
+	props: {
+		minDragDistance: {
+			type: Number,
+			default: 10,
+		},
+		minDragDuration: {
+			type: Number,
+			default: 100,
+		},
+		minSwipeDistance: {
+			type: Number,
+			default: 30,
+		},
+		maxSwipeDuration: {
+			type: Number,
+			default: 400,
+		},
+	},
+
+	data() {
+		return {
+			...initialValues,
+			touchEvent: throttle(this.handleTouchEvent, eventThrottle),
+		};
+	},
+
+	computed: {
+		timeElapsed() {
+			return this.timeCurrent - this.timeStart;
+		},
+
+		changeY() {
+			return Math.round(this.clientYCurrent - this.clientYStart);
+		},
+
+		changeX() {
+			return Math.round(this.clientXCurrent - this.clientXStart);
+		},
+
+		direction() {
+			const { changeY, changeX } = this;
+			if (Math.abs(changeY) > Math.abs(changeX)) {
+				return changeY < 0 ? 'up' : 'down';
+			}
+			return changeX < 0 ? 'left' : 'right';
+		},
+
+		gesture() {
+			const { changeY, changeX } = this;
+			return {
+				changeX,
+				changeY,
+			};
+		},
+
+		isDragGesture() {
+			if (this.touchPoints !== touchPointsDrag) {
+				return false;
+			}
+			return this.timeElapsed > this.minDragDuration
+				&& (Math.abs(this.changeY) > this.minDragDistance
+				|| Math.abs(this.changeX) > this.minDragDistance);
+		},
+
+		isSwipeGesture() {
+			if (this.touchPoints !== touchPointsSwipe) {
+				return false;
+			}
+			return this.timeElapsed > this.minSwipeDuration
+				&& (Math.abs(this.changeY) > this.minSwipeDistance
+				|| Math.abs(this.changeX) > this.minSwipeDistance);
+		},
+	},
+
+	watch: {
+		touchEnded(completed) {
+			if (completed) {
+				if (this.isSwipeGesture) {
+					this.$emit(`on-swipe-${this.direction}`, this.gesture);
+				} else if (this.isDragGesture) {
+					this.$emit('on-drag-end', this.gesture);
+				}
+				this.resetGesture();
+			}
+		},
+		timeCurrent() {
+			if (this.isDragGesture) {
+				this.$emit(`on-drag-${this.direction}`, this.gesture);
+			}
+		},
+	},
+
+	methods: {
+		handleTouchEvent(event) {
+			switch (event.type) {
+			case 'touchstart':
+				this.touchStarted = true;
+				this.clientYStart = event.changedTouches[0].clientY;
+				this.clientXStart = event.changedTouches[0].clientX;
+				this.timeStart = event.timeStamp;
+				this.touchPoints = event.changedTouches.length;
+				break;
+			case 'touchmove':
+				this.clientYCurrent = event.changedTouches[0].clientY;
+				this.clientXCurrent = event.changedTouches[0].clientX;
+				this.timeCurrent = event.timeStamp;
+				this.touchPoints = event.changedTouches.length;
+				break;
+			case 'touchend':
+				this.clientYCurrent = event.changedTouches[0].clientY;
+				this.clientXCurrent = event.changedTouches[0].clientX;
+				this.timeCurrent = event.timeStamp;
+				this.touchEnded = true;
+				break;
+			default:
+				break;
+			}
+		},
+
+		resetGesture() {
+			Object.entries(initialValues).forEach(([key, value]) => {
+				this[key] = value;
+			});
+		},
+	},
+};
+</script>


### PR DESCRIPTION
PR for drag/swipe to dismiss functionality on mobile modals as prototyped below.

- Modal is only swipe/draggable in mobile
- `on-swipe-down` is a single point touch event, min 30px in distance, max 300ms in duration. It closes the Modal
- `on-drag-down` is a single point touch even
- `on-drag-end` is the end of a drag event. Modal closes if it's been dragged more than 30% client height. Otherwise it bounces back into place.
- Touch to dismiss events only work when Modal is scrolled to the top. When modal is scrolled up/down, there's a 800ms delay before dismiss events are active again.
- The distance/timing thresholds  swipe events can be adjusted, as can the minimum drag to close

Design:
![screencast 2021-10-06 11-24-20](https://user-images.githubusercontent.com/1486885/140580095-cafb3842-2958-4089-b918-2eca2a92fe66.gif)
Lab:
https://square.github.io/maker/lab/swipe-dismiss/#/ActionBarTest
