### PR TITLE
feat(transition-staggered): staggered transition

### DIFF
--- a/lab/experiments/ContentAnimateIn.vue
+++ b/lab/experiments/ContentAnimateIn.vue
@@ -5,7 +5,7 @@
 			:class="$s.ProductGrid"
 		>
 			<div
-				v-for="index in 12"
+				v-for="index in 16"
 				:key="index"
 				:class="$s.Product"
 			>
@@ -19,7 +19,7 @@
 		>
 			<template #default="{ dataLoadIndex }">
 				<div
-					v-for="index in 12"
+					v-for="index in 16"
 					v-show="reveal"
 					:key="index"
 					:data-load-index="dataLoadIndex(index)"

--- a/lab/experiments/ContentAnimateIn.vue
+++ b/lab/experiments/ContentAnimateIn.vue
@@ -30,7 +30,7 @@
 					:src="`https://picsum.photos/600/300?${i}`"
 					height="200px"
 				>
-				<div>This is item number {{ Math.random() }}</div>
+				<div>This is item number {{ i }}</div>
 			</div>
 		</transition-group>
 	</div>

--- a/lab/experiments/ContentAnimateIn.vue
+++ b/lab/experiments/ContentAnimateIn.vue
@@ -1,0 +1,105 @@
+<template>
+	<div :class="$s.ProductLoad">
+		<div :class="$s.ProductGrid">
+			<div
+				v-for="i in 12"
+				v-show="!reveal"
+				:key="i"
+				:class="$s.Product"
+			>
+				<m-skeleton-block :class="$s.ProductImage" />
+				<m-skeleton-text />
+			</div>
+		</div>
+		<transition-group
+			:class="$s.ProductGrid"
+			v-bind="$attrs"
+			tag="div"
+			@enter="handleEnter"
+			@leave="handleLeave"
+		>
+			<div
+				v-for="i in 12"
+				v-show="reveal"
+				:key="i"
+				:data-load-index="[i % columns > 0 ? i % columns : columns]"
+				:class="$s.Product"
+			>
+				<img
+					:class="$s.ProductImage"
+					:src="`https://picsum.photos/600/300?${i}`"
+					height="200px"
+				>
+				<div>This is item number {{ Math.random() }}</div>
+			</div>
+		</transition-group>
+	</div>
+</template>
+
+<script>
+import { MSkeletonBlock, MSkeletonText } from '@square/maker/components/Skeleton';
+import { staggeredFloatUpFn, floatDownFn } from '@square/maker/utils/transitions';
+
+export default {
+	components: {
+		MSkeletonBlock,
+		MSkeletonText,
+	},
+
+	data() {
+		return {
+			columns: 4,
+			reveal: false,
+		};
+	},
+
+	mounted() {
+		const loadDelay = 1000;
+		setTimeout(() => {
+			this.reveal = true;
+		}, loadDelay);
+	},
+
+	methods: {
+		handleEnter(element, onComplete) {
+			staggeredFloatUpFn({ element, onComplete });
+		},
+
+		handleLeave(element, onComplete) {
+			floatDownFn({ element, onComplete });
+		},
+	},
+};
+</script>
+
+<style module="$s">
+.ProductLoad {
+	margin: 0 auto;
+	padding: 24px;
+
+	@media screen and (min-width: 840px) {
+		padding: 48px;
+	}
+}
+
+.ProductGrid {
+	display: flex;
+	flex-wrap: wrap;
+}
+
+.Product {
+	width: 100%;
+	margin: 0 auto 24px;
+
+	@media screen and (min-width: 840px) {
+		width: calc(25% - 24px);
+		margin: 0 12px 24px;
+	}
+}
+
+.ProductImage {
+	width: 100%;
+	height: 200px;
+	margin-bottom: 12px;
+}
+</style>

--- a/lab/experiments/ContentAnimateIn.vue
+++ b/lab/experiments/ContentAnimateIn.vue
@@ -1,7 +1,6 @@
 <template>
 	<div :class="$s.ProductLoad">
 		<div
-			v-show="!reveal"
 			:class="$s.ProductGrid"
 		>
 			<div
@@ -9,31 +8,32 @@
 				:key="index"
 				:class="$s.Product"
 			>
