### PR TITLE
refactor(actionbar): Add --chrome-bottom-offset to bottom padding

### DIFF
--- a/lab/experiments/ActionBarTransition/ItemModal.vue
+++ b/lab/experiments/ActionBarTransition/ItemModal.vue
@@ -171,6 +171,7 @@ export default {
 </style>
 
 <style module="$s">
+/* stylelint-disable length-zero-no-unit */
 .ActionBarWrapper {
 	--regular-bottom-padding: 32px;
 	--extra-bottom-padding-for-deadclick: 32px;
@@ -180,6 +181,7 @@ export default {
 			var(--regular-bottom-padding)
 			+ var(--extra-bottom-padding-for-deadclick)
 			+ var(--safe-area-inset-padding)
+			+ var(--chrome-bottom-offset, 0px)
 		);
 	--actionbar-size: 64px;
 	--actionbar-top-padding: 32px;

--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -86,10 +86,16 @@ export default {
 </script>
 
 <style module="$s">
+/* stylelint-disable length-zero-no-unit */
 .ActionBarLayer {
 	--actionbar-top-padding: 24px;
 	--actionbar-size: 64px;
-	--actionbar-bottom-padding: calc(24px + env(safe-area-inset-bottom, 24px));
+	--actionbar-bottom-padding:
+		calc(
+			24px
+			+ env(safe-area-inset-bottom, 24px)
+			+ var(--chrome-bottom-offset, 0px)
+		);
 
 	padding-bottom:
 		calc(

--- a/src/components/ActionBar/src/AtomicActionBar.vue
+++ b/src/components/ActionBar/src/AtomicActionBar.vue
@@ -40,11 +40,19 @@ export default {
 </script>
 
 <style module="$s">
+/* stylelint-disable length-zero-no-unit */
 .ActionBar {
+	--actionbar-bottom-padding:
+		calc(
+			24px
+			+ env(safe-area-inset-bottom, 24px)
+			+ var(--chrome-bottom-offset, 0px)
+		);
+
 	display: flex;
 	justify-content: space-between;
 	box-sizing: border-box;
-	padding: 24px;
+	padding: 24px 24px var(--actionbar-bottom-padding) 24px;
 	pointer-events: none;
 }
 

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -51,7 +51,15 @@ export default {
 </script>
 
 <style module="$s">
+/* stylelint-disable length-zero-no-unit */
 .ActionBarWrapper {
-	padding: 24px 24px calc(24px + env(safe-area-inset-bottom, 24px)) 24px;
+	--actionbar-bottom-padding:
+		calc(
+			24px
+			+ env(safe-area-inset-bottom, 24px)
+			+ var(--chrome-bottom-offset, 0px)
+		);
+
+	padding: 24px 24px var(--actionbar-bottom-padding) 24px;
 }
 </style>


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
Action bar is missing on iOS Chrome when a page opens in a new tab. (body height is not consistent when open in a new tab vs reload) 

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
 I added `--chrome-bottom-offset` to the action bars and let the app calculate the offset and set the extra space to the action bar.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
Few people were having similar issue:
https://stackoverflow.com/questions/65086394/sticky-element-doesnt-work-properly-in-ios-chrome
https://stackoverflow.com/questions/65282211/chrome-on-iphone-overflows-content-on-empty-page-on-new-tab-only-not-reload
https://stackoverflow.com/questions/37112218/css3-100vh-not-constant-in-mobile-browser
