### PR TITLE
feat(transition-staggered): staggered transition group

### DIFF
--- a/lab/experiments/ContentAnimateIn.vue
+++ b/lab/experiments/ContentAnimateIn.vue
@@ -5,7 +5,7 @@
 			:class="$s.ProductGrid"
 		>
 			<div
-				v-for="index in 12"
+				v-for="index in 16"
 				:key="index"
 				:class="$s.Product"
 			>
@@ -19,7 +19,7 @@
 		>
 			<template #default="{ dataLoadIndex }">
 				<div
-					v-for="index in 12"
+					v-for="index in 16"
 					v-show="reveal"
 					:key="index"
 					:data-load-index="dataLoadIndex(index)"

--- a/lab/experiments/ContentAnimateIn.vue
+++ b/lab/experiments/ContentAnimateIn.vue
@@ -30,7 +30,7 @@
 					:src="`https://picsum.photos/600/300?${i}`"
 					height="200px"
 				>
-				<div>This is item number {{ Math.random() }}</div>
+				<div>This is item number {{ i }}</div>
 			</div>
 		</transition-group>
 	</div>

--- a/lab/experiments/ContentAnimateIn.vue
+++ b/lab/experiments/ContentAnimateIn.vue
@@ -1,0 +1,105 @@
+<template>
+	<div :class="$s.ProductLoad">
+		<div :class="$s.ProductGrid">
+			<div
+				v-for="i in 12"
+				v-show="!reveal"
+				:key="i"
+				:class="$s.Product"
+			>
+				<m-skeleton-block :class="$s.ProductImage" />
+				<m-skeleton-text />
+			</div>
+		</div>
+		<transition-group
+			:class="$s.ProductGrid"
+			v-bind="$attrs"
+			tag="div"
+			@enter="handleEnter"
+			@leave="handleLeave"
+		>
+			<div
+				v-for="i in 12"
+				v-show="reveal"
+				:key="i"
+				:data-load-index="[i % columns > 0 ? i % columns : columns]"
+				:class="$s.Product"
+			>
+				<img
+					:class="$s.ProductImage"
+					:src="`https://picsum.photos/600/300?${i}`"
+					height="200px"
+				>
+				<div>This is item number {{ Math.random() }}</div>
+			</div>
+		</transition-group>
+	</div>
+</template>
+
+<script>
+import { MSkeletonBlock, MSkeletonText } from '@square/maker/components/Skeleton';
+import { staggeredFloatUpFn, floatDownFn } from '@square/maker/utils/transitions';
+
+export default {
+	components: {
+		MSkeletonBlock,
+		MSkeletonText,
+	},
+
+	data() {
+		return {
+			columns: 4,
+			reveal: false,
+		};
+	},
+
+	mounted() {
+		const loadDelay = 1000;
+		setTimeout(() => {
+			this.reveal = true;
+		}, loadDelay);
+	},
+
+	methods: {
+		handleEnter(element, onComplete) {
+			staggeredFloatUpFn({ element, onComplete });
+		},
+
+		handleLeave(element, onComplete) {
+			floatDownFn({ element, onComplete });
+		},
+	},
+};
+</script>
+
+<style module="$s">
+.ProductLoad {
+	margin: 0 auto;
+	padding: 24px;
+
+	@media screen and (min-width: 840px) {
+		padding: 48px;
+	}
+}
+
+.ProductGrid {
+	display: flex;
+	flex-wrap: wrap;
+}
+
+.Product {
+	width: 100%;
+	margin: 0 auto 24px;
+
+	@media screen and (min-width: 840px) {
+		width: calc(25% - 24px);
+		margin: 0 12px 24px;
+	}
+}
+
+.ProductImage {
+	width: 100%;
+	height: 200px;
+	margin-bottom: 12px;
+}
+</style>

--- a/lab/experiments/ContentAnimateIn.vue
+++ b/lab/experiments/ContentAnimateIn.vue
@@ -1,55 +1,66 @@
 <template>
 	<div :class="$s.ProductLoad">
-		<div :class="$s.ProductGrid">
+		<div
+			v-show="!reveal"
+			:class="$s.ProductGrid"
+		>
 			<div
-				v-for="i in 12"
-				v-show="!reveal"
-				:key="i"
+				v-for="index in 12"
+				:key="index"
 				:class="$s.Product"
 			>
 				<m-skeleton-block :class="$s.ProductImage" />
 				<m-skeleton-text />
 			</div>
 		</div>
