### PR TITLE
ci: use setup-node with node-version-file

### DIFF
--- a/.github/workflows/deploy-styleguide.yml
+++ b/.github/workflows/deploy-styleguide.yml
@@ -20,14 +20,16 @@ jobs:
           repository: square/maker
           ref: deploys
           path: .dist
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
       - name: Build & deploy
-        shell: bash -e -l {0}
         run: |
           cd .dist
           git config user.name github-actions
           git config user.email github-actions@github.com
           cd ..
-          nvm i
           npm ci
           npm run styleguide-deploy
       - name: Comment Styleguide Deploy link on PR

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -14,10 +14,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
+      - name: Install dependencies
+        run: npm ci
       - name: Lint code
-        shell: bash -e -l {0}
-        run: |
-          nvm i
-          npm ci
-          npm run lint
-          node .github/dep-version-check
+        run: npm run lint
+      - name: Lint package dependencies
+        run: node .github/dep-version-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,28 +10,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Release
-      shell: bash -e -l {0}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      run: |
-        nvm i
-        npm ci
-        npx 'semantic-release@^17.0.0'
-    - name: Checkout nested Maker Repo deploys branch in .dist directory
-      uses: actions/checkout@v2
-      with:
-        repository: square/maker
-        ref: deploys
-        path: .dist
-    - name: Build & deploy styleguide
-      shell: bash -e -l {0}
-      run: |
-        cd .dist
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        cd ..
-        npm run styleguide-deploy
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
+      - name: Install dependencies
+        run: npm ci
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release@17
+      - name: Checkout nested Maker Repo deploys branch in .dist directory
+        uses: actions/checkout@v2
+        with:
+          repository: square/maker
+          ref: deploys
+          path: .dist
+      - name: Build & deploy styleguide
+        run: |
+          cd .dist
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          cd ..
+          npm run styleguide-deploy


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
Previously, GitHub's official Node.js action, `setup-node` did not support reading from `.nvmrc` so we had to use a custom bash instance to use nvm to setup node.

However, they recently added support for  [`node-version-file`](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file) which means we can go back to using `setup-node`.

`setup-node` is GitHub's [official recommendation](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs-or-python#specifying-the-node.js-version) for installing a specific version of Node.js.
## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
- Use `setup-node` with `node-version-file`

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
Will follow up with a dependency caching PR