### PR TITLE
feat(Dialog): Add closeOnClickOutside option to the Dialog component

### DIFF
--- a/src/components/Dialog/README.md
+++ b/src/components/Dialog/README.md
@@ -234,6 +234,21 @@ export default {
 </script>
 ```
 
+### Configurable options
+The `dialogApi.open()` function has a second optional object parameter that offers configurable options. Current available options are:
+
+```ts
+{
+	// Dialog will close when clicked outside of it - default false
+	closeOnClickOutside: boolean;
+
+	// Dialog will call this async function to determine if it should close
+	beforeCloseHook: () => Promise<boolean>;
+}
+```
+
+To hook into the close function, add the `beforeCloseHook` property on the options object when opening the dialog.
+The function must be an async function that returns a boolean - true to close the modal or false to block closing.
 
 
 ## Examples

--- a/src/components/Dialog/src/DialogLayer.vue
+++ b/src/components/Dialog/src/DialogLayer.vue
@@ -10,12 +10,18 @@
 			<div
 				v-if="dialogApi.state.vnode"
 				:class="$s.DialogLayer"
+				@click.capture="closeOnClickOutside"
 			>
 				<pseudo-window
 					body
 					:class="$s.disableScroll"
 				/>
-				<v :nodes="dialogApi.state.vnode" />
+				<div
+					ref="dialog"
+					:class="$s.DialogContent"
+				>
+					<v :nodes="dialogApi.state.vnode" />
+				</div>
 			</div>
 		</m-transition-responsive>
 	</div>
@@ -43,11 +49,16 @@ const apiMixin = {
 		const api = {
 			state: Vue.observable({
 				vnode: undefined,
+				options: {},
 			}),
 
-			open(renderFn) {
+			open(renderFn, options) {
 				const vnode = renderFn(vm.$createElement);
 				this.state.vnode = vnode;
+				this.state.options = {
+					closeOnClickOutside: false,
+					...options,
+				};
 				// function that only closes this specific Dialog
 				return () => {
 					if (this.state.vnode === vnode) {
@@ -107,6 +118,17 @@ export default {
 				leave: floatDownFn,
 			}],
 		};
+	},
+
+	methods: {
+		closeOnClickOutside(event) {
+			const { closeOnClickOutside } = this.dialogApi.state.options;
+			const { dialog } = this.$refs;
+
+			if (dialog && closeOnClickOutside && !dialog.contains(event.target)) {
+				this.dialogApi.close();
+			}
+		},
 	},
 };
 </script>

--- a/src/components/Dialog/src/DialogLayer.vue
+++ b/src/components/Dialog/src/DialogLayer.vue
@@ -52,13 +52,15 @@ const apiMixin = {
 				options: {},
 			}),
 
-			open(renderFn, options) {
+			open(renderFn, options = {}) {
 				const vnode = renderFn(vm.$createElement);
 				this.state.vnode = vnode;
 				this.state.options = {
 					closeOnClickOutside: false,
+					beforeCloseHook: async () => true,
 					...options,
 				};
+
 				// function that only closes this specific Dialog
 				return () => {
 					if (this.state.vnode === vnode) {
@@ -67,10 +69,17 @@ const apiMixin = {
 				};
 			},
 
-			close() {
+			async close() {
 				// Close the open popover (if present) and then close the dialog in the next tick.
 				// Closing at the same time will result in the popover content becoming inline and
 				// causes a weird content shift as the dialog fades away.
+
+				if (this.state.vnode && typeof this.state.options.beforeCloseHook === 'function') {
+					if (!(await this.state.options.beforeCloseHook())) {
+						return; // cancel
+					}
+				}
+
 				vm.popoverApi?.closePopover();
 				vm.$nextTick(() => {
 					this.state.vnode = undefined;


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses

See https://github.com/square/maker/issues/207

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->

This PR adds two configurable options to the Dialog component when opening it via the dialog API.

1. `closeOnClickOutside` - If a click is captured on the dialog layer that is not contained within the dialog content slot, then the dialog will close. Default is false.
2. `beforeCloseHook` - This function gets called before a dialog closes out. The Dialog will only proceed to close if the this hook function returns true