-				<m-skeleton-block :class="$s.ProductImage" />
-				<m-skeleton-text />
+				<template
+					v-if="!reveal"
+				>
+					<m-skeleton-block :class="$s.ProductImage" />
+					<m-skeleton-text />
+				</template>
+				<m-transition-staggered
+					:stagger-item-count="staggerItemCount"
+					:index="index"
+				>
+					<template #default="{ dataLoadIndex }">
+						<div
+							v-show="reveal"
+							:data-load-index="dataLoadIndex(index)"
+						>
+							<img
+								:class="$s.ProductImage"
+								:src="`https://picsum.photos/600/300?${index}`"
+								height="200px"
+							>
+							<div>This is item number {{ index }}</div>
+						</div>
+					</template>
+				</m-transition-staggered>
 			</div>
 		</div>
-		<m-transition-staggered
-			:stagger-item-count="staggerItemCount"
-			:class="$s.ProductGrid"
-		>
-			<template #default="{ dataLoadIndex }">
-				<div
-					v-for="index in 16"
-					v-show="reveal"
-					:key="index"
-					:data-load-index="dataLoadIndex(index)"
-					:class="$s.Product"
-				>
-					<img
-						:class="$s.ProductImage"
-						:src="`https://picsum.photos/600/300?${index}`"
-						height="200px"
-					>
-					<div>This is item number {{ index }}</div>
-				</div>
-			</template>
-		</m-transition-staggered>
 	</div>
 </template>
 

