### PR TITLE
fix(modal): fix type error when page is scrolled before modal finishes rendering

### DIFF
--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -50,6 +50,13 @@ export default {
 		};
 	},
 
+	computed: {
+		scrollTop() {
+			return this.$refs.modal && this.$refs.modal.$el
+				? this.$refs.modal.$el.scrollTop : 0;
+		},
+	},
+
 	watch: {
 		beforeClose: {
 			immediate: true,
@@ -61,9 +68,7 @@ export default {
 
 	methods: {
 		setScrollTop() {
-			if (this.$refs.modal.$el) {
-				this.isScrolledToTop = this.$refs.modal.$el.scrollTop <= 0;
-			}
+			this.isScrolledToTop = this.scrollTop <= 0;
 		},
 
 		onSwipeDown() {


### PR DESCRIPTION
Fix for this Sentry error when page is scrolled before modal is finished rendering.
https://sentry.io/organizations/square-inc/issues/2860398335/