### PR TITLE
fix(choice): update MChoice selected state when selected prop updates

### DIFF
--- a/lab/experiments/MChoice.vue
+++ b/lab/experiments/MChoice.vue
@@ -1,0 +1,48 @@
+<template>
+	<m-container>
+		<pre>Selected Choice: {{ selectedChoice }}</pre>
+		<m-choice v-model="selectedChoice">
+			<m-choice-option
+				v-for="choice in choices"
+				:key="choice"
+				:value="choice"
+			>
+				{{ choice }}
+			</m-choice-option>
+		</m-choice>
+		<br>
+		<m-button @click="setToVal(4)">
+			Set to 4
+		</m-button>
+	</m-container>
+</template>
+
+<script>
+import { MContainer } from '@square/maker/components/Container';
+import { MChoice, MChoiceOption } from '@square/maker/components/Choice';
+import { MButton } from '@square/maker/components/Button';
+
+// eslint-disable-next-line no-magic-numbers
+const choices = [1, 2, 3, 4, 5];
+
+export default {
+	components: {
+		MContainer,
+		MChoice,
+		MChoiceOption,
+		MButton,
+	},
+	data() {
+		return {
+			selectedChoice: undefined,
+			choices,
+		};
+	},
+
+	methods: {
+		setToVal(number) {
+			this.selectedChoice = number;
+		},
+	},
+};
+</script>

--- a/src/components/Choice/src/Choice.vue
+++ b/src/components/Choice/src/Choice.vue
@@ -93,6 +93,7 @@ export default {
 	watch: {
 		selected() {
 			this.validateProps();
+			this.currentValue = this.selected;
 		},
 
 		currentValue(newValue) {


### PR DESCRIPTION
Fix for https://github.com/square/maker/issues/200
Currently, the selected state of `MChoice` can only be updated from `MChoiceOption`. This updates the selected state when the `selected` property on `MChoice` changes.