### PR TITLE
fix(modal): fix modals closing if popover layer is missing

### DIFF
--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -97,7 +97,7 @@ const apiMixin = {
 					// Close the open popover (if present) and then close the modal in the next tick.
 					// Closing at the same time will result in the popover content becoming inline and
 					// causes a weird content shift as the modal fades away.
-					vm.popoverApi.closePopover();
+					vm.popoverApi?.closePopover();
 					vm.$nextTick(() => {
 						vm.currentLayer.state.vnode = undefined;
 					});
@@ -130,7 +130,10 @@ export default {
 	],
 
 	inject: {
-		popoverApi: PopoverAPIKey,
+		popoverApi: {
+			from: PopoverAPIKey,
+			default: undefined,
+		},
 	},
 
 	inheritAttrs: false,


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
This PR fixes an issue where modals would be able to close if a popover layer was not present.

Closes #192 

## Describe the changes in this PR
The fix is to add an optional chaining operator to `vm.popoverApi?.closePopover()` in the modal layer's `close` method, as well as set a default value for `PopoverApiKey` injection in the modal layer.