### PR TITLE
fix(actionbar): adjust padding to be 24 and include env inset calc

### DIFF
--- a/src/components/ActionBar/README.md
+++ b/src/components/ActionBar/README.md
@@ -38,7 +38,7 @@ There are 2 versions of ActionBar:
 							key="confirm"
 							full-width
 						>
-							Confirm Action
+							Confirm action
 						</m-action-bar-button>
 					</m-inline-action-bar>
 				</div>
@@ -99,7 +99,7 @@ export default {
 	<m-action-bar-layer class="FixInlineActionBarLayerDemosInStyleguide">
 		<div class="showOnMobile">
 			<button @click="showActionBar = !showActionBar">
-				toggle actionbar
+				Toggle actionbar
 			</button>
 			<demo-action-bar v-if="showActionBar" />
 		</div>
@@ -164,7 +164,7 @@ _DemoActionBar.vue_
 				key="confirm"
 				full-width
 			>
-				Confirm Action
+				Confirm action
 			</m-action-bar-button>
 		</m-action-bar>
 	</div>

--- a/src/components/ActionBar/README.md
+++ b/src/components/ActionBar/README.md
@@ -38,7 +38,7 @@ There are 2 versions of ActionBar:
 							key="confirm"
 							full-width
 						>
-							Confirm or whatever
+							Confirm Action
 						</m-action-bar-button>
 					</m-inline-action-bar>
 				</div>
@@ -164,7 +164,7 @@ _DemoActionBar.vue_
 				key="confirm"
 				full-width
 			>
-				Confirm or whatever
+				Confirm Action
 			</m-action-bar-button>
 		</m-action-bar>
 	</div>

--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -81,17 +81,9 @@ export default {
 
 <style module="$s">
 .ActionBarLayer {
-	--regular-bottom-padding: 32px;
-	--extra-bottom-padding-for-deadclick: 32px;
-	--safe-area-inset-padding: env(safe-area-inset-bottom, 0);
-	--actionbar-bottom-padding:
-		calc(
-			var(--regular-bottom-padding)
-			+ var(--extra-bottom-padding-for-deadclick)
-			+ var(--safe-area-inset-padding)
-		);
+	--actionbar-top-padding: 24px;
 	--actionbar-size: 64px;
-	--actionbar-top-padding: 32px;
+	--actionbar-bottom-padding: calc(24px + env(safe-area-inset-bottom));
 
 	padding-bottom:
 		calc(
@@ -101,12 +93,6 @@ export default {
 		);
 
 	&.NoActionBar {
-		padding-bottom: 0;
-	}
-}
-
-@media screen and (min-width: 840px) {
-	.ActionBarLayer {
 		padding-bottom: 0;
 	}
 }

--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -83,7 +83,7 @@ export default {
 .ActionBarLayer {
 	--actionbar-top-padding: 24px;
 	--actionbar-size: 64px;
-	--actionbar-bottom-padding: calc(24px + env(safe-area-inset-bottom));
+	--actionbar-bottom-padding: calc(24px + env(safe-area-inset-bottom, 24px));
 
 	padding-bottom:
 		calc(

--- a/src/components/ActionBar/src/AtomicActionBar.vue
+++ b/src/components/ActionBar/src/AtomicActionBar.vue
@@ -44,6 +44,7 @@ export default {
 	display: flex;
 	justify-content: space-between;
 	box-sizing: border-box;
+	padding: 24px;
 	pointer-events: none;
 }
 

--- a/src/components/ActionBar/src/AtomicActionBar.vue
+++ b/src/components/ActionBar/src/AtomicActionBar.vue
@@ -41,18 +41,9 @@ export default {
 
 <style module="$s">
 .ActionBar {
-	--regular-bottom-padding: 24px;
-	--safe-area-inset-padding: env(safe-area-inset-bottom, 24px);
-	--mobile-bottom-padding:
-		calc(
-			var(--regular-bottom-padding)
-			+ var(--safe-area-inset-padding)
-		);
-
 	display: flex;
 	justify-content: space-between;
 	box-sizing: border-box;
-	padding: 24px 24px var(--mobile-bottom-padding) 24px;
 	pointer-events: none;
 }
 
@@ -65,10 +56,6 @@ export default {
 @media screen and (min-width: 840px) {
 	.hide-on_tablet {
 		display: none;
-	}
-
-	.ActionBar {
-		padding: 24px 24px var(--regular-bottom-padding) 24px;
 	}
 }
 

--- a/src/components/ActionBar/src/AtomicActionBar.vue
+++ b/src/components/ActionBar/src/AtomicActionBar.vue
@@ -41,13 +41,11 @@ export default {
 
 <style module="$s">
 .ActionBar {
-	--regular-bottom-padding: 32px;
-	--extra-bottom-padding-for-deadclick: 32px;
-	--safe-area-inset-padding: env(safe-area-inset-bottom, 0);
+	--regular-bottom-padding: 24px;
+	--safe-area-inset-padding: env(safe-area-inset-bottom, 24px);
 	--mobile-bottom-padding:
 		calc(
 			var(--regular-bottom-padding)
-			+ var(--extra-bottom-padding-for-deadclick)
 			+ var(--safe-area-inset-padding)
 		);
 

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -29,6 +29,6 @@ export default {
 
 <style module="$s">
 .ActionBarWrapper {
-	padding: 24px 24px calc(24px + env(safe-area-inset-bottom)) 24px;
+	padding: 24px 24px calc(24px + env(safe-area-inset-bottom, 24px)) 24px;
 }
 </style>

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -29,33 +29,6 @@ export default {
 
 <style module="$s">
 .ActionBarWrapper {
-	--regular-bottom-padding: 32px;
-	--extra-bottom-padding-for-deadclick: 32px;
-	--safe-area-inset-padding: env(safe-area-inset-bottom, 0);
-	--actionbar-bottom-padding:
-		calc(
-			var(--regular-bottom-padding)
-			+ var(--extra-bottom-padding-for-deadclick)
-			+ var(--safe-area-inset-padding)
-		);
-	--actionbar-size: 64px;
-	--actionbar-top-padding: 32px;
-
-	padding-bottom:
-		calc(
-			var(--actionbar-top-padding)
-			+ var(--actionbar-size)
-			+ var(--actionbar-bottom-padding)
-		);
-}
-
-@media screen and (min-width: 840px) {
-	.ActionBarWrapper {
-		--actionbar-size: 48px;
-		--actionbar-top-padding: 24px;
-
-		/* no safe-area or deadclick issues on non-mobile resolutions */
-		--actionbar-bottom-padding: var(--regular-bottom-padding);
-	}
+	padding: 24px 24px calc(24px + env(safe-area-inset-bottom)) 24px;
 }
 </style>


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
https://github.com/square/maker/issues/169

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
Adjusted padding to be the desirable 24px all the way around (original design intent)
![CleanShot 2021-11-10 at 15 18 28](https://user-images.githubusercontent.com/129122/141209151-1a3d2320-1f43-40f8-8d6e-270f7fe099a8.png)

Simplified the padding calculations with the [env()](https://developer.mozilla.org/en-US/docs/Web/CSS/env())

Added fallbacks in case env isn't supported.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
Previously we had a significant amount of extra padding added to get around the nefarious Safari "deadclick" zone. The usage of the env safe zone should have resolved that, but it looks some of those calculations resulted in roughly the same less than ideal positioning. Tested thoroughly on desktop + mobile on Chrome and Safari. Even did a built test on our PWA version:
![Screen Shot 2021-11-17 at 10 51 09 AM](https://user-images.githubusercontent.com/129122/142284702-702c843f-6e9f-45a3-9bee-8c54994f71b6.png)


