### PR TITLE
fix(action bar buttons): allow wrapping text on action bar buttons

### DIFF
--- a/lab/experiments/ActionBarButtons.vue
+++ b/lab/experiments/ActionBarButtons.vue
@@ -15,7 +15,7 @@
 					key="confirm"
 					full-width
 				>
-					Action button with very long text that wraps with very long text that wraps
+					Action long text that wraps with very long text that wraps
 					with very long text that wraps with very long text that wraps
 				</m-action-bar-button>
 			</m-inline-action-bar>
@@ -32,11 +32,9 @@
 					key="confirm"
 					full-width
 				>
-					Action button with very long text that wraps with very long text that wraps
-					with very long text that wraps with very long text that wraps
+					Action with text that wraps
 					<template #information>
-						Label with very long text that wraps with very long text that wraps
-						with very long text that wraps with very long text that wraps
+						Label with long text that wraps
 					</template>
 				</m-action-bar-button>
 			</m-inline-action-bar>
@@ -54,11 +52,9 @@
 					full-width
 					align="space-between"
 				>
-					Action button with very long text that wraps with very long text that wraps
-					with very long text that wraps with very long text that wraps
+					Action with text that wraps
 					<template #information>
-						Label with very long text that wraps with very long text that wraps
-						with very long text that wraps with very long text that wraps
+						Label with long text that wraps
 					</template>
 				</m-action-bar-button>
 			</m-inline-action-bar>
@@ -69,7 +65,7 @@
 					key="confirm"
 					full-width
 				>
-					Action button with text that wraps Action button with text that wraps
+					Action with text that wraps Action with text that wraps
 				</m-action-bar-button>
 			</m-inline-action-bar>
 		</div>
@@ -79,7 +75,7 @@
 					key="confirm"
 					full-width
 				>
-					Action button with text that wraps
+					Confirm
 					<template #information>
 						Label
 					</template>