--- a/lab/experiments/ContentAnimateIn.vue
+++ b/lab/experiments/ContentAnimateIn.vue
@@ -49,16 +49,6 @@ export default {
 	data() {
 		return {
 			reveal: false,
-			itemsPerRow: [
-				{
-					minWidth: 0,
-					itemCount: 1,
-				},
-				{
-					minWidth: 840,
-					itemCount: 4,
-				},
-			],
 		};
 	},
 

--- a/lab/experiments/ContentAnimateIn.vue
+++ b/lab/experiments/ContentAnimateIn.vue
@@ -15,21 +15,20 @@
 					<m-skeleton-text />
 				</template>
 				<m-transition-staggered
-					:stagger-item-count="staggerItemCount"
+					:items-per-row-mobile="1"
+					:items-per-row-tablet="4"
+					:item-index="index"
 				>
-					<template #default="{ dataLoadIndex }">
-						<div
-							v-show="reveal"
-							:data-load-index="dataLoadIndex(index)"
+					<div
+						v-show="reveal"
+					>
+						<img
+							:class="$s.ProductImage"
+							:src="`https://picsum.photos/600/300?${index}`"
+							height="200px"
 						>
-							<img
-								:class="$s.ProductImage"
-								:src="`https://picsum.photos/600/300?${index}`"
-								height="200px"
-							>
-							<div>This is item number {{ index }}</div>
-						</div>
-					</template>
+						<div>This is item number {{ index }}</div>
+					</div>
 				</m-transition-staggered>
 			</div>
 		</div>
@@ -50,7 +49,7 @@ export default {
 	data() {
 		return {
 			reveal: false,
-			staggerItemCount: [
+			itemsPerRow: [
 				{
 					minWidth: 0,
 					itemCount: 1,

--- a/lab/experiments/ContentAnimateIn.vue
+++ b/lab/experiments/ContentAnimateIn.vue
@@ -1,55 +1,66 @@
 <template>
 	<div :class="$s.ProductLoad">
-		<div :class="$s.ProductGrid">
+		<div
+			v-show="!reveal"
+			:class="$s.ProductGrid"
+		>
 			<div
-				v-for="i in 12"
-				v-show="!reveal"
-				:key="i"
+				v-for="index in 12"
+				:key="index"
 				:class="$s.Product"
 			>
 				<m-skeleton-block :class="$s.ProductImage" />
 				<m-skeleton-text />
 			</div>
 		</div>
-		<transition-group
+		<m-transition-staggered
+			:stagger-item-count="staggerItemCount"
 			:class="$s.ProductGrid"
-			v-bind="$attrs"
-			tag="div"
-			@enter="handleEnter"
-			@leave="handleLeave"
 		>
-			<div
-				v-for="i in 12"
-				v-show="reveal"
-				:key="i"
-				:data-load-index="[i % columns > 0 ? i % columns : columns]"
-				:class="$s.Product"
-			>
-				<img
-					:class="$s.ProductImage"
-					:src="`https://picsum.photos/600/300?${i}`"
-					height="200px"
+			<template #default="{ dataLoadIndex }">
+				<div
+					v-for="index in 12"
+					v-show="reveal"
+					:key="index"
+					:data-load-index="dataLoadIndex(index)"
+					:class="$s.Product"
 				>
-				<div>This is item number {{ i }}</div>
-			</div>
-		</transition-group>
+					<img
+						:class="$s.ProductImage"
+						:src="`https://picsum.photos/600/300?${index}`"
+						height="200px"
+					>
+					<div>This is item number {{ index }}</div>
+				</div>
+			</template>
+		</m-transition-staggered>
 	</div>
 </template>
 
 <script>
 import { MSkeletonBlock, MSkeletonText } from '@square/maker/components/Skeleton';
-import { staggeredFloatUpFn, floatDownFn } from '@square/maker/utils/transitions';
+import { MTransitionStaggered } from '@square/maker/components/TransitionStaggered';
 
 export default {
 	components: {
 		MSkeletonBlock,
 		MSkeletonText,
+		MTransitionStaggered,
 	},
 
 	data() {
 		return {
-			columns: 4,
 			reveal: false,
+			staggerItemCount: [
+				{
+					minWidth: 0,
+					itemCount: 1,
+				},
+				{
+					minWidth: 840,
+					itemCount: 4,
+				},
+			],
 		};
 	},
 
@@ -58,16 +69,6 @@ export default {
 		setTimeout(() => {
 			this.reveal = true;
 		}, loadDelay);
-	},
-
-	methods: {
-		handleEnter(element, onComplete) {
-			staggeredFloatUpFn({ element, onComplete });
-		},
-
-		handleLeave(element, onComplete) {
-			floatDownFn({ element, onComplete });
-		},
 	},
 };
 </script>

--- a/lab/experiments/ContentAnimateIn.vue
+++ b/lab/experiments/ContentAnimateIn.vue
@@ -16,7 +16,6 @@
 				</template>
 				<m-transition-staggered
 					:stagger-item-count="staggerItemCount"
-					:index="index"
 				>
 					<template #default="{ dataLoadIndex }">
 						<div

--- a/src/components/TransitionStaggered/README.md
+++ b/src/components/TransitionStaggered/README.md
@@ -4,7 +4,7 @@
 <template>
 	<div class="grid">
 		<div
-			v-for="index in 16"
+			v-for="index in 12"
 			:key="index"
 			class="grid-column"
 		>
@@ -49,25 +49,34 @@ export default {
 .grid {
 	display: flex;
 	flex-wrap: wrap;
-	height: 530px;
+	min-height: 624px;
 }
 
 .grid-column {
 	width: 100%;
-	margin: 0 auto 24px;
-}
-
-@media screen and (min-width: 840px) {
-	.grid-column {
-		width: calc(25% - 24px);
-		margin: 0 12px 24px;
-	}
+	height: 40px;
+	margin: 0 auto 12px;
 }
 
 .grid-item {
-	background-color: #999;
 	width: 100%;
-	height: 100px;
+	height: 40px;
+	background-color: #999;
+}
+
+@media screen and (min-width: 840px) {
+	.grid {
+		min-height: 372px;
+	}
+
+	.grid-column {
+		width: calc(25% - 24px);
+		height: 100px;
+		margin: 0 12px 24px;
+	}
+	.grid-item {
+		height: 100px;
+	}
 }
 </style>
 ```

--- a/src/components/TransitionStaggered/README.md
+++ b/src/components/TransitionStaggered/README.md
@@ -49,6 +49,7 @@ export default {
 .grid {
 	display: flex;
 	flex-wrap: wrap;
+	height: 530px;
 }
 
 .grid-column {
@@ -64,7 +65,9 @@ export default {
 }
 
 .grid-item {
-	background-color: #333;
+	background-color: #999;
+	width: 100%;
+	height: 100px;
 }
 </style>
 ```

--- a/src/components/TransitionStaggered/README.md
+++ b/src/components/TransitionStaggered/README.md
@@ -1,0 +1,86 @@
+# Transition Staggered
+
+```vue
+<template>
+	<div class="grid">
+		<div
+			v-for="index in 16"
+			:key="index"
+			class="grid-column"
+		>
+			<m-transition-staggered
+				:items-per-row-mobile="1"
+				:items-per-row-tablet="4"
+				:item-index="index"
+			>
+				<div
+					v-show="visible"
+					class="grid-item"
+				/>
+			</m-transition-staggered>
+		</div>
+	</div>
+</template>
+
+<script>
+import { MTransitionStaggered } from '@square/maker/components/TransitionStaggered';
+
+export default {
+	components: {
+		MTransitionStaggered,
+	},
+
+	data() {
+		return {
+			visible: true,
+		};
+	},
+
+	mounted() {
+		const transitionIntervalMs = 2000;
+		setInterval(() => {
+			this.visible = !this.visible;
+		}, transitionIntervalMs);
+	},
+};
+</script>
+
+<style scoped>
+.grid {
+	display: flex;
+	flex-wrap: wrap;
+}
+
+.grid-column {
+	width: 100%;
+	margin: 0 auto 24px;
+}
+
+@media screen and (min-width: 840px) {
+	.grid-column {
+		width: calc(25% - 24px);
+		margin: 0 12px 24px;
+	}
+}
+
+.grid-item {
+	background-color: #333;
+}
+</style>
+```
+
+<!-- api-tables:start -->
+## Props
+
+| Prop                 | Type     | Default | Possible values                    | Description                           |
+| -------------------- | -------- | ------- | ---------------------------------- | ------------------------------------- |
+| items-per-row-mobile | `number` | `1`     | —                                  | items to stagger per row on mobile    |
+| items-per-row-tablet | `number` | `1`     | —                                  | items to stagger per row on tablet    |
+| item-index           | `number` | `1`     | —                                  | the index of the item within a list   |
+
+## Slots
+
+| Slot    | Description          |
+| ------- | -------------------- |
+| default | content to spring up |
+<!-- api-tables:end -->

--- a/src/components/TransitionStaggered/README.md
+++ b/src/components/TransitionStaggered/README.md
@@ -1,5 +1,7 @@
 # Transition Staggered
 
+MTransitionStaggered creates a staggered load animation on a group of items (in a list or grid layout). It wraps each individual item and calculates its animation distance through an item-index prop.
+
 ```vue
 <template>
 	<div class="grid">
@@ -84,15 +86,15 @@ export default {
 <!-- api-tables:start -->
 ## Props
 
-| Prop                 | Type     | Default | Possible values                    | Description                           |
-| -------------------- | -------- | ------- | ---------------------------------- | ------------------------------------- |
-| items-per-row-mobile | `number` | `1`     | —                                  | items to stagger per row on mobile    |
-| items-per-row-tablet | `number` | `1`     | —                                  | items to stagger per row on tablet    |
-| item-index           | `number` | `1`     | —                                  | the index of the item within a list   |
+| Prop                 | Type     | Default | Possible values | Description                         |
+| -------------------- | -------- | ------- | --------------- | ----------------------------------- |
+| items-per-row-mobile | `number` | `1`     | —               | Items to stagger per row on mobile  |
+| items-per-row-tablet | `number` | `1`     | —               | Items to stagger per row on tablet  |
+| item-index           | `number` | `1`     | —               | The index of the item within a list |
 
 ## Slots
 
-| Slot    | Description          |
-| ------- | -------------------- |
-| default | content to spring up |
+| Slot    | Description        |
+| ------- | ------------------ |
+| default | content to animate |
 <!-- api-tables:end -->

--- a/src/components/TransitionStaggered/index.js
+++ b/src/components/TransitionStaggered/index.js
@@ -1,0 +1,1 @@
+export { default as MTransitionStaggered } from './src/TransitionStaggered.vue';

--- a/src/components/TransitionStaggered/src/TransitionStaggered.vue
+++ b/src/components/TransitionStaggered/src/TransitionStaggered.vue
@@ -1,14 +1,13 @@
 <template>
-	<transition-group
+	<transition
 		v-bind="$attrs"
-		tag="div"
 		@enter="handleEnter"
 		@leave="handleLeave"
 	>
 		<slot
 			:data-load-index="loadIndex"
 		/>
-	</transition-group>
+	</transition>
 </template>
 
 <script>
@@ -51,6 +50,10 @@ export default {
 					|| itemCount.minWidth === 0)
 					&& itemCount.itemCount);
 			},
+		},
+		index: {
+			type: Number,
+			default: 1,
 		},
 	},
 

--- a/src/components/TransitionStaggered/src/TransitionStaggered.vue
+++ b/src/components/TransitionStaggered/src/TransitionStaggered.vue
@@ -1,0 +1,91 @@
+<template>
+	<transition-group
+		v-bind="$attrs"
+		tag="div"
+		@enter="handleEnter"
+		@leave="handleLeave"
+	>
+		<slot
+			:data-load-index="loadIndex"
+		/>
+	</transition-group>
+</template>
+
+<script>
+import { staggeredFloatUpFn, floatDownFn } from '@square/maker/utils/transitions';
+
+const defaultItemCount = [
+	{
+		minWidth: 0,
+		itemCount: 1,
+	},
+];
+
+export default {
+	props: {
+		// Number of items to stagger at a time for a viewport
+		// E.g. [
+		// 	{
+		// 		minWidth: 0,
+		// 		staggerItemCount: 1,
+		// 	},
+		// 	{
+		// 		minWidth: 840,
+		// 		staggerItemCount: 4,
+		// 	},
+		// ]
+		staggerItemCount: {
+			type: Array,
+			default: () => defaultItemCount,
+			validator: (staggerItemCount) => {
+				// cannot be empty
+				if (staggerItemCount.length === 0) {
+					return false;
+				}
+				// must have default catch-all count
+				if (staggerItemCount[0].minWidth !== 0) {
+					return false;
+				}
+				return staggerItemCount.every((itemCount) => (itemCount.minWidth
+					|| itemCount.minWidth === 0)
+					&& itemCount.itemCount);
+			},
+		},
+	},
+
+	data() {
+		return {
+			viewportWidth: 0,
+		};
+	},
+
+	mounted() {
+		this.viewportWidth = window.innerWidth;
+	},
+
+	methods: {
+		handleEnter(element, onComplete) {
+			staggeredFloatUpFn({ element, onComplete });
+		},
+
+		handleLeave(element, onComplete) {
+			floatDownFn({ element, onComplete });
+		},
+
+		loadIndex(index) {
+			const { staggerItemCount, viewportWidth } = this;
+			let items;
+			staggerItemCount.forEach((count) => {
+				if (count.minWidth < viewportWidth) {
+					items = count.itemCount;
+				}
+			});
+			if (items === defaultItemCount[0].itemCount) {
+				return index;
+			}
+			const remainder = index % items;
+			return remainder > 0 ? remainder : items;
+		},
+	},
+};
+</script>

--- a/src/components/TransitionStaggered/src/TransitionStaggered.vue
+++ b/src/components/TransitionStaggered/src/TransitionStaggered.vue
@@ -14,10 +14,11 @@
 <script>
 import { staggeredFloatUpFn, floatDownFn } from '@square/maker/utils/transitions';
 
+const singleItem = 1;
 const defaultItemCount = [
 	{
 		minWidth: 0,
-		itemCount: 1,
+		itemCount: singleItem,
 	},
 ];
 
@@ -80,11 +81,12 @@ export default {
 					items = count.itemCount;
 				}
 			});
-			if (items === defaultItemCount[0].itemCount) {
+			if (items === singleItem) {
 				return index;
 			}
-			const remainder = index % items;
-			return remainder > 0 ? remainder : items;
+			const row = Math.ceil(index / items);
+			const rowIndex = index % items > 0 ? index % items : items;
+			return row * rowIndex;
 		},
 	},
 };

--- a/src/components/TransitionStaggered/src/TransitionStaggered.vue
+++ b/src/components/TransitionStaggered/src/TransitionStaggered.vue
@@ -51,10 +51,6 @@ export default {
 					&& itemCount.itemCount);
 			},
 		},
-		index: {
-			type: Number,
-			default: 1,
-		},
 	},
 
 	data() {

--- a/src/components/TransitionStaggered/src/TransitionStaggered.vue
+++ b/src/components/TransitionStaggered/src/TransitionStaggered.vue
@@ -83,9 +83,8 @@ export default {
 			if (items === singleItem) {
 				return index;
 			}
-			const row = Math.ceil(index / items);
 			const rowIndex = index % items > 0 ? index % items : items;
-			return row * rowIndex;
+			return rowIndex;
 		},
 	},
 };

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -22,7 +22,7 @@ export const spring = {
 export const springSubtle = {
 	type,
 	stiffness: 200,
-	damping: 30,
+	damping: 60,
 	mass: 1,
 };
 
@@ -36,7 +36,6 @@ export const springBounce = {
 const START_VALUE = 0;
 const END_VALUE = 100;
 const MINI_END_VALUE = 40;
-const MICRO_END_VALUE = 20;
 
 export const animateUp = {
 	from: START_VALUE,
@@ -82,15 +81,17 @@ const toOpacity = styleFactory(START_VALUE, END_VALUE, 'opacity', '%');
 const toRelativeY = styleFactory(START_VALUE, END_VALUE, 'y', '%');
 const toRelativeX = styleFactory(START_VALUE, END_VALUE, 'x', '%');
 const toMiniSlideY = styleFactory(MINI_END_VALUE, START_VALUE, 'y', 'px');
-const toMicroSlideY = styleFactory(MICRO_END_VALUE, START_VALUE, 'y', 'px');
 const toFloatyY = (progress) => ({
 	...toOpacity(progress),
 	...toMiniSlideY(progress),
 });
-const toSubtleFloatyY = (progress) => ({
-	...toOpacity(progress),
-	...toMicroSlideY(progress),
-});
+const toStaggeredFloatyY = (distance, progress) => {
+	const toCustomSlideY = styleFactory(distance, START_VALUE, 'y', 'px');
+	return {
+		...toOpacity(progress),
+		...toCustomSlideY(progress),
+	};
+};
 
 export function fadeInFn({ element, onComplete }) {
 	const elementStyler = styler(element);
@@ -243,22 +244,21 @@ export function delayedFloatUpFn({ element, onComplete }) {
 
 export function staggeredFloatUpFn({ element, onComplete }) {
 	const elementStyler = styler(element);
-	const styleFn = toSubtleFloatyY;
+	const styleFn = toStaggeredFloatyY;
 	const animationDirection = animateUp;
-	const delay = 50;
-	const staggerDelay = element.dataset.loadIndex * delay;
+	const distanceBase = 20;
+	const distanceMultiplier = 10;
+	const endValue = distanceBase + (element.dataset.loadIndex * distanceMultiplier);
 	elementStyler.set(styleFn(animationDirection.from));
 	elementStyler.render();
-	setTimeout(() => {
-		animate({
-			...animationDirection,
-			...springSubtle,
-			onUpdate(number) {
-				elementStyler.set(styleFn(number));
-			},
-			onComplete,
-		});
-	}, staggerDelay);
+	animate({
+		...animationDirection,
+		...springSubtle,
+		onUpdate(number) {
+			elementStyler.set(styleFn(endValue, number));
+		},
+		onComplete,
+	});
 }
 
 export function floatDownFn({ element, onComplete }) {

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -19,9 +19,17 @@ export const spring = {
 	mass,
 };
 
+export const springSubtle = {
+	type,
+	stiffness: 200,
+	damping: 30,
+	mass: 1,
+};
+
 const START_VALUE = 0;
 const END_VALUE = 100;
 const MINI_END_VALUE = 40;
+const MICRO_END_VALUE = 20;
 
 export const animateUp = {
 	from: START_VALUE,
@@ -67,9 +75,14 @@ const toOpacity = styleFactory(START_VALUE, END_VALUE, 'opacity', '%');
 const toRelativeY = styleFactory(START_VALUE, END_VALUE, 'y', '%');
 const toRelativeX = styleFactory(START_VALUE, END_VALUE, 'x', '%');
 const toMiniSlideY = styleFactory(MINI_END_VALUE, START_VALUE, 'y', 'px');
+const toMicroSlideY = styleFactory(MICRO_END_VALUE, START_VALUE, 'y', 'px');
 const toFloatyY = (progress) => ({
 	...toOpacity(progress),
 	...toMiniSlideY(progress),
+});
+const toSubtleFloatyY = (progress) => ({
+	...toOpacity(progress),
+	...toMicroSlideY(progress),
 });
 
 export function fadeInFn({ element, onComplete }) {
@@ -219,6 +232,26 @@ export function delayedFloatUpFn({ element, onComplete }) {
 			onComplete,
 		});
 	}, springDelay);
+}
+
+export function staggeredFloatUpFn({ element, onComplete }) {
+	const elementStyler = styler(element);
+	const styleFn = toSubtleFloatyY;
+	const animationDirection = animateUp;
+	const delay = 50;
+	const staggerDelay = element.dataset.loadIndex * delay;
+	elementStyler.set(styleFn(animationDirection.from));
+	elementStyler.render();
+	setTimeout(() => {
+		animate({
+			...animationDirection,
+			...springSubtle,
+			onUpdate(number) {
+				elementStyler.set(styleFn(number));
+			},
+			onComplete,
+		});
+	}, staggerDelay);
 }
 
 export function floatDownFn({ element, onComplete }) {

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -85,7 +85,7 @@ const toFloatyY = (progress) => ({
 	...toOpacity(progress),
 	...toMiniSlideY(progress),
 });
-const toStaggeredFloatyY = (distance, progress) => {
+const toStaggeredFloatyY = (progress, distance) => {
 	const toCustomSlideY = styleFactory(distance, START_VALUE, 'y', 'px');
 	return {
 		...toOpacity(progress),
@@ -255,7 +255,7 @@ export function staggeredFloatUpFn({ element, onComplete }) {
 		...animationDirection,
 		...springSubtle,
 		onUpdate(number) {
-			elementStyler.set(styleFn(endValue, number));
+			elementStyler.set(styleFn(number, endValue));
 		},
 		onComplete,
 	});

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -22,7 +22,7 @@ export const spring = {
 export const springSubtle = {
 	type,
 	stiffness: 400,
-	damping,
+	damping: 40,
 	mass,
 };
 

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -247,7 +247,7 @@ export function staggeredFloatUpFn({ element, onComplete }) {
 	const styleFn = toStaggeredFloatyY;
 	const animationDirection = animateUp;
 	const distanceBase = 20;
-	const distanceMultiplier = 10;
+	const distanceMultiplier = 5;
 	const endValue = distanceBase + (element.dataset.loadIndex * distanceMultiplier);
 	elementStyler.set(styleFn(animationDirection.from));
 	elementStyler.render();

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -246,9 +246,9 @@ export function staggeredFloatUpFn({ element, onComplete }) {
 	const elementStyler = styler(element);
 	const styleFn = toStaggeredFloatyY;
 	const animationDirection = animateUp;
-	const distanceBase = 20;
-	const distanceMultiplier = 5;
-	const endValue = distanceBase + (element.dataset.loadIndex * distanceMultiplier);
+	const distanceYBase = 20;
+	const distanceYMultiplier = 5;
+	const endValue = distanceYBase + (element.dataset.loadIndex * distanceYMultiplier);
 	elementStyler.set(styleFn(animationDirection.from));
 	elementStyler.render();
 	animate({

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -21,9 +21,9 @@ export const spring = {
 
 export const springSubtle = {
 	type,
-	stiffness: 200,
-	damping: 60,
-	mass: 1,
+	stiffness: 400,
+	damping,
+	mass,
 };
 
 export const springBounce = {


### PR DESCRIPTION
## Describe the problem this PR addresses
This PR adds a transition group component that allows for staggered list transitions.

## Describe the changes in this PR
- `ContentAnimation`: experiment to demo the staggered transition
- `transitions`: add  `springSubtle`, `toSubtleFloatyY` constants and `staggeredFloatUpFn` for the designed transition that accepts a stagger
- `TransitionStaggered`: transition group component that takes a stagger item count by viewport and passes back a function to calculate the load index.

For a mobile stagger count of 1 item at a time and desktop stagger count of 4 at a time:

![mobile](https://user-images.githubusercontent.com/1486885/142294887-bba07e66-26e8-4575-ba3a-d42651acb55d.gif)

![desktop](https://user-images.githubusercontent.com/1486885/142294902-75fafa3f-0e52-4f29-a50d-99ff0811a94e.gif)


