### PR TITLE
feat(inline-action-bar): delayed spring transition

### DIFF
--- a/lab/experiments/ActionBarTransition.vue
+++ b/lab/experiments/ActionBarTransition.vue
@@ -1,0 +1,31 @@
+<template>
+	<div>
+		<m-action-bar-layer>
+			<router-view />
+		</m-action-bar-layer>
+		<m-modal-layer />
+	</div>
+</template>
+
+<script>
+import { MActionBarLayer } from '@square/maker/components/ActionBar';
+import { MModalLayer } from '@square/maker/components/Modal';
+
+export default {
+	components: {
+		MActionBarLayer,
+		MModalLayer,
+	},
+
+	mixins: [
+		MModalLayer.apiMixin,
+	],
+};
+</script>
+
+<style>
+html,
+body {
+	font-family: "Square Market", system-ui;
+}
+</style>

--- a/lab/experiments/ActionBarTransition/ItemModal.vue
+++ b/lab/experiments/ActionBarTransition/ItemModal.vue
@@ -17,54 +17,63 @@
 			</div>
 		</m-container>
 
-		<m-inline-action-bar
-			:enter-animation="springUpFn"
-			:leave-animation="springDownFn"
-			:enter-delay="enterDelay"
-		>
-			<m-action-bar-button
-				key="close"
-				color="#f6f6f6"
-				@click="modalApi.close()"
+		<div :class="$s.ActionBarWrapper">
+			<m-transition
+				:enter="springUpFn"
+				:leave="springDownFn"
 			>
-				<x class="icon" />
-			</m-action-bar-button>
-			<m-action-bar-button
-				key="primary"
-				align="center"
-				full-width
-				@click="modalApi.close()"
-			>
-				Add to Cart
-				<template #information>
-					$10.00
-				</template>
-			</m-action-bar-button>
-		</m-inline-action-bar>
+				<atomic-action-bar
+					v-if="loaded"
+					v-bind="$attrs"
+					v-on="$listeners"
+				>
+					<m-action-bar-button
+						key="close"
+						color="#f6f6f6"
+						@click="modalApi.close()"
+					>
+						<x class="icon" />
+					</m-action-bar-button>
+					<m-action-bar-button
+						key="primary"
+						align="center"
+						full-width
+						@click="modalApi.close()"
+					>
+						Add to Cart
+						<template #information>
+							$10.00
+						</template>
+					</m-action-bar-button>
+				</atomic-action-bar>
+			</m-transition>
+		</div>
 	</m-modal>
 </template>
 
 <script>
 import { MModal, modalApi } from '@square/maker/components/Modal';
-import { MInlineActionBar, MActionBarButton } from '@square/maker/components/ActionBar';
+import { MActionBarButton } from '@square/maker/components/ActionBar';
 import { MContainer } from '@square/maker/components/Container';
 import { MImage } from '@square/maker/components/Image';
+import { MTransition } from '@square/maker/utils/Transition';
 import X from '@square/maker-icons/X';
-
 import styler from 'stylefire';
 import { animate } from 'popmotion';
 import {
 	styleFactory, animateUp, animateDown,
 } from '@square/maker/utils/transitions';
+import AtomicActionBar from '../../../src/components/ActionBar/src/AtomicActionBar.vue';
 
 export default {
 	components: {
 		MModal,
-		MInlineActionBar,
 		MActionBarButton,
 		MImage,
 		MContainer,
 		X,
+		MTransition,
+		AtomicActionBar,
 	},
 
 	inject: {
@@ -133,7 +142,14 @@ export default {
 					onComplete,
 				});
 			},
+			loaded: false,
 		};
+	},
+
+	mounted() {
+		setTimeout(() => {
+			this.loaded = true;
+		}, this.enterDelay);
 	},
 };
 </script>