@@ -165,7 +161,7 @@ export default {
 .wrapper {
 	max-width: 400px;
 	margin: 0 auto;
-	font-family: Arial, Helvetica, sans-serif;
+	font-family: "Square Market", system-ui;
 	background: #ccc;
 
 	& > div {

--- a/lab/experiments/ActionBarButtons.vue
+++ b/lab/experiments/ActionBarButtons.vue
@@ -1,0 +1,181 @@
+<template>
+	<div
+		class="wrapper"
+		bg-color="#ccc"
+	>
+		<div>
+			<m-inline-action-bar>
+				<m-action-bar-button
+					key="close"
+					color="#f6f6f6"
+				>
+					<x-icon class="icon" />
+				</m-action-bar-button>
+				<m-action-bar-button
+					key="confirm"
+					full-width
+				>
+					Action button with very long text that wraps with very long text that wraps
+					with very long text that wraps with very long text that wraps
+				</m-action-bar-button>
+			</m-inline-action-bar>
+		</div>
+		<div>
+			<m-inline-action-bar>
+				<m-action-bar-button
+					key="close"
+					color="#f6f6f6"
+				>
+					<x-icon class="icon" />
+				</m-action-bar-button>
+				<m-action-bar-button
+					key="confirm"
+					full-width
+				>
+					Action button with very long text that wraps with very long text that wraps
+					with very long text that wraps with very long text that wraps
+					<template #information>
+						Label with very long text that wraps with very long text that wraps
+						with very long text that wraps with very long text that wraps
+					</template>
+				</m-action-bar-button>
+			</m-inline-action-bar>
+		</div>
+		<div>
+			<m-inline-action-bar>
+				<m-action-bar-button
+					key="close"
+					color="#f6f6f6"
+				>
+					<x-icon class="icon" />
+				</m-action-bar-button>
+				<m-action-bar-button
+					key="confirm"
+					full-width
+					align="space-between"
+				>
+					Action button with very long text that wraps with very long text that wraps
+					with very long text that wraps with very long text that wraps
+					<template #information>
+						Label with very long text that wraps with very long text that wraps
+						with very long text that wraps with very long text that wraps
+					</template>
+				</m-action-bar-button>
+			</m-inline-action-bar>
+		</div>
+		<div>
+			<m-inline-action-bar>
+				<m-action-bar-button
+					key="confirm"
+					full-width
+				>
+					Action button with text that wraps Action button with text that wraps
+				</m-action-bar-button>
+			</m-inline-action-bar>
+		</div>
+		<div>
+			<m-inline-action-bar>
+				<m-action-bar-button
+					key="confirm"
+					full-width
+				>
+					Action button with text that wraps
+					<template #information>
+						Label
+					</template>
+				</m-action-bar-button>
+			</m-inline-action-bar>
+		</div>
+		<div>
+			<m-inline-action-bar>
+				<m-action-bar-button
+					key="confirm"
+					full-width
+					align="space-between"
+				>
+					Confirm
+					<template #information>
+						Label
+					</template>
+				</m-action-bar-button>
+			</m-inline-action-bar>
+		</div>
+		<div>
+			<m-inline-action-bar>
+				<m-action-bar-button
+					key="action"
+					color="#f6f6f6"
+					full-width
+				>
+					Action
+				</m-action-bar-button>
+				<m-action-bar-button
+					key="confirm"
+					full-width
+				>
+					Confirm
+				</m-action-bar-button>
+			</m-inline-action-bar>
+		</div>
+		<div>
+			<m-inline-action-bar>
+				<m-action-bar-button
+					key="close"
+					color="#f6f6f6"
+				>
+					<x-icon class="icon" />
+				</m-action-bar-button>
+			</m-inline-action-bar>
+		</div>
+		<div>
+			<m-inline-action-bar>
+				<m-action-bar-button
+					key="close"
+					full-width
+					color="#f6f6f6"
+				>
+					<m-loading />
+				</m-action-bar-button>
+			</m-inline-action-bar>
+		</div>
+	</div>
+</template>
+
+<script>
+import { MInlineActionBar, MActionBarButton } from '@square/maker/components/ActionBar';
+import XIcon from '@square/maker-icons/X';
+import { MLoading } from '@square/maker/components/Loading';
+
+export default {
+	components: {
+		MInlineActionBar,
+		MActionBarButton,
+		XIcon,
+		MLoading,
+	},
+
+	data() {
+		return {
+		};
+	},
+};
+</script>
+
+<style scoped>
+.wrapper {
+	max-width: 400px;
+	margin: 0 auto;
+	font-family: Arial, Helvetica, sans-serif;
+	background: #ccc;
+
+	& > div {
+		position: relative;
+		height: 96px;
+	}
+}
+
+.icon {
+	width: 16px;
+	height: 16px;
+}
+</style>

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -1,12 +1,13 @@
 <template>
 	<button
+		ref="button"
 		:class="[
 			$s.Button,
 			$s[`align_${align}`],
 			$s[`shape_${shape}`],
 			{
 				[$s.fullWidth]: fullWidth,
-				[$s.iconButton]: isSingleChild(),
+				[$s.iconButton]: isSingleChild() && !fullWidth,
 				[$s.loading]: loading,
 			}
 		]"
@@ -20,13 +21,29 @@
 			v-if="loading"
 			:class="$s.Loading"
 		/>
-		<span :class="[$s.MainText, $s.TruncateText]">
+		<span
+			ref="main"
+			:class="[
+				$s.MainText,
+				{
+					[$s.TruncateText]: !isSingleChild(),
+					[$s.ShrinkText]: isMainTextWrapping,
+				}
+			]"
+		>
 			<!-- @slot Button label -->
 			<slot />
 		</span>
 		<span
 			v-if="$scopedSlots.information"
-			:class="[$s.InformationText, $s.TruncateText]"
+			ref="info"
+			:class="[
+				$s.InformationText,
+				$s.TruncateText,
+				{
+					[$s.ShrinkText]: isInfoTextWrapping,
+				}
+			]"
 		>
 			<!-- @slot Information label -->
 			<slot
@@ -141,6 +158,13 @@ export default {
 		},
 	},
 
+	data() {
+		return {
+			isMainTextWrapping: false,
+			isInfoTextWrapping: false,
+		};
+	},
+
 	computed: {
 		style() {
 			return fill({
@@ -148,6 +172,16 @@ export default {
 				textColor: this.textColor,
 			});
 		},
+	},
+
+	mounted() {
+		this.$nextTick(() => {
+			const { button, main, info } = this.$refs;
+			/* eslint-disable no-magic-numbers */
+			this.isMainTextWrapping = main && main.offsetHeight > button.offsetHeight / 2;
+			this.isInfoTextWrapping = info && info.offsetHeight > button.offsetHeight / 2;
+			/* eslint-enable no-magic-numbers */
+		});
 	},
 
 	methods: {
@@ -181,6 +215,7 @@ export default {
 	--medium-font-size: 16px;
 	--medium-padding: 24px;
 	--medium-line-height: 1.77;
+	--shrink-font-size: 14px;
 
 	position: relative;
 	display: inline-flex;
@@ -321,11 +356,18 @@ export default {
 }
 
 .TruncateText {
+	display: -webkit-box;
+	flex: 1;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
 	max-width: 100%;
 	overflow: hidden;
 	line-height: 1.1;
-	white-space: nowrap;
 	text-overflow: ellipsis;
+}
+
+.ShrinkText {
+	font-size: var(--shrink-font-size);
 }
 
 .Button.align_center .InformationText {

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -1,6 +1,5 @@
 <template>
 	<button
-		ref="button"
 		:class="[
 			$s.Button,
 			$s[`align_${align}`],
@@ -8,6 +7,7 @@
 			{
 				[$s.fullWidth]: fullWidth,
 				[$s.iconButton]: isSingleChild() && !fullWidth,
+				[$s.hasMainAndLabelText]: hasMainAndLabelText(),
 				[$s.loading]: loading,
 			}
 		]"
@@ -22,12 +22,10 @@
 			:class="$s.Loading"
 		/>
 		<span
-			ref="main"
 			:class="[
 				$s.MainText,
 				{
 					[$s.TruncateText]: !isSingleChild(),
-					[$s.ShrinkText]: isMainTextWrapping,
 				}
 			]"
 		>
@@ -36,14 +34,7 @@
 		</span>
 		<span
 			v-if="$scopedSlots.information"
-			ref="info"
-			:class="[
-				$s.InformationText,
-				$s.TruncateText,
-				{
-					[$s.ShrinkText]: isInfoTextWrapping,
-				}
-			]"
+			:class="[$s.InformationText, $s.TruncateText]"
 		>
 			<!-- @slot Information label -->
 			<slot
@@ -158,13 +149,6 @@ export default {
 		},
 	},
 
