### PR TITLE
fix(modal): fix background site drag for modal on safari

### DIFF
--- a/lab/experiments/ActionBarTest/index.vue
+++ b/lab/experiments/ActionBarTest/index.vue
@@ -4,6 +4,12 @@
 		<button @click="openCart(false)">
 			Open modal without image
 		</button>
+		<div
+			v-for="i in 100"
+			:key="i"
+		>
+			Long text {{ i }}
+		</div>
 		<m-action-bar>
 			<m-action-bar-button
 				key="primary"

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -3,6 +3,7 @@
 		ref="modal"
 		:class="$s.Modal"
 		:style="modalStyles"
+		:prevent-default="preventDefault"
 		@scroll.native="onScroll"
 		@on-drag-down="onDragDown"
 		@on-drag-end="onDragEnd"
@@ -45,6 +46,7 @@ export default {
 			modalStyles: {},
 			isScrolledToTop: true,
 			onScroll: throttle(this.setScrollTop, scrollCheckDelay),
+			preventDefault: false,
 		};
 	},
 
@@ -59,17 +61,21 @@ export default {
 
 	methods: {
 		setScrollTop() {
-			this.isScrolledToTop = this.$refs.modal.$el.scrollTop <= 0;
+			if (this.$refs.modal.$el) {
+				this.isScrolledToTop = this.$refs.modal.$el.scrollTop <= 0;
+			}
 		},
 
 		onSwipeDown() {
 			if (this.isScrolledToTop) {
+				this.preventDefault = true;
 				this.modalApi.close();
 			}
 		},
 
 		onDragDown(gesture) {
 			if (this.isScrolledToTop) {
+				this.preventDefault = true;
 				const transform = `translateY(${gesture.changeY}px)`;
 				this.modalStyles = {
 					transform,
@@ -83,10 +89,12 @@ export default {
 		onDragEnd(gesture) {
 			// percent of window height modal must be dragged to close on release
 			const minDragCloseDistance = 0.3;
+			const minDragThreshold = window.innerHeight * minDragCloseDistance;
 			if (this.isScrolledToTop
-			&& gesture.changeY > (window.innerHeight * minDragCloseDistance)) {
+			&& gesture.changeY > minDragThreshold) {
 				this.modalApi.close();
 			} else {
+				this.preventDefault = false;
 				this.modalStyles = {};
 			}
 		},

--- a/src/components/TouchCapture/src/TouchCapture.vue
+++ b/src/components/TouchCapture/src/TouchCapture.vue
@@ -27,6 +27,10 @@ export default {
 	name: 'TouchCapture',
 
 	props: {
+		preventDefault: {
+			type: Boolean,
+			default: false,
+		},
 		minSwipeDistance: {
 			type: Number,
 			default: 30,
@@ -107,6 +111,9 @@ export default {
 
 	methods: {
 		handleTouchEvent(event) {
+			if (this.preventDefault) {
+				event.preventDefault();
+			}
 			switch (event.type) {
 			case 'touchstart':
 				this.touchStarted = true;


### PR DESCRIPTION
This PR addresses the previously observed bug where dragging the modal also dragged the underlying site on mobile Safari.  This produces an unwanted visual effect and can also cause the page to reload.

Bug:
https://user-images.githubusercontent.com/1486885/145483791-21495336-b1cc-46ce-a146-965f6b3a6f89.mov

Fix:
https://user-images.githubusercontent.com/1486885/145483830-456e08c0-6c19-4bcc-8b7c-bb6b6b579af5.mov


