### PR TITLE
feat(transitions): transitions changes for modal, actionbar and staggered transition

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
 			ignoreArrayIndexes: true,
 			ignoreDefaultValues: true,
 			enforceConst: true,
+			ignore: [0],
 		}],
 
 		// As a library, dependencies are packaged in and can be in devDeps

--- a/lab/experiments/ActionBarTest.vue
+++ b/lab/experiments/ActionBarTest.vue
@@ -1,8 +1,10 @@
 <template>
-	<m-action-bar-layer>
-		<router-view />
+	<div>
+		<m-action-bar-layer>
+			<router-view />
+		</m-action-bar-layer>
 		<m-modal-layer />
-	</m-action-bar-layer>
+	</div>
 </template>
 
 <script>

--- a/lab/experiments/ActionBarTest/CartModal.vue
+++ b/lab/experiments/ActionBarTest/CartModal.vue
@@ -1,21 +1,34 @@
 <template>
 	<m-modal>
-		<div class="cover-photo">
+		<div
+			v-if="showImage"
+			class="cover-photo"
+		>
 			<m-image
 				src="https://i.picsum.photos/id/507/900/900.jpg?hmac=NDltE7xXtFlZjUoyDqGjehzY5ORPtj4-d42qbFgAFkk"
 			/>
 		</div>
-
-		<div>
-			<h1>Cart modal content</h1>
-			<div
-				v-for="i in 100"
-				:key="i"
-			>
-				Long text {{ i }}
-			</div>
+		<m-segmented-control
+			v-else
+			v-model="selected"
+		>
+			<m-segment value="short">
+				Local Delivery
+			</m-segment>
+			<m-segment value="medium">
+				Pickup
+			</m-segment>
+			<m-segment value="long">
+				Ship
+			</m-segment>
+		</m-segmented-control>
+		<h1>Cart modal content</h1>
+		<div
+			v-for="i in 100"
+			:key="i"
+		>
+			Long text {{ i }}
 		</div>
-
 		<m-inline-action-bar>
 			<m-action-bar-button
 				key="close"
@@ -43,6 +56,7 @@
 import { MModal, modalApi } from '@square/maker/components/Modal';
 import { MInlineActionBar, MActionBarButton } from '@square/maker/components/ActionBar';
 import { MImage } from '@square/maker/components/Image';
+import { MSegmentedControl, MSegment } from '@square/maker/components/SegmentedControl';
 import X from '@square/maker-icons/X';
 
 export default {
@@ -50,11 +64,27 @@ export default {
 		MModal,
 		MInlineActionBar,
 		MActionBarButton,
+		MSegmentedControl,
+		MSegment,
 		MImage,
 		X,
 	},
+
 	inject: {
 		modalApi,
+	},
+
+	props: {
+		showImage: {
+			type: Boolean,
+			default: true,
+		},
+	},
+
+	data() {
+		return {
+			selected: 'short',
+		};
 	},
 };
 </script>

--- a/lab/experiments/ActionBarTest/index.vue
+++ b/lab/experiments/ActionBarTest/index.vue
@@ -4,6 +4,12 @@
 		<button @click="openCart(false)">
 			Open modal without image
 		</button>
+		<div
+			v-for="i in 100"
+			:key="i"
+		>
+			Long text {{ i }}
+		</div>
 		<m-action-bar>
 			<m-action-bar-button
 				key="primary"

--- a/lab/experiments/ActionBarTest/index.vue
+++ b/lab/experiments/ActionBarTest/index.vue
@@ -1,12 +1,15 @@
 <template>
 	<div>
 		<h1>root index</h1>
+		<button @click="openCart(false)">
+			Open modal without image
+		</button>
 		<m-action-bar>
 			<m-action-bar-button
 				key="primary"
 				align="center"
 				full-width
-				@click="openCart"
+				@click="openCart(true)"
 			>
 				View Cart
 				<template #information>
@@ -33,8 +36,12 @@ export default {
 	},
 
 	methods: {
-		openCart() {
-			this.modalApi.open(() => <CartModal />);
+		openCart(showImage) {
+			this.modalApi.open((h) => h(CartModal, {
+				props: {
+					showImage,
+				},
+			}));
 		},
 	},
 };