-	data() {
-		return {
-			isMainTextWrapping: false,
-			isInfoTextWrapping: false,
-		};
-	},
-
 	computed: {
 		style() {
 			return fill({
@@ -174,28 +158,30 @@ export default {
 		},
 	},
 
-	mounted() {
-		this.$nextTick(() => {
-			const { button, main, info } = this.$refs;
-			/* eslint-disable no-magic-numbers */
-			this.isMainTextWrapping = main && main.offsetHeight > button.offsetHeight / 2;
-			this.isInfoTextWrapping = info && info.offsetHeight > button.offsetHeight / 2;
-			/* eslint-enable no-magic-numbers */
-		});
-	},
-
 	methods: {
 		isSingleChild() {
 			if (this.$scopedSlots.information) {
 				return false;
 			}
-			const zero = 0;
 			const children = (this.$slots.default || []).filter(
-				(vnode) => vnode.tag || vnode.text.trim().length > zero,
+				(vnode) => vnode.tag || vnode.text.trim().length > 0,
 			);
 			const singleChild = 1;
 			const firstChildIndex = 0;
 			return children.length === singleChild && children[firstChildIndex].tag;
+		},
+
+		hasMainAndLabelText() {
+			if (!this.$scopedSlots.information) {
+				return false;
+			}
+			const main = (this.$slots.default || []).filter(
+				(vnode) => vnode.tag || vnode.text.trim().length > 0,
+			);
+			const info = (this.$scopedSlots.information() || []).filter(
+				(vnode) => vnode.tag || vnode.text.trim().length > 0,
+			);
+			return main.length > 0 && info.length > 0;
 		},
 
 		handleEscKey() {
@@ -212,10 +198,9 @@ export default {
 <style module="$s">
 .Button {
 	--medium-height: 48px;
-	--medium-font-size: 16px;
+	--medium-font-size: 14px;
 	--medium-padding: 24px;
 	--medium-line-height: 1.77;
-	--shrink-font-size: 14px;
 
 	position: relative;
 	display: inline-flex;
@@ -355,6 +340,14 @@ export default {
 	font-size: 12px;
 }
 
+.hasMainAndLabelText {
+	text-align: right;
+
+	& .InformationText {
+		text-align: left;
+	}
+}
+
 .TruncateText {
 	display: -webkit-box;
 	flex: 1;
@@ -364,10 +357,6 @@ export default {
 	overflow: hidden;
 	line-height: 1.1;
 	text-overflow: ellipsis;
-}
-
-.ShrinkText {
-	font-size: var(--shrink-font-size);
 }
 
 .Button.align_center .InformationText {

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -7,7 +7,7 @@
 			$s[`align_${align}`],
 			{
 				[$s.fullWidth]: fullWidth,
-				[$s.iconButton]: isSingleChild(),
+				[$s.iconButton]: isSingleChild() && !fullWidth,
 				[$s.loading]: loading,
 			}
 		]"


### PR DESCRIPTION
This PR:
- Reduces action bar button text size from 16px to 14px, to align with medium buttons
- Allows action bar button text to wrap before truncating after 2 lines
- Fixes [issue](https://github.com/square/maker/issues/221) where the `isSingleChild` class was overriding the `full-width` prop.
<img width="403" alt="Screen Shot 2022-02-15 at 3 44 41 PM" src="https://user-images.githubusercontent.com/1486885/154147493-4c707d5f-9daf-4e12-9164-e4f420c70845.png">