-		<transition-group
+		<m-transition-staggered
+			:stagger-item-count="staggerItemCount"
 			:class="$s.ProductGrid"
-			v-bind="$attrs"
-			tag="div"
-			@enter="handleEnter"
-			@leave="handleLeave"
 		>
-			<div
-				v-for="i in 12"
-				v-show="reveal"
-				:key="i"
-				:data-load-index="[i % columns > 0 ? i % columns : columns]"
-				:class="$s.Product"
-			>
-				<img
-					:class="$s.ProductImage"
-					:src="`https://picsum.photos/600/300?${i}`"
-					height="200px"
+			<template #default="{ dataLoadIndex }">
+				<div
+					v-for="index in 12"
+					v-show="reveal"
+					:key="index"
+					:data-load-index="dataLoadIndex(index)"
+					:class="$s.Product"
 				>
-				<div>This is item number {{ i }}</div>
-			</div>
-		</transition-group>
+					<img
+						:class="$s.ProductImage"
+						:src="`https://picsum.photos/600/300?${index}`"
+						height="200px"
+					>
+					<div>This is item number {{ index }}</div>
+				</div>
+			</template>
+		</m-transition-staggered>
 	</div>
 </template>
 
 <script>
 import { MSkeletonBlock, MSkeletonText } from '@square/maker/components/Skeleton';
-import { staggeredFloatUpFn, floatDownFn } from '@square/maker/utils/transitions';
+import { MTransitionStaggered } from '@square/maker/components/TransitionStaggered';
 
 export default {
 	components: {
 		MSkeletonBlock,
 		MSkeletonText,
+		MTransitionStaggered,
 	},
 
 	data() {
 		return {
-			columns: 4,
 			reveal: false,
+			staggerItemCount: [
+				{
+					minWidth: 0,
+					itemCount: 1,
+				},
+				{
+					minWidth: 840,
+					itemCount: 4,
+				},
+			],
 		};
 	},
 
@@ -58,16 +69,6 @@ export default {
 		setTimeout(() => {
 			this.reveal = true;
 		}, loadDelay);
-	},
-
-	methods: {
-		handleEnter(element, onComplete) {
-			staggeredFloatUpFn({ element, onComplete });
-		},
-
-		handleLeave(element, onComplete) {
-			floatDownFn({ element, onComplete });
-		},
 	},
 };
 </script>

--- a/src/components/TransitionStaggered/index.js
+++ b/src/components/TransitionStaggered/index.js
@@ -1,0 +1,1 @@
+export { default as MTransitionStaggered } from './src/TransitionStaggered.vue';