--- a/lab/experiments/ActionBarTransition.vue
+++ b/lab/experiments/ActionBarTransition.vue
@@ -1,0 +1,31 @@
+<template>
+	<div>
+		<m-action-bar-layer>
+			<router-view />
+		</m-action-bar-layer>
+		<m-modal-layer />
+	</div>
+</template>
+
+<script>
+import { MActionBarLayer } from '@square/maker/components/ActionBar';
+import { MModalLayer } from '@square/maker/components/Modal';
+
+export default {
+	components: {
+		MActionBarLayer,
+		MModalLayer,
+	},
+
+	mixins: [
+		MModalLayer.apiMixin,
+	],
+};
+</script>
+
+<style>
+html,
+body {
+	font-family: "Square Market", system-ui;
+}
+</style>

--- a/lab/experiments/ActionBarTransition/ItemModal.vue
+++ b/lab/experiments/ActionBarTransition/ItemModal.vue
@@ -1,0 +1,204 @@
+<template>
+	<m-modal>
+		<div class="cover-photo">
+			<m-image
+				src="https://i.picsum.photos/id/507/900/900.jpg?hmac=NDltE7xXtFlZjUoyDqGjehzY5ORPtj4-d42qbFgAFkk"
+			/>
+		</div>
+		<m-container>
+			<template #label>
+				<h1>Modal with Inline Action Bar</h1>
+			</template>
+			<div
+				v-for="i in 100"
+				:key="i"
+			>
+				Long text {{ i }}
+			</div>
+		</m-container>
+
+		<div :class="$s.ActionBarWrapper">
+			<m-transition
+				:enter="springUpFn"
+				:leave="springDownFn"
+			>
+				<atomic-action-bar
+					v-if="loaded"
+					v-bind="$attrs"
+					v-on="$listeners"
+				>
+					<m-action-bar-button
+						key="close"
+						color="#f6f6f6"
+						@click="modalApi.close()"
+					>
+						<x class="icon" />
+					</m-action-bar-button>
+					<m-action-bar-button
+						key="primary"
+						align="center"
+						full-width
+						@click="modalApi.close()"
+					>
+						Add to Cart
+						<template #information>
+							$10.00
+						</template>
+					</m-action-bar-button>
+				</atomic-action-bar>
+			</m-transition>
+		</div>
+	</m-modal>
+</template>
+
+<script>
+import { MModal, modalApi } from '@square/maker/components/Modal';
+import { MActionBarButton } from '@square/maker/components/ActionBar';
+import { MContainer } from '@square/maker/components/Container';
+import { MImage } from '@square/maker/components/Image';
+import { MTransition } from '@square/maker/utils/Transition';
+import X from '@square/maker-icons/X';
+import styler from 'stylefire';
+import { animate } from 'popmotion';
+import {
+	styleFactory, animateUp, animateDown,
+} from '@square/maker/utils/transitions';
+import AtomicActionBar from '../../../src/components/ActionBar/src/AtomicActionBar.vue';
+
+export default {
+	components: {
+		MModal,
+		MActionBarButton,
+		MImage,
+		MContainer,
+		X,
+		MTransition,
+		AtomicActionBar,
+	},
+
+	inject: {
+		modalApi,
+	},
+
+	inheritAttrs: false,
+
+	props: {
+		enterDelay: {
+			type: Number,
+			default: undefined,
+		},
+		springStiffness: {
+			type: Number,
+			default: undefined,
+		},
+		springDamping: {
+			type: Number,
+			default: undefined,
+		},
+		springMass: {
+			type: Number,
+			default: undefined,
+		},
+	},
+
+	data() {
+		// eslint-disable-next-line no-magic-numbers
+		const toRelativeY = styleFactory(0, 100, 'y', '%');
+
+		return {
+			springUpFn: ({ element, onComplete }) => {
+				const elementStyler = styler(element);
+				const styleFn = toRelativeY;
+				const animationDirection = animateDown;
+				elementStyler.set(styleFn(animationDirection.from));
+				elementStyler.render();
+				animate({
+					...animationDirection,
+					type: 'spring',
+					stiffness: this.springStiffness,
+					damping: this.springDamping,
+					mass: this.springMass,
+					onUpdate(number) {
+						elementStyler.set(styleFn(number));
+					},
+					onComplete,
+				});
+			},
+			springDownFn: ({ element, onComplete }) => {
+				const elementStyler = styler(element);
+				const styleFn = toRelativeY;
+				const animationDirection = animateUp;
+				elementStyler.set(styleFn(animationDirection.from));
+				elementStyler.render();
+				animate({
+					...animationDirection,
+					type: 'spring',
+					stiffness: this.springStiffness,
+					damping: this.springDamping,
+					mass: this.springMass,
+					onUpdate(number) {
+						elementStyler.set(styleFn(number));
+					},
+					onComplete,
+				});
+			},
+			loaded: false,
+		};
+	},
+
+	mounted() {
+		setTimeout(() => {
+			this.loaded = true;
+		}, this.enterDelay);
+	},
+};
+</script>
+
+<style scoped>
+.cover-photo {
+	width: 100%;
+	height: 280px;
+}
+
+.image {
+	width: 100%;
+}
+
+.icon {
+	width: 16px;
+	height: 16px;
+}
+</style>
+
+<style module="$s">
+.ActionBarWrapper {
+	--regular-bottom-padding: 32px;
+	--extra-bottom-padding-for-deadclick: 32px;
+	--safe-area-inset-padding: env(safe-area-inset-bottom, 0);
+	--actionbar-bottom-padding:
+		calc(
+			var(--regular-bottom-padding)
+			+ var(--extra-bottom-padding-for-deadclick)
+			+ var(--safe-area-inset-padding)
+		);
+	--actionbar-size: 64px;
+	--actionbar-top-padding: 32px;
+
+	padding-bottom:
+		calc(
+			var(--actionbar-top-padding)
+			+ var(--actionbar-size)
+			+ var(--actionbar-bottom-padding)
+		);
+}
+
+@media screen and (min-width: 840px) {
+	.ActionBarWrapper {
+		--actionbar-size: 48px;
+		--actionbar-top-padding: 24px;
+
+		/* no safe-area or deadclick issues on non-mobile resolutions */
+		--actionbar-bottom-padding: var(--regular-bottom-padding);
+	}
+}
+</style>

