### PR TITLE
fix(dialog): Add a width:100% to the div wrapping the dialog content

### DIFF
--- a/src/components/Dialog/src/DialogLayer.vue
+++ b/src/components/Dialog/src/DialogLayer.vue
@@ -18,7 +18,7 @@
 				/>
 				<div
 					ref="dialog"
-					:class="$s.DialogContent"
+					:class="$s.DialogContentWrapper"
 				>
 					<v :nodes="dialogApi.state.vnode" />
 				</div>
@@ -162,6 +162,12 @@ export default {
 @media screen and (--for-tablet-landscape-up) {
 	.DialogLayer {
 		align-items: center;
+	}
+}
+
+@media screen and (--for-tablet-landscape-down) {
+	.DialogContentWrapper {
+		width: 100%;
 	}
 }
 


### PR DESCRIPTION
## Describe the problem this PR addresses
[A previous PR of mine](https://github.com/square/maker/commit/f054fa01a8f86e96efe118b726c0998458d8f9ee) where I introduced `clickOnCloseOutside` to the dialog component causes a regression in which the dialog was no longer 100% width on mobile. This is because I wrapped the content in div in order to set up a vue `$ref` which broke the styling.

## Describe the changes in this PR
Pretty simple fix I am proposing here. Just set the width to 100% for mobile screens. 

Before:

![image](https://user-images.githubusercontent.com/32466096/153924998-ef8cad3b-eef7-4522-9592-1fb86fd2bd22.png)


After 

![image](https://user-images.githubusercontent.com/32466096/153924932-6578b590-0e73-4bf2-858a-c84163a54f20.png)

![image](https://user-images.githubusercontent.com/32466096/153925199-6890e05b-df31-4a70-a594-3bf88294e852.png)