--- a/src/components/TransitionStaggered/src/TransitionStaggered.vue
+++ b/src/components/TransitionStaggered/src/TransitionStaggered.vue
@@ -1,0 +1,91 @@
+<template>
+	<transition-group
+		v-bind="$attrs"
+		tag="div"
+		@enter="handleEnter"
+		@leave="handleLeave"
+	>
+		<slot
+			:data-load-index="loadIndex"
+		/>
+	</transition-group>
+</template>
+
+<script>
+import { staggeredFloatUpFn, floatDownFn } from '@square/maker/utils/transitions';
+
+const defaultItemCount = [
+	{
+		minWidth: 0,
+		itemCount: 1,
+	},
+];
+
+export default {
+	props: {
+		// Number of items to stagger at a time for a viewport
+		// E.g. [
+		// 	{
+		// 		minWidth: 0,
+		// 		staggerItemCount: 1,
+		// 	},
+		// 	{
+		// 		minWidth: 840,
+		// 		staggerItemCount: 4,
+		// 	},
+		// ]
+		staggerItemCount: {
+			type: Array,
+			default: () => defaultItemCount,
+			validator: (staggerItemCount) => {
+				// cannot be empty
+				if (staggerItemCount.length === 0) {
+					return false;
+				}
+				// must have default catch-all count
+				if (staggerItemCount[0].minWidth !== 0) {
+					return false;
+				}
+				return staggerItemCount.every((itemCount) => (itemCount.minWidth
+					|| itemCount.minWidth === 0)
+					&& itemCount.itemCount);
+			},
+		},
+	},
+
+	data() {
+		return {
+			viewportWidth: 0,
+		};
+	},
+
+	mounted() {
+		this.viewportWidth = window.innerWidth;
+	},
+
+	methods: {
+		handleEnter(element, onComplete) {
+			staggeredFloatUpFn({ element, onComplete });
+		},
+
+		handleLeave(element, onComplete) {
+			floatDownFn({ element, onComplete });
+		},
+
+		loadIndex(index) {
+			const { staggerItemCount, viewportWidth } = this;
+			let items;
+			staggerItemCount.forEach((count) => {
+				if (count.minWidth < viewportWidth) {
+					items = count.itemCount;
+				}
+			});
+			if (items === defaultItemCount[0].itemCount) {
+				return index;
+			}
+			const remainder = index % items;
+			return remainder > 0 ? remainder : items;
+		},
+	},
+};
+</script>

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -22,7 +22,7 @@ export const spring = {
 export const springSubtle = {
 	type,
 	stiffness: 200,
-	damping: 30,
+	damping: 60,
 	mass: 1,
 };
 
@@ -245,7 +245,7 @@ export function staggeredFloatUpFn({ element, onComplete }) {
 	const elementStyler = styler(element);
 	const styleFn = toSubtleFloatyY;
 	const animationDirection = animateUp;
-	const delay = 50;
+	const delay = 125;
 	const staggerDelay = element.dataset.loadIndex * delay;
 	elementStyler.set(styleFn(animationDirection.from));
 	elementStyler.render();

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -19,9 +19,17 @@ export const spring = {
 	mass,
 };
 
+export const springSubtle = {
+	type,
+	stiffness: 200,
+	damping: 30,
+	mass: 1,
+};
+
 const START_VALUE = 0;
 const END_VALUE = 100;
 const MINI_END_VALUE = 40;
+const MICRO_END_VALUE = 20;
 
 export const animateUp = {
 	from: START_VALUE,
@@ -67,9 +75,14 @@ const toOpacity = styleFactory(START_VALUE, END_VALUE, 'opacity', '%');
 const toRelativeY = styleFactory(START_VALUE, END_VALUE, 'y', '%');
 const toRelativeX = styleFactory(START_VALUE, END_VALUE, 'x', '%');
 const toMiniSlideY = styleFactory(MINI_END_VALUE, START_VALUE, 'y', 'px');
+const toMicroSlideY = styleFactory(MICRO_END_VALUE, START_VALUE, 'y', 'px');
 const toFloatyY = (progress) => ({
 	...toOpacity(progress),
 	...toMiniSlideY(progress),
+});
+const toSubtleFloatyY = (progress) => ({
+	...toOpacity(progress),
+	...toMicroSlideY(progress),
 });
 
 export function fadeInFn({ element, onComplete }) {
@@ -219,6 +232,26 @@ export function delayedFloatUpFn({ element, onComplete }) {
 			onComplete,
 		});
 	}, springDelay);
+}
+
+export function staggeredFloatUpFn({ element, onComplete }) {
+	const elementStyler = styler(element);
+	const styleFn = toSubtleFloatyY;
+	const animationDirection = animateUp;
+	const delay = 50;
+	const staggerDelay = element.dataset.loadIndex * delay;
+	elementStyler.set(styleFn(animationDirection.from));
+	elementStyler.render();
+	setTimeout(() => {
+		animate({
+			...animationDirection,
+			...springSubtle,
+			onUpdate(number) {
+				elementStyler.set(styleFn(number));
+			},
+			onComplete,
+		});
+	}, staggerDelay);
 }
 
 export function floatDownFn({ element, onComplete }) {


### PR DESCRIPTION
## Describe the problem this PR addresses
This PR adds a transition group component that allows for staggered list transitions.

## Describe the changes in this PR
- `ContentAnimation`: experiment to demo the staggered transition
- `transitions`: add  `springSubtle`, `toSubtleFloatyY` constants and `staggeredFloatUpFn` for the designed transition that accepts a stagger
- `TransitionStaggered`: transition group component that takes a stagger item count by viewport and passes back a function to calculate the load index.

For a mobile stagger count of 1 item at a time and desktop stagger count of 4 at a time:

![mobile](https://user-images.githubusercontent.com/1486885/142294887-bba07e66-26e8-4575-ba3a-d42651acb55d.gif)

![desktop](https://user-images.githubusercontent.com/1486885/142294902-75fafa3f-0e52-4f29-a50d-99ff0811a94e.gif)