@@ -151,5 +167,38 @@ export default {
 .icon {
 	width: 16px;
 	height: 16px;
+}
+</style>
+
+<style module="$s">
+.ActionBarWrapper {
+	--regular-bottom-padding: 32px;
+	--extra-bottom-padding-for-deadclick: 32px;
+	--safe-area-inset-padding: env(safe-area-inset-bottom, 0);
+	--actionbar-bottom-padding:
+		calc(
+			var(--regular-bottom-padding)
+			+ var(--extra-bottom-padding-for-deadclick)
+			+ var(--safe-area-inset-padding)
+		);
+	--actionbar-size: 64px;
+	--actionbar-top-padding: 32px;
+
+	padding-bottom:
+		calc(
+			var(--actionbar-top-padding)
+			+ var(--actionbar-size)
+			+ var(--actionbar-bottom-padding)
+		);
+}
+
+@media screen and (min-width: 840px) {
+	.ActionBarWrapper {
+		--actionbar-size: 48px;
+		--actionbar-top-padding: 24px;
+
+		/* no safe-area or deadclick issues on non-mobile resolutions */
+		--actionbar-bottom-padding: var(--regular-bottom-padding);
+	}
 }
 </style>

--- a/lab/experiments/ActionBarTransition/ItemModal.vue
+++ b/lab/experiments/ActionBarTransition/ItemModal.vue
@@ -1,0 +1,155 @@
+<template>
+	<m-modal>
+		<div class="cover-photo">
+			<m-image
+				src="https://i.picsum.photos/id/507/900/900.jpg?hmac=NDltE7xXtFlZjUoyDqGjehzY5ORPtj4-d42qbFgAFkk"
+			/>
+		</div>
+		<m-container>
+			<template #label>
+				<h1>Modal with Inline Action Bar</h1>
+			</template>
+			<div
+				v-for="i in 100"
+				:key="i"
+			>
+				Long text {{ i }}
+			</div>
+		</m-container>
+
+		<m-inline-action-bar
+			:enter-animation="springUpFn"
+			:leave-animation="springDownFn"
+			:enter-delay="enterDelay"
+		>
+			<m-action-bar-button
+				key="close"
+				color="#f6f6f6"
+				@click="modalApi.close()"
+			>
+				<x class="icon" />
+			</m-action-bar-button>
+			<m-action-bar-button
+				key="primary"
+				align="center"
+				full-width
+				@click="modalApi.close()"
+			>
+				Add to Cart
+				<template #information>
+					$10.00
+				</template>
+			</m-action-bar-button>
+		</m-inline-action-bar>
+	</m-modal>
+</template>
+
+<script>
+import { MModal, modalApi } from '@square/maker/components/Modal';
+import { MInlineActionBar, MActionBarButton } from '@square/maker/components/ActionBar';
+import { MContainer } from '@square/maker/components/Container';
+import { MImage } from '@square/maker/components/Image';
+import X from '@square/maker-icons/X';
+
+import styler from 'stylefire';
+import { animate } from 'popmotion';
+import {
+	styleFactory, animateUp, animateDown,
+} from '@square/maker/utils/transitions';
+
+export default {
+	components: {
+		MModal,
+		MInlineActionBar,
+		MActionBarButton,
+		MImage,
+		MContainer,
+		X,
+	},
+
+	inject: {
+		modalApi,
+	},
+
+	inheritAttrs: false,
+
+	props: {
+		enterDelay: {
+			type: Number,
+			default: undefined,
+		},
+		springStiffness: {
+			type: Number,
+			default: undefined,
+		},
+		springDamping: {
+			type: Number,
+			default: undefined,
+		},
+		springMass: {
+			type: Number,
+			default: undefined,
+		},
+	},
+
+	data() {
+		// eslint-disable-next-line no-magic-numbers
+		const toRelativeY = styleFactory(0, 100, 'y', '%');
+
+		return {
+			springUpFn: ({ element, onComplete }) => {
+				const elementStyler = styler(element);
+				const styleFn = toRelativeY;
+				const animationDirection = animateDown;
+				elementStyler.set(styleFn(animationDirection.from));
+				elementStyler.render();
+				animate({
+					...animationDirection,
+					type: 'spring',
+					stiffness: this.springStiffness,
+					damping: this.springDamping,
+					mass: this.springMass,
+					onUpdate(number) {
+						elementStyler.set(styleFn(number));
+					},
+					onComplete,
+				});
+			},
+			springDownFn: ({ element, onComplete }) => {
+				const elementStyler = styler(element);
+				const styleFn = toRelativeY;
+				const animationDirection = animateUp;
+				elementStyler.set(styleFn(animationDirection.from));
+				elementStyler.render();
+				animate({
+					...animationDirection,
+					type: 'spring',
+					stiffness: this.springStiffness,
+					damping: this.springDamping,
+					mass: this.springMass,
+					onUpdate(number) {
+						elementStyler.set(styleFn(number));
+					},
+					onComplete,
+				});
+			},
+		};
+	},
+};
+</script>
+
+<style scoped>
+.cover-photo {
+	width: 100%;
+	height: 280px;
+}
+
+.image {
+	width: 100%;
+}
+
+.icon {
+	width: 16px;
+	height: 16px;
+}
+</style>

--- a/lab/experiments/ActionBarTransition/index.vue
+++ b/lab/experiments/ActionBarTransition/index.vue
@@ -1,0 +1,149 @@
+<template>
+	<m-container>
+		<h1>Action bar test</h1>
+		<p>To preview the persistent action bar, please view this page in a mobile browser.</p>
+		<p>
+			Otherwise
+			<button @click="openCart">
+				Click here
+			</button>
+			to open the item modal.
+		</p>
+
+		<div :class="$s.Controls">
+			<h4>Delay (milliseconds)</h4>
+			<m-segmented-control
+				v-model="enterDelay"
+				size="small"
+			>
+				<m-segment
+					v-for="i in 8"
+					:key="i"
+					:value="i * 100"
+				>
+					{{ i * 100 }}
+				</m-segment>
+			</m-segmented-control>
+			<h4>Stiffness</h4>
+			<p>A higher stiffness will result in a snappier animation.</p>
+			<m-segmented-control
+				v-model="springStiffness"
+				size="small"
+			>
+				<m-segment
+					v-for="i in 10"
+					:key="i"
+					:value="i * 100"
+				>
+					{{ i * 100 }}
+				</m-segment>
+			</m-segmented-control>
+			<h4>Damping</h4>
+			<p>
+				This is the opposing force to stiffness.
+				As you reduce this value, relative to stiffness,
+				the spring will become bouncier and the animation
+				will last longer. Likewise, higher relative values will
+				have less bounciness and result in shorter animations.
+			</p>
+			<m-segmented-control
+				v-model="springDamping"
+				size="small"
+			>
+				<m-segment
+					v-for="i in 10"
+					:key="i"
+					:value="i * 10"
+				>
+					{{ i * 10 }}
+				</m-segment>
+			</m-segmented-control>
+			<h4>Mass</h4>
+			<p>
+				This is the mass of the animating object.
+				Heavier objects will take longer to speed up and slow down.
+			</p>
+			<m-segmented-control
+				v-model="springMass"
+				size="small"
+			>
+				<m-segment
+					v-for="i in 10"
+					:key="i"
+					:value="i / 2"
+				>
+					{{ i / 2 }}
+				</m-segment>
+			</m-segmented-control>
+		</div>
+		<m-action-bar>
+			<m-action-bar-button
+				key="primary"
+				align="center"
+				full-width
+				@click="openCart"
+			>
+				View Cart
+				<template #information>
+					3 items
+				</template>
+			</m-action-bar-button>
+		</m-action-bar>
+	</m-container>
+</template>
+
+<script>
+
+import { modalApi } from '@square/maker/components/Modal';
+import { MActionBar, MActionBarButton } from '@square/maker/components/ActionBar';
+import { MContainer } from '@square/maker/components/Container';
+import { MSegmentedControl, MSegment } from '@square/maker/components/SegmentedControl';
+import ItemModal from './ItemModal.vue';
+
+export default {
+	components: {
+		MActionBar,
+		MActionBarButton,
+		MContainer,
+		MSegmentedControl,
+		MSegment,
+	},
+
+	inject: {
+		modalApi,
+	},
+
+	data() {
+		return {
+			enterDelay: 800,
+			springStiffness: 400,
+			springDamping: 30,
+			springMass: 2,
+		};
+	},
+
+	methods: {
+
+		openCart() {
+			this.modalApi.open((h) => h(
+				ItemModal,
+				{
+					props: {
+						enterDelay: this.enterDelay,
+						springStiffness: this.springStiffness,
+						springDamping: this.springDamping,
+						springMass: this.springMass,
+					},
+				},
+			));
+		},
+	},
+};
+</script>
+
+<style module="$s">
+.Controls {
+	padding: 16px 24px 36px;
+	background: #fff;
+}
+</style>

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -1,16 +1,23 @@
 <template>
 	<div :class="$s.ActionBarWrapper">
-		<atomic-action-bar
-			v-bind="$attrs"
-			v-on="$listeners"
+		<m-transition
+			:enter="enterAnimation"
+			:leave="leaveAnimation"
 		>
-			<!-- @slot ActionBar items -->
-			<slot />
-		</atomic-action-bar>
+			<atomic-action-bar
+				v-if="loaded"
+				v-bind="$attrs"
+				v-on="$listeners"
+			>
+				<slot />
+			</atomic-action-bar>
+		</m-transition>
 	</div>
 </template>
 
 <script>
+import { MTransition } from '@square/maker/utils/Transition';
+import { springUpBounceFn, springDownBounceFn } from '@square/maker/utils/transitions';
 import AtomicActionBar from './AtomicActionBar.vue';
 
 /**
@@ -21,9 +28,37 @@ import AtomicActionBar from './AtomicActionBar.vue';
 export default {
 	components: {
 		AtomicActionBar,
+		MTransition,
 	},
 
 	inheritAttrs: false,
+
+	props: {
+		enterAnimation: {
+			type: Function,
+			default: springUpBounceFn,
+		},
+		leaveAnimation: {
+			type: Function,
+			default: springDownBounceFn,
+		},
+		enterDelay: {
+			type: Number,
+			default: 800,
+		},
+	},
+
+	data() {
+		return {
+			loaded: false,
+		};
+	},
+
+	mounted() {
+		setTimeout(() => {
+			this.loaded = !!this.$slots.default;
+		}, this.enterDelay);
+	},
 };
 </script>
 

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -1,8 +1,8 @@
 <template>
 	<div :class="$s.ActionBarWrapper">
 		<m-transition
-			:enter="enterAnimation"
-			:leave="leaveAnimation"
+			:enter="springUpBounceFn"
+			:leave="springDownBounceFn"
 		>
 			<atomic-action-bar
 				v-if="loaded"
@@ -33,31 +33,19 @@ export default {
 
 	inheritAttrs: false,
 
-	props: {
-		enterAnimation: {
-			type: Function,
-			default: springUpBounceFn,
-		},
-		leaveAnimation: {
-			type: Function,
-			default: springDownBounceFn,
-		},
-		enterDelay: {
-			type: Number,
-			default: 800,
-		},
-	},
-
 	data() {
 		return {
 			loaded: false,
+			springUpBounceFn,
+			springDownBounceFn,
 		};
 	},
 
 	mounted() {
+		const enterDelay = 800;
 		setTimeout(() => {
 			this.loaded = !!this.$slots.default;
-		}, this.enterDelay);
+		}, enterDelay);
 	},
 };
 </script>

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -19,6 +19,13 @@ export const spring = {
 	mass,
 };
 
+export const springBounce = {
+	type,
+	stiffness: 400,
+	damping: 30,
+	mass: 2,
+};
+
 const START_VALUE = 0;
 const END_VALUE = 100;
 const MINI_END_VALUE = 40;
@@ -230,6 +237,38 @@ export function floatDownFn({ element, onComplete }) {
 	animate({
 		...animationDirection,
 		...spring,
+		onUpdate(number) {
+			elementStyler.set(styleFn(number));
+		},
+		onComplete,
+	});
+}
+
+export function springUpBounceFn({ element, onComplete }) {
+	const elementStyler = styler(element);
+	const styleFn = toRelativeY;
+	const animationDirection = animateDown;
+	elementStyler.set(styleFn(animationDirection.from));
+	elementStyler.render();
+	animate({
+		...animationDirection,
+		...springBounce,
+		onUpdate(number) {
+			elementStyler.set(styleFn(number));
+		},
+		onComplete,
+	});
+}
+
+export function springDownBounceFn({ element, onComplete }) {
+	const elementStyler = styler(element);
+	const styleFn = toRelativeY;
+	const animationDirection = animateUp;
+	elementStyler.set(styleFn(animationDirection.from));
+	elementStyler.render();
+	animate({
+		...animationDirection,
+		...springBounce,
 		onUpdate(number) {
 			elementStyler.set(styleFn(number));
 		},


### PR DESCRIPTION
## Describe the problem this PR addresses
This PR adds a delayed bouncy spring up transition to the inline action bar, as well as a lab experiment to preview different delay/stiffness/damping/mass values for the transition.

## Describe the changes in this PR
- `ActionBarTransition`: experiment to demo inline action bar spring transition values
- `transitions`: add  `springUpBounceFn` and `springDownBounceFn` for the new default inline action bar transitions
- `InlineActionbar`: add `enterAnimation`, `leaveAnimation`, and `enterDelay` props

![Nov-09-2021 15-32-36](https://user-images.githubusercontent.com/1486885/141000159-17b9d63f-9c6d-4002-9d0f-2f73557c5133.gif)