--- a/lab/experiments/ActionBarTransition/index.vue
+++ b/lab/experiments/ActionBarTransition/index.vue
@@ -115,7 +115,7 @@ export default {
 
 	data() {
 		return {
-			enterDelay: 800,
+			enterDelay: 600,
 			springStiffness: 400,
 			springDamping: 30,
 			springMass: 2,

--- a/lab/experiments/ActionBarTransition/index.vue
+++ b/lab/experiments/ActionBarTransition/index.vue
@@ -1,0 +1,149 @@
+<template>
+	<m-container>
+		<h1>Action bar test</h1>
+		<p>To preview the persistent action bar, please view this page in a mobile browser.</p>
+		<p>
+			Otherwise
+			<button @click="openCart">
+				Click here
+			</button>
+			to open the item modal.
+		</p>
+
+		<div :class="$s.Controls">
+			<h4>Delay (milliseconds)</h4>
+			<m-segmented-control
+				v-model="enterDelay"
+				size="small"
+			>
+				<m-segment
+					v-for="i in 8"
+					:key="i"
+					:value="i * 100"
+				>
+					{{ i * 100 }}
+				</m-segment>
+			</m-segmented-control>
+			<h4>Stiffness</h4>
+			<p>A higher stiffness will result in a snappier animation.</p>
+			<m-segmented-control
+				v-model="springStiffness"
+				size="small"
+			>
+				<m-segment
+					v-for="i in 10"
+					:key="i"
+					:value="i * 100"
+				>
+					{{ i * 100 }}
+				</m-segment>
+			</m-segmented-control>
+			<h4>Damping</h4>
+			<p>
+				This is the opposing force to stiffness.
+				As you reduce this value, relative to stiffness,
+				the spring will become bouncier and the animation
+				will last longer. Likewise, higher relative values will
+				have less bounciness and result in shorter animations.
+			</p>
+			<m-segmented-control
+				v-model="springDamping"
+				size="small"
+			>
+				<m-segment
+					v-for="i in 10"
+					:key="i"
+					:value="i * 10"
+				>
+					{{ i * 10 }}
+				</m-segment>
+			</m-segmented-control>
+			<h4>Mass</h4>
+			<p>
+				This is the mass of the animating object.
+				Heavier objects will take longer to speed up and slow down.
+			</p>
+			<m-segmented-control
+				v-model="springMass"
+				size="small"
+			>
+				<m-segment
+					v-for="i in 10"
+					:key="i"
+					:value="i / 2"
+				>
+					{{ i / 2 }}
+				</m-segment>
+			</m-segmented-control>
+		</div>
+		<m-action-bar>
+			<m-action-bar-button
+				key="primary"
+				align="center"
+				full-width
+				@click="openCart"
+			>
+				View Cart
+				<template #information>
+					3 items
+				</template>
+			</m-action-bar-button>
+		</m-action-bar>
+	</m-container>
+</template>
+
+<script>
+
+import { modalApi } from '@square/maker/components/Modal';
+import { MActionBar, MActionBarButton } from '@square/maker/components/ActionBar';
+import { MContainer } from '@square/maker/components/Container';
+import { MSegmentedControl, MSegment } from '@square/maker/components/SegmentedControl';
+import ItemModal from './ItemModal.vue';
+
+export default {
+	components: {
+		MActionBar,
+		MActionBarButton,
+		MContainer,
+		MSegmentedControl,
+		MSegment,
+	},
+
+	inject: {
+		modalApi,
+	},
+
+	data() {
+		return {
+			enterDelay: 800,
+			springStiffness: 400,
+			springDamping: 30,
+			springMass: 2,
+		};
+	},
+
+	methods: {
+
+		openCart() {
+			this.modalApi.open((h) => h(
+				ItemModal,
+				{
+					props: {
+						enterDelay: this.enterDelay,
+						springStiffness: this.springStiffness,
+						springDamping: this.springDamping,
+						springMass: this.springMass,
+					},
+				},
+			));
+		},
+	},
+};
+</script>
+
+<style module="$s">
+.Controls {
+	padding: 16px 24px 36px;
+	background: #fff;
+}
+</style>

--- a/lab/experiments/ActionBarTransition/index.vue
+++ b/lab/experiments/ActionBarTransition/index.vue
@@ -118,7 +118,7 @@ export default {
 			enterDelay: 600,
 			springStiffness: 400,
 			springDamping: 30,
-			springMass: 2,
+			springMass: 1.5,
 		};
 	},
 

--- a/lab/experiments/ContentAnimateIn.vue
+++ b/lab/experiments/ContentAnimateIn.vue
@@ -1,0 +1,94 @@
+<template>
+	<div :class="$s.ProductLoad">
+		<div
+			:class="$s.ProductGrid"
+		>
+			<div
+				v-for="index in 16"
+				:key="index"
+				:class="$s.Product"
+			>
+				<template
+					v-if="!reveal"
+				>
+					<m-skeleton-block :class="$s.ProductImage" />
+					<m-skeleton-text />
+				</template>
+				<m-transition-staggered
+					:items-per-row-mobile="1"
+					:items-per-row-tablet="4"
+					:item-index="index"
+				>
+					<div
+						v-show="reveal"
+					>
+						<img
+							:class="$s.ProductImage"
+							:src="`https://picsum.photos/600/300?${index}`"
+							height="200px"
+						>
+						<div>This is item number {{ index }}</div>
+					</div>
+				</m-transition-staggered>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { MSkeletonBlock, MSkeletonText } from '@square/maker/components/Skeleton';
+import { MTransitionStaggered } from '@square/maker/components/TransitionStaggered';
+
+export default {
+	components: {
+		MSkeletonBlock,
+		MSkeletonText,
+		MTransitionStaggered,
+	},
+
+	data() {
+		return {
+			reveal: false,
+		};
+	},
+
+	mounted() {
+		const loadDelay = 1000;
+		setTimeout(() => {
+			this.reveal = true;
+		}, loadDelay);
+	},
+};
+</script>
+
+<style module="$s">
+.ProductLoad {
+	margin: 0 auto;
+	padding: 24px;
+
+	@media screen and (min-width: 840px) {
+		padding: 48px;
+	}
+}
+
+.ProductGrid {
+	display: flex;
+	flex-wrap: wrap;
+}
+
+.Product {
+	width: 100%;
+	margin: 0 auto 24px;
+
+	@media screen and (min-width: 840px) {
+		width: calc(25% - 24px);
+		margin: 0 12px 24px;
+	}
+}
+
+.ProductImage {
+	width: 100%;
+	height: 200px;
+	margin-bottom: 12px;
+}
+</style>

--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -9,7 +9,10 @@
 	>
 		<slot />
 
-		<m-transition-spring-up>
+		<m-transition
+			:enter="springUpBounceFn"
+			:leave="springDownBounceFn"
+		>
 			<atomic-action-bar
 				v-if="actionBarVnodes"
 				hide-on="tablet"
@@ -17,20 +20,21 @@
 			>
 				<v :nodes="actionBarVnodes" />
 			</atomic-action-bar>
-		</m-transition-spring-up>
+		</m-transition>
 	</div>
 </template>
 
 <script>
 import { throttle } from 'lodash';
 import V from 'vue-v';
-import { MTransitionSpringUp } from '@square/maker/components/TransitionSpringUp';
+import { MTransition } from '@square/maker/utils/Transition';
+import { springUpBounceFn, springDownBounceFn } from '@square/maker/utils/transitions';
 import AtomicActionBar from './AtomicActionBar.vue';
 
 export default {
 	components: {
 		V,
-		MTransitionSpringUp,
+		MTransition,
 		AtomicActionBar,
 	},
 
@@ -57,6 +61,8 @@ export default {
 		return {
 			registeredBy: undefined,
 			actionBarVnodes: undefined,
+			springUpBounceFn,
+			springDownBounceFn,
 		};
 	},
 

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -1,16 +1,23 @@
 <template>
 	<div :class="$s.ActionBarWrapper">
-		<atomic-action-bar
-			v-bind="$attrs"
-			v-on="$listeners"
+		<m-transition
+			:enter="springUpBounceFn"
+			:leave="springDownBounceFn"
 		>
-			<!-- @slot ActionBar items -->
-			<slot />
-		</atomic-action-bar>
+			<atomic-action-bar
+				v-if="loaded"
+				v-bind="$attrs"
+				v-on="$listeners"
+			>
+				<slot />
+			</atomic-action-bar>
+		</m-transition>
 	</div>
 </template>
 
 <script>
+import { MTransition } from '@square/maker/utils/Transition';
+import { springUpBounceFn, springDownBounceFn } from '@square/maker/utils/transitions';
 import AtomicActionBar from './AtomicActionBar.vue';
 
 /**
@@ -21,9 +28,25 @@ import AtomicActionBar from './AtomicActionBar.vue';
 export default {
 	components: {
 		AtomicActionBar,
+		MTransition,
 	},
 
 	inheritAttrs: false,
+
+	data() {
+		return {
+			loaded: false,
+			springUpBounceFn,
+			springDownBounceFn,
+		};
+	},
+
+	mounted() {
+		const enterDelay = 800;
+		setTimeout(() => {
+			this.loaded = !!this.$slots.default;
+		}, enterDelay);
+	},
 };
 </script>
 

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -42,7 +42,7 @@ export default {
 	},
 
 	mounted() {
-		const enterDelay = 800;
+		const enterDelay = 600;
 		setTimeout(() => {
 			this.loaded = !!this.$slots.default;
 		}, enterDelay);

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -3,6 +3,7 @@
 		ref="modal"
 		:class="$s.Modal"
 		:style="modalStyles"
+		:prevent-default="preventDefault"
 		@scroll.native="onScroll"
 		@on-drag-down="onDragDown"
 		@on-drag-end="onDragEnd"
@@ -45,6 +46,7 @@ export default {
 			modalStyles: {},
 			isScrolledToTop: true,
 			onScroll: throttle(this.setScrollTop, scrollCheckDelay),
+			preventDefault: false,
 		};
 	},
 
@@ -59,17 +61,21 @@ export default {
 
 	methods: {
 		setScrollTop() {
-			this.isScrolledToTop = this.$refs.modal.$el.scrollTop <= 0;
+			if (this.$refs.modal.$el) {
+				this.isScrolledToTop = this.$refs.modal.$el.scrollTop <= 0;
+			}
 		},
 
 		onSwipeDown() {
 			if (this.isScrolledToTop) {
+				this.preventDefault = true;
 				this.modalApi.close();
 			}
 		},
 
 		onDragDown(gesture) {
 			if (this.isScrolledToTop) {
+				this.preventDefault = true;
 				const transform = `translateY(${gesture.changeY}px)`;
 				this.modalStyles = {
 					transform,
@@ -83,10 +89,12 @@ export default {
 		onDragEnd(gesture) {
 			// percent of window height modal must be dragged to close on release
 			const minDragCloseDistance = 0.3;
+			const minDragThreshold = window.innerHeight * minDragCloseDistance;
 			if (this.isScrolledToTop
-			&& gesture.changeY > (window.innerHeight * minDragCloseDistance)) {
+			&& gesture.changeY > minDragThreshold) {
 				this.modalApi.close();
 			} else {
+				this.preventDefault = false;
 				this.modalStyles = {};
 			}
 		},

--- a/src/components/TouchCapture/index.js
+++ b/src/components/TouchCapture/index.js
@@ -1,0 +1,1 @@
+export { default as MTouchCapture } from './src/TouchCapture.vue';

--- a/src/components/TouchCapture/src/TouchCapture.vue
+++ b/src/components/TouchCapture/src/TouchCapture.vue
@@ -27,6 +27,10 @@ export default {
 	name: 'TouchCapture',
 
 	props: {
+		preventDefault: {
+			type: Boolean,
+			default: false,
+		},
 		minSwipeDistance: {
 			type: Number,
 			default: 30,
@@ -107,6 +111,9 @@ export default {
 
 	methods: {
 		handleTouchEvent(event) {
+			if (this.preventDefault) {
+				event.preventDefault();
+			}
 			switch (event.type) {
 			case 'touchstart':
 				this.touchStarted = true;

--- a/src/components/TouchCapture/src/TouchCapture.vue
+++ b/src/components/TouchCapture/src/TouchCapture.vue
@@ -1,0 +1,140 @@
+<template>
+	<div
+		@touchstart="handleTouchEvent"
+		@touchmove="handleTouchEvent"
+		@touchend="handleTouchEvent"
+	>
+		<slot />
+	</div>
+</template>
+
+<script>
+const touchPointsDrag = 1;
+const touchPointsSwipe = 1;
+const initialValues = {
+	touchStarted: false,
+	touchEnded: false,
+	touchPoints: [],
+	timeStart: 0,
+	clientXStart: 0,
+	clientYStart: 0,
+	clientXCurrent: 0,
+	clientYCurrent: 0,
+	timeCurrent: 0,
+};
+
+export default {
+	name: 'TouchCapture',
+
+	props: {
+		minSwipeDistance: {
+			type: Number,
+			default: 30,
+		},
+		maxSwipeDuration: {
+			type: Number,
+			default: 300,
+		},
+	},
+
+	data() {
+		return {
+			...initialValues,
+		};
+	},
+
+	computed: {
+		timeElapsed() {
+			return this.timeCurrent - this.timeStart;
+		},
+
+		changeY() {
+			return this.clientYCurrent - this.clientYStart;
+		},
+
+		changeX() {
+			return this.clientXCurrent - this.clientXStart;
+		},
+
+		direction() {
+			const { changeY, changeX } = this;
+			if (Math.abs(changeY) > Math.abs(changeX)) {
+				return changeY < 0 ? 'up' : 'down';
+			}
+			return changeX < 0 ? 'left' : 'right';
+		},
+
+		gesture() {
+			const { changeY, changeX } = this;
+			return {
+				changeX,
+				changeY,
+			};
+		},
+
+		isSwipeGesture() {
+			const invalidTouchPoints = this.touchPoints.filter((value) => value !== touchPointsSwipe);
+			return invalidTouchPoints.length === 0
+				&& this.timeElapsed < this.maxSwipeDuration
+				&& (Math.abs(this.changeY) > this.minSwipeDistance
+				|| Math.abs(this.changeX) > this.minSwipeDistance);
+		},
+
+		isDragGesture() {
+			const invalidTouchPoints = this.touchPoints.filter((value) => value !== touchPointsDrag);
+			return invalidTouchPoints.length === 0;
+		},
+	},
+
+	watch: {
+		timeCurrent() {
+			if (this.isDragGesture) {
+				this.$emit(`on-drag-${this.direction}`, this.gesture);
+			}
+		},
+
+		touchEnded(completed) {
+			if (completed) {
+				if (this.isSwipeGesture) {
+					this.$emit(`on-swipe-${this.direction}`, this.gesture);
+				} else if (this.isDragGesture) {
+					this.$emit('on-drag-end', this.gesture);
+				}
+				this.resetGesture();
+			}
+		},
+	},
+
+	methods: {
+		handleTouchEvent(event) {
+			switch (event.type) {
+			case 'touchstart':
+				this.touchStarted = true;
+				this.clientXStart = event.changedTouches[0].clientX;
+				this.clientYStart = event.changedTouches[0].clientY;
+				this.timeStart = event.timeStamp;
+				break;
+			case 'touchmove':
+				this.touchPoints.push(event.changedTouches.length);
+				this.clientXCurrent = event.changedTouches[0].clientX;
+				this.clientYCurrent = event.changedTouches[0].clientY;
+				this.timeCurrent = event.timeStamp;
+				break;
+			case 'touchend':
+				this.touchEnded = true;
+				this.clientXCurrent = event.changedTouches[0].clientX;
+				this.clientYCurrent = event.changedTouches[0].clientY;
+				break;
+			default:
+				break;
+			}
+		},
+
+		resetGesture() {
+			Object.entries(initialValues).forEach(([key, value]) => {
+				this[key] = value;
+			});
+		},
+	},
+};
+</script>

--- a/src/components/TransitionStaggered/README.md
+++ b/src/components/TransitionStaggered/README.md
@@ -1,0 +1,100 @@
+# Transition Staggered
+
+MTransitionStaggered creates a staggered load animation on a group of items (in a list or grid layout). It wraps each individual item and calculates its animation distance through an item-index prop.
+
+```vue
+<template>
+	<div class="grid">
+		<div
+			v-for="index in 12"
+			:key="index"
+			class="grid-column"
+		>
+			<m-transition-staggered
+				:items-per-row-mobile="1"
+				:items-per-row-tablet="4"
+				:item-index="index"
+			>
+				<div
+					v-show="visible"
+					class="grid-item"
+				/>
+			</m-transition-staggered>
+		</div>
+	</div>
+</template>
+
+<script>
+import { MTransitionStaggered } from '@square/maker/components/TransitionStaggered';
+
+export default {
+	components: {
+		MTransitionStaggered,
+	},
+
+	data() {
+		return {
+			visible: true,
+		};
+	},
+
+	mounted() {
+		const transitionIntervalMs = 2000;
+		setInterval(() => {
+			this.visible = !this.visible;
+		}, transitionIntervalMs);
+	},
+};
+</script>
+
+<style scoped>
+.grid {
+	display: flex;
+	flex-wrap: wrap;
+	min-height: 624px;
+}
+
+.grid-column {
+	width: 100%;
+	height: 40px;
+	margin: 0 auto 12px;
+}
+
+.grid-item {
+	width: 100%;
+	height: 40px;
+	background-color: #999;
+}
+
+@media screen and (min-width: 840px) {
+	.grid {
+		min-height: 372px;
+	}
+
+	.grid-column {
+		width: calc(25% - 24px);
+		height: 100px;
+		margin: 0 12px 24px;
+	}
+	.grid-item {
+		height: 100px;
+	}
+}
+</style>
+```
+
+<!-- api-tables:start -->
+## Props
+
+| Prop                 | Type     | Default | Possible values | Description                         |
+| -------------------- | -------- | ------- | --------------- | ----------------------------------- |
+| items-per-row-mobile | `number` | `1`     | —               | Items to stagger per row on mobile  |
+| items-per-row-tablet | `number` | `1`     | —               | Items to stagger per row on tablet  |
+| item-index           | `number` | `1`     | —               | The index of the item within a list |
+
+## Slots
+
+| Slot    | Description        |
+| ------- | ------------------ |
+| default | content to animate |
+<!-- api-tables:end -->

--- a/src/components/TransitionStaggered/index.js
+++ b/src/components/TransitionStaggered/index.js
@@ -1,0 +1,1 @@
+export { default as MTransitionStaggered } from './src/TransitionStaggered.vue';

--- a/src/components/TransitionStaggered/src/TransitionStaggered.vue
+++ b/src/components/TransitionStaggered/src/TransitionStaggered.vue
@@ -1,0 +1,69 @@
+<template>
+	<transition
+		v-bind="$attrs"
+		@enter="handleEnter"
+		@leave="handleLeave"
+	>
+		<slot />
+	</transition>
+</template>
+
+<script>
+import { staggeredFloatUpFn, floatDownFn, tabletMinWidth } from '@square/maker/utils/transitions';
+
+const singleItem = 1;
+
+export default {
+	props: {
+		itemsPerRowMobile: {
+			type: Number,
+			default: 1,
+		},
+		itemsPerRowTablet: {
+			type: Number,
+			default: 1,
+		},
+		itemIndex: {
+			type: Number,
+			default: 1,
+		},
+	},
+
+	data() {
+		return {
+			viewportWidth: 0,
+		};
+	},
+
+	computed: {
+		loadIndex() {
+			const { itemIndex } = this;
+			const { itemsPerRowMobile, itemsPerRowTablet, viewportWidth } = this;
+			const items = viewportWidth < tabletMinWidth ? itemsPerRowMobile : itemsPerRowTablet;
+
+			if (items === singleItem) {
+				return itemIndex;
+			}
+
+			const row = Math.ceil(itemIndex / items);
+			const rowIndex = itemIndex % items > 0 ? itemIndex % items : items;
+			return row * rowIndex;
+		},
+	},
+
+	mounted() {
+		this.viewportWidth = window.innerWidth;
+	},
+
+	methods: {
+		handleEnter(element, onComplete) {
+			element.dataset.loadIndex = this.loadIndex;
+			staggeredFloatUpFn({ element, onComplete });
+		},
+
+		handleLeave(element, onComplete) {
+			floatDownFn({ element, onComplete });
+		},
+	},
+};
+</script>

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -19,6 +19,13 @@ export const spring = {
 	mass,
 };
 
+export const springSubtle = {
+	type,
+	stiffness: 400,
+	damping: 40,
+	mass,
+};
+
 export const springBounce = {
 	type,
 	stiffness: 400,
@@ -78,6 +85,13 @@ const toFloatyY = (progress) => ({
 	...toOpacity(progress),
 	...toMiniSlideY(progress),
 });
+const toStaggeredFloatyY = (progress, distance) => {
+	const toCustomSlideY = styleFactory(distance, START_VALUE, 'y', 'px');
+	return {
+		...toOpacity(progress),
+		...toCustomSlideY(progress),
+	};
+};
 
 export function fadeInFn({ element, onComplete }) {
 	const elementStyler = styler(element);
@@ -226,6 +240,25 @@ export function delayedFloatUpFn({ element, onComplete }) {
 			onComplete,
 		});
 	}, springDelay);
+}
+
+export function staggeredFloatUpFn({ element, onComplete }) {
+	const elementStyler = styler(element);
+	const styleFn = toStaggeredFloatyY;
+	const animationDirection = animateUp;
+	const distanceYBase = 20;
+	const distanceYMultiplier = 5;
+	const endValue = distanceYBase + (element.dataset.loadIndex * distanceYMultiplier);
+	elementStyler.set(styleFn(animationDirection.from));
+	elementStyler.render();
+	animate({
+		...animationDirection,
+		...springSubtle,
+		onUpdate(number) {
+			elementStyler.set(styleFn(number, endValue));
+		},
+		onComplete,
+	});
 }
 
 export function floatDownFn({ element, onComplete }) {

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -30,7 +30,7 @@ export const springBounce = {
 	type,
 	stiffness: 400,
 	damping: 30,
-	mass: 2,
+	mass: 1.5,
 };
 
 const START_VALUE = 0;

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -19,6 +19,13 @@ export const spring = {
 	mass,
 };
 
+export const springBounce = {
+	type,
+	stiffness: 400,
+	damping: 30,
+	mass: 2,
+};
+
 const START_VALUE = 0;
 const END_VALUE = 100;
 const MINI_END_VALUE = 40;
@@ -230,6 +237,38 @@ export function floatDownFn({ element, onComplete }) {
 	animate({
 		...animationDirection,
 		...spring,
+		onUpdate(number) {
+			elementStyler.set(styleFn(number));
+		},
+		onComplete,
+	});
+}
+
+export function springUpBounceFn({ element, onComplete }) {
+	const elementStyler = styler(element);
+	const styleFn = toRelativeY;
+	const animationDirection = animateDown;
+	elementStyler.set(styleFn(animationDirection.from));
+	elementStyler.render();
+	animate({
+		...animationDirection,
+		...springBounce,
+		onUpdate(number) {
+			elementStyler.set(styleFn(number));
+		},
+		onComplete,
+	});
+}
+
+export function springDownBounceFn({ element, onComplete }) {
+	const elementStyler = styler(element);
+	const styleFn = toRelativeY;
+	const animationDirection = animateUp;
+	elementStyler.set(styleFn(animationDirection.from));
+	elementStyler.render();
+	animate({
+		...animationDirection,
+		...springBounce,
 		onUpdate(number) {
 			elementStyler.set(styleFn(number));
 		},


### PR DESCRIPTION
This PR combines previously reviewed components and changes for the Transitions release, including:
- Modal swipe or drag to close functionality on mobile using the `TouchCapture` component
- New `springUpBounceFn` and `springDownBounceFn` transitions on the default and inline action bar
- New `TransitionStaggered` component that takes a row count and item index and animates in item with a delay