### PR TITLE
docs: Heading / Text Doc Revision

### DIFF
--- a/src/components/Heading/README.md
+++ b/src/components/Heading/README.md
@@ -1,258 +1,43 @@
 # Heading
 
-Use the Heading component for heading text. There are 9 heading sizes: -2 to 7. The font family, font weight, and text color are customizable.
+Use the Heading component for Heading text. There are 10 text sizes: -2 to 7. The font family, font weight, and text color are customizable.
 
 ```vue
 <template>
 	<div>
-		font family
-		<br>
-		<select v-model="fontFamily">
-			<option value="inherit">
-				inherit
-			</option>
-			<option value="arial">
-				arial
-			</option>
-			<option value="serif">
-				serif
-			</option>
-			<option value="sans-serif">
-				sans-serif
-			</option>
-			<option value="monospace">
-				monospace
-			</option>
-		</select>
-		<br>
-		font weight
-		<br>
-		<input
-			v-model="fontWeight"
-			type="range"
-			min="100"
-			max="900"
-			step="100"
-		>
-		{{ fontWeight }}
-		<br>
-		text color
-		<br>
-		<input
-			v-model="textColor"
-			type="color"
-		>
-		<br>
-		<br>
 		<m-heading
-			v-for="namedSize in namedSizes"
-			:key="namedSize.name"
-			:size="namedSize.size"
-			:font-family="fontFamily"
-			:weight="Number.parseInt(fontWeight, 10)"
-			:text-color="textColor"
+			v-for="size in [5, 4, 3, 2, 1]"
+			:key="size"
+			:size="size"
 		>
-			{{ namedSize.name }}
+			Heading (Size {{ size }})
 		</m-heading>
 	</div>
 </template>
 
 <script>
-import { defaultTheme } from '@square/maker/components/Theme';
 import { MHeading } from '@square/maker/components/Heading';
 
 export default {
 	components: {
 		MHeading,
 	},
-	data() {
-		const defaults = defaultTheme();
-		return {
-			fontFamily: defaults.heading.fontFamily,
-			fontWeight: defaults.heading.weight,
-			textColor: defaults.resolve(defaults.heading.textColor),
-			namedSizes: [
-				{
-					name: 'Headline 1',
-					size: 7,
-				},
-				{
-					name: 'Headline 2',
-					size: 6,
-				},
-				{
-					name: 'Headline 3',
-					size: 5,
-				},
-				{
-					name: 'Headline 4',
-					size: 4,
-				},
-				{
-					name: 'Headline 5',
-					size: 3,
-				},
-				{
-					name: 'Title 1',
-					size: 4,
-				},
-				{
-					name: 'Title 2',
-					size: 3,
-				},
-				{
-					name: 'Title 3',
-					size: 2,
-				},
-				{
-					name: 'Title 4',
-					size: 1,
-				},
-				{
-					name: 'Title 5',
-					size: -1,
-				},
-				{
-					name: 'Title 6',
-					size: -2,
-				},
-			],
-		};
-	},
 };
 </script>
 ```
-
-## Theming
-
-The Heading component can be further customized via the Theme component, where the base font size and font size scale can be set to create a custom typographical hierarchy.
-
-```vue
-<template>
-	<m-theme :theme="theme">
-		base font size
-		<br>
-		<input
-			v-model="baseFontSize"
-			type="range"
-			min="16"
-			max="24"
-			step="1"
-		>
-		{{ baseFontSize }}px
-		<br>
-		font size scale
-		<br>
-		<input
-			v-model="fontSizeScale"
-			type="range"
-			min="1"
-			max="1.62"
-			step="0.01"
-		>
-		{{ fontSizeScale }}
-		<br>
-		font family
-		<br>
-		<select v-model="fontFamily">
-			<option value="inherit">
-				inherit
-			</option>
-			<option value="arial">
-				arial
-			</option>
-			<option value="serif">
-				serif
-			</option>
-			<option value="sans-serif">
-				sans-serif
-			</option>
-			<option value="monospace">
-				monospace
-			</option>
-		</select>
-		<br>
-		font weight
-		<br>
-		<input
-			v-model="fontWeight"
-			type="range"
-			min="100"
-			max="900"
-			step="100"
-		>
-		{{ fontWeight }}
-		<br>
-		text color
-		<br>
-		<input
-			v-model="textColor"
-			type="color"
-		>
-		<br>
-		<br>
-		<m-heading
-			v-for="size in [-2, -1, 0, 1, 2, 3, 4, 5, 6, 7]"
-			:key="size"
-			:size="size"
-		>
-			Size {{ size }}
-		</m-heading>
-	</m-theme>
-</template>
-
-<script>
-import { MTheme, defaultTheme } from '@square/maker/components/Theme';
-import { MHeading } from '@square/maker/components/Heading';
-
-export default {
-	components: {
-		MHeading,
-		MTheme,
-	},
-	data() {
-		const defaults = defaultTheme();
-		return {
-			baseFontSize: defaults.fonts.baseSize,
-			fontSizeScale: defaults.fonts.sizeScale,
-			fontFamily: defaults.heading.fontFamily,
-			fontWeight: defaults.heading.weight,
-			textColor: defaults.resolve(defaults.heading.textColor),
-		};
-	},
-	computed: {
-		theme() {
-			return {
-				fonts: {
-					baseSize: Number.parseInt(this.baseFontSize, 10),
-					sizeScale: Number.parseFloat(this.fontSizeScale),
-				},
-				heading: {
-					fontFamily: this.fontFamily,
-					textColor: this.textColor,
-					weight: Number.parseInt(this.fontWeight, 10),
-				},
-			};
-		},
-	},
-};
-</script>
-```
-
-
 
 <!-- api-tables:start -->
 ## Props
 
-Supports attributes from [`<h1>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h1).
+Supports attributes from [`<Heading_Elements>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements).
 
-| Prop        | Type     | Default | Possible values                           | Description                                                             |
-| ----------- | -------- | ------- | ----------------------------------------- | ----------------------------------------------------------------------- |
-| size        | `number` | —       | —                                         | Size of heading. Influences which element is used.                      |
-| element     | `string` | —       | `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `div` | Override Heading element. By default, the element is derived from size. |
-| font-family | `string` | —       | —                                         | Heading font family                                                     |
-| text-color  | `string` | —       | —                                         | Heading text color                                                      |
-| weight      | `number` | —       | —                                         | font weight                                                             |
+| Prop        | Type     | Default | Possible values                                               | Description                                                             |
+| ----------- | -------- | ------- | ------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| size        | `number` | —       | `7`, `6`, `5`, `4`, `3`, `2`, `1`, `0`, `-1`, `-2`            | Size of heading. Influences which element is used.                      |
+| element     | `string` | —       | `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `div`                     | Override Heading element. By default, the element is derived from size. |
+| font-family | `string` | —       | —                                                             | Font family                                                             |
+| font-weight | `number` | —       | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values                        |
+| color       | `string` | —       | —                                                             | Color                                                                   |
 
 
 ## Slots
@@ -260,9 +45,4 @@ Supports attributes from [`<h1>`](https://developer.mozilla.org/en-US/docs/Web/H
 | Slot    | Description     |
 | ------- | --------------- |
 | default | heading content |
-
-
-## Events
-
-Supports events from [`<h1>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h1).
 <!-- api-tables:end -->

--- a/src/components/Heading/src/Heading.vue
+++ b/src/components/Heading/src/Heading.vue
@@ -9,8 +9,7 @@ const MAX_WEIGHT = 900;
 
 /**
  * Heading
- * @inheritAttrs h1
- * @inheritListeners h1
+ * @inheritAttrs Heading_Elements
  */
 export default {
 	inject: {
@@ -25,6 +24,7 @@ export default {
 	props: {
 		/**
 		 * Size of heading. Influences which element is used.
+		 * @values 7, 6, 5, 4, 3, 2, 1, 0, -1, -2
 		 */
 		size: {
 			type: Number,
@@ -40,32 +40,35 @@ export default {
 			validator: (element) => ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div'].includes(element),
 		},
 		/**
-		 * Heading font family
+		 * Font family
+		 * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/font-family}
 		 */
 		fontFamily: {
 			type: String,
 			default: undefined,
 		},
 		/**
-		 * Heading text color
+		 * Font weight with standard numeric keyword values
+		 * @values 100, 200, 300, 400, 500, 600, 700, 800, 900
 		 */
-		textColor: {
-			type: String,
-			default: undefined,
-			validator: (color) => chroma.valid(color),
-		},
-		/**
-		 * font weight
-		 */
-		weight: {
+		fontWeight: {
 			type: Number,
 			default: undefined,
 			validator: (weight) => weight >= MIN_WEIGHT && weight <= MAX_WEIGHT,
 		},
+		/**
+		 * Color
+		 * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color}
+		 */
+		color: {
+			type: String,
+			default: undefined,
+			validator: (color) => chroma.valid(color),
+		},
 	},
 
 	computed: {
-		...resolveThemeableProps('heading', ['size', 'fontFamily', 'textColor', 'weight']),
+		...resolveThemeableProps('heading', ['size', 'fontFamily', 'fontWeight', 'color']),
 		tag() {
 			if (this.element) {
 				return this.element;
@@ -103,8 +106,8 @@ export default {
 			const { fonts } = this.theme;
 			return {
 				fontFamily: this.resolvedFontFamily,
-				color: this.resolvedTextColor,
-				fontWeight: this.resolvedWeight,
+				fontWeight: this.resolvedFontWeight,
+				color: this.resolvedColor,
 				'--mobile-base-font-size': fonts.baseSize,
 				'--mobile-font-size-scale': fonts.sizeScale,
 			};

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -1,229 +1,44 @@
 # Text
 
-Use the Text component for regular body text. There are 9 text sizes: -2 to 1. The font family, font weight, and text color are customizable.
+Use the Text component for regular body text. There are 10 text sizes: -2 to 7. The font family, font weight, and text color are customizable.
 
 ```vue
 <template>
 	<div>
-		font family
-		<br>
-		<select v-model="fontFamily">
-			<option value="inherit">
-				inherit
-			</option>
-			<option value="arial">
-				arial
-			</option>
-			<option value="serif">
-				serif
-			</option>
-			<option value="sans-serif">
-				sans-serif
-			</option>
-			<option value="monospace">
-				monospace
-			</option>
-		</select>
-		<br>
-		font weight
-		<br>
-		<input
-			v-model="fontWeight"
-			type="range"
-			min="100"
-			max="900"
-			step="100"
-		>
-		{{ fontWeight }}
-		<br>
-		text color
-		<br>
-		<input
-			v-model="textColor"
-			type="color"
-		>
-		<br>
 		<m-text
-			v-for="namedSize in namedSizes"
-			:key="namedSize.name"
-			:size="namedSize.size"
-			:font-family="fontFamily"
-			:weight="Number.parseInt(fontWeight, 10)"
-			:text-color="textColor"
+			v-for="size in [1, 0, -1, -2]"
+			:key="size"
+			:size="size"
+			:font-weight="600"
 		>
-			{{ namedSize.name }}
+			Text (Size {{ size }})
 		</m-text>
 	</div>
 </template>
 
 <script>
-import { defaultTheme } from '@square/maker/components/Theme';
 import { MText } from '@square/maker/components/Text';
 
 export default {
 	components: {
 		MText,
 	},
-	data() {
-		const defaults = defaultTheme();
-		return {
-			fontFamily: defaults.text.fontFamily,
-			fontWeight: defaults.text.weight,
-			textColor: defaults.resolve(defaults.text.textColor),
-			namedSizes: [
-				{
-					name: 'Paragraph 1 / Label 1',
-					size: 1,
-				},
-				{
-					name: 'Paragraph 2 / Label 2',
-					size: 0,
-				},
-				{
-					name: 'Paragraph 3 / Label 3',
-					size: -1,
-				},
-				{
-					name: 'Paragraph 4 / Label 4',
-					size: -2,
-				},
-			],
-		};
-	},
 };
 </script>
 ```
-
-## Theming
-
-The Text component can be further customized via the Theme component, where the base font size and font size scale can be set to create a custom typographical hierarchy.
-
-```vue
-<template>
-	<m-theme :theme="theme">
-		base font size
-		<br>
-		<input
-			v-model="baseFontSize"
-			type="range"
-			min="16"
-			max="24"
-			step="1"
-		>
-		{{ baseFontSize }}px
-		<br>
-		font size scale
-		<br>
-		<input
-			v-model="fontSizeScale"
-			type="range"
-			min="1"
-			max="1.62"
-			step="0.01"
-		>
-		{{ fontSizeScale }}
-		<br>
-		font family
-		<br>
-		<select v-model="fontFamily">
-			<option value="inherit">
-				inherit
-			</option>
-			<option value="arial">
-				arial
-			</option>
-			<option value="serif">
-				serif
-			</option>
-			<option value="sans-serif">
-				sans-serif
-			</option>
-			<option value="monospace">
-				monospace
-			</option>
-		</select>
-		<br>
-		font weight
-		<br>
-		<input
-			v-model="fontWeight"
-			type="range"
-			min="100"
-			max="900"
-			step="100"
-		>
-		{{ fontWeight }}
-		<br>
-		text color
-		<br>
-		<input
-			v-model="textColor"
-			type="color"
-		>
-		<br>
-		<m-text
-			v-for="size in [-2, -1, 0, 1]"
-			:key="size"
-			:size="size"
-		>
-			Size {{ size }}
-		</m-text>
-	</m-theme>
-</template>
-
-<script>
-import { MTheme, defaultTheme } from '@square/maker/components/Theme';
-import { MText } from '@square/maker/components/Text';
-
-export default {
-	components: {
-		MText,
-		MTheme,
-	},
-	data() {
-		const defaults = defaultTheme();
-		return {
-			baseFontSize: defaults.fonts.baseSize,
-			fontSizeScale: defaults.fonts.sizeScale,
-			fontFamily: defaults.text.fontFamily,
-			fontWeight: defaults.text.weight,
-			textColor: defaults.resolve(defaults.text.textColor),
-		};
-	},
-	computed: {
-		theme() {
-			return {
-				fonts: {
-					baseSize: Number.parseInt(this.baseFontSize, 10),
-					sizeScale: Number.parseFloat(this.fontSizeScale),
-				},
-				text: {
-					fontFamily: this.fontFamily,
-					textColor: this.textColor,
-					weight: Number.parseInt(this.fontWeight, 10),
-				},
-			};
-		},
-	},
-};
-</script>
-```
-
-
 
 <!-- api-tables:start -->
 ## Props
 
-Supports attributes from [`<span>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span).
+Supports attributes from [`global attributes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes). The following props are provided for convenience.
 
 | Prop        | Type     | Default | Possible values | Description                              |
 | ----------- | -------- | ------- | --------------- | ---------------------------------------- |
 | element     | `string` | `'p'`   | `p`, `span`     | which HTML element to wrap the text with |
-| size        | `number` | —       | —               | size of text                             |
-| font-family | `string` | —       | —               | text font family                         |
-| text-color  | `string` | —       | —               | text color                               |
-| weight      | `number` | —       | —               | font weight                              |
-
+| size        | `number` | `0`     | `-2`,`-1`,`0`,`1`,`2`,`3`,`4`,`5`,`6`,`7` | size of text                             |
+| font-family | `string` | —       | —               | [font family](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family)                         |
+| color       | `string` | —       | —               | [color](https://developer.mozilla.org/en-US/docs/Web/CSS/color)                               |
+| font-weight | `number` | —       | `100`,`...`,`900`| Font weight with standard numeric keyword values                              |
 
 ## Slots
 
@@ -231,8 +46,4 @@ Supports attributes from [`<span>`](https://developer.mozilla.org/en-US/docs/Web
 | ------- | ------------ |
 | default | text content |
 
-
-## Events
-
-Supports events from [`<span>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span).
 <!-- api-tables:end -->

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -9,7 +9,6 @@ Use the Text component for regular body text. There are 10 text sizes: -2 to 7. 
 			v-for="size in [1, 0, -1, -2]"
 			:key="size"
 			:size="size"
-			:font-weight="600"
 		>
 			Text (Size {{ size }})
 		</m-text>

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -29,20 +29,20 @@ export default {
 <!-- api-tables:start -->
 ## Props
 
-Supports attributes from [`global attributes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes). The following props are provided for convenience.
+Supports attributes from [`<p>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p).
 
-| Prop        | Type     | Default | Possible values | Description                              |
-| ----------- | -------- | ------- | --------------- | ---------------------------------------- |
-| element     | `string` | `'p'`   | `p`, `span`     | which HTML element to wrap the text with |
-| size        | `number` | `0`     | `-2`,`-1`,`0`,`1`,`2`,`3`,`4`,`5`,`6`,`7` | size of text                             |
-| font-family | `string` | —       | —               | [font family](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family)                         |
-| color       | `string` | —       | —               | [color](https://developer.mozilla.org/en-US/docs/Web/CSS/color)                               |
-| font-weight | `number` | —       | `100`,`...`,`900`| Font weight with standard numeric keyword values                              |
+| Prop        | Type     | Default | Possible values                                               | Description                                      |
+| ----------- | -------- | ------- | ------------------------------------------------------------- | ------------------------------------------------ |
+| element     | `string` | `'p'`   | `p`, `span`                                                   | HTML Element wrapper                             |
+| size        | `number` | —       | `7`, `6`, `5`, `4`, `3`, `2`, `1`, `0`, `-1`, `-2`            | Size of text                                     |
+| font-family | `string` | —       | —                                                             | Font family                                      |
+| font-weight | `number` | —       | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values |
+| color       | `string` | —       | —                                                             | Color                                            |
+
 
 ## Slots
 
 | Slot    | Description  |
 | ------- | ------------ |
 | default | text content |
-
 <!-- api-tables:end -->

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -8,8 +8,7 @@ const MIN_WEIGHT = 100;
 const MAX_WEIGHT = 900;
 
 /**
- * @inheritAttrs span
- * @inheritListeners span
+ * @inheritAttrs p
  */
 export default {
 	inject: {
@@ -23,7 +22,7 @@ export default {
 
 	props: {
 		/**
-		 * which HTML element to wrap the text with
+		 * HTML Element wrapper
 		 */
 		element: {
 			type: String,
@@ -31,7 +30,8 @@ export default {
 			validator: (element) => ['p', 'span'].includes(element),
 		},
 		/**
-		 * size of text
+		 * Size of text
+		 * @values 7, 6, 5, 4, 3, 2, 1, 0, -1, -2
 		 */
 		size: {
 			type: Number,
@@ -39,32 +39,35 @@ export default {
 			validator: (size) => size >= MIN_SIZE && size <= MAX_SIZE,
 		},
 		/**
-		 * text font family
+		 * Font family
+		 * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/font-family}
 		 */
 		fontFamily: {
 			type: String,
 			default: undefined,
 		},
 		/**
-		 * text color
-		 */
-		color: {
-			type: String,
-			default: undefined,
-			validator: (color) => chroma.valid(color),
-		},
-		/**
-		 * font weight
+		 * Font weight with standard numeric keyword values
+		 * @values 100, 200, 300, 400, 500, 600, 700, 800, 900
 		 */
 		fontWeight: {
 			type: Number,
 			default: undefined,
 			validator: (fontWeight) => fontWeight >= MIN_WEIGHT && fontWeight <= MAX_WEIGHT,
 		},
+		/**
+		 * Color
+		 * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color}
+		 */
+		color: {
+			type: String,
+			default: undefined,
+			validator: (color) => chroma.valid(color),
+		},
 	},
 
 	computed: {
-		...resolveThemeableProps('text', ['size', 'fontFamily', 'color', 'fontWeight']),
+		...resolveThemeableProps('text', ['size', 'fontFamily', 'fontWeight', 'color']),
 		sizeClass() {
 			const minNonNegativeSize = 0;
 			if (this.resolvedSize >= minNonNegativeSize) {
@@ -76,8 +79,8 @@ export default {
 			const { fonts } = this.theme;
 			return {
 				fontFamily: this.resolvedFontFamily,
-				color: this.resolvedColor,
 				fontWeight: this.resolvedFontWeight,
+				color: this.resolvedColor,
 				'--mobile-base-font-size': fonts.baseSize,
 				'--mobile-font-size-scale': fonts.sizeScale,
 			};

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -48,7 +48,7 @@ export default {
 		/**
 		 * text color
 		 */
-		textColor: {
+		color: {
 			type: String,
 			default: undefined,
 			validator: (color) => chroma.valid(color),
@@ -56,7 +56,7 @@ export default {
 		/**
 		 * font weight
 		 */
-		weight: {
+		fontWeight: {
 			type: Number,
 			default: undefined,
 			validator: (weight) => weight >= MIN_WEIGHT && weight <= MAX_WEIGHT,
@@ -64,7 +64,7 @@ export default {
 	},
 
 	computed: {
-		...resolveThemeableProps('text', ['size', 'fontFamily', 'textColor', 'weight']),
+		...resolveThemeableProps('text', ['size', 'fontFamily', 'color', 'fontWeight']),
 		sizeClass() {
 			const minNonNegativeSize = 0;
 			if (this.resolvedSize >= minNonNegativeSize) {
@@ -76,7 +76,7 @@ export default {
 			const { fonts } = this.theme;
 			return {
 				fontFamily: this.resolvedFontFamily,
-				color: this.resolvedTextColor,
+				color: this.resolvedcolor,
 				fontWeight: this.resolvedWeight,
 				'--mobile-base-font-size': fonts.baseSize,
 				'--mobile-font-size-scale': fonts.sizeScale,

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -59,7 +59,7 @@ export default {
 		fontWeight: {
 			type: Number,
 			default: undefined,
-			validator: (weight) => weight >= MIN_WEIGHT && weight <= MAX_WEIGHT,
+			validator: (fontWeight) => fontWeight >= MIN_WEIGHT && fontWeight <= MAX_WEIGHT,
 		},
 	},
 
@@ -76,8 +76,8 @@ export default {
 			const { fonts } = this.theme;
 			return {
 				fontFamily: this.resolvedFontFamily,
-				color: this.resolvedcolor,
-				fontWeight: this.resolvedWeight,
+				color: this.resolvedColor,
+				fontWeight: this.resolvedFontWeight,
 				'--mobile-base-font-size': fonts.baseSize,
 				'--mobile-font-size-scale': fonts.sizeScale,
 			};

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -48,8 +48,8 @@ export default function defaultTheme() {
 		text: {
 			fontFamily: 'inherit',
 			size: 0,
-			textColor: '@colors.text',
-			weight: 400,
+			color: '@colors.text',
+			fontWeight: 400,
 		},
 		heading: {
 			fontFamily: 'inherit',


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
### Documentation complexity
The documentation for Heading and Text was overly complex to convey what the basic components do on their own. 

### Missing or incorrect documentation
The generated docs for Heading and Text either cited incorrect information or was missing information.

### Prop names
We haven't been consistent with prop names particularly in cases that map directly to a CSS property.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
### Simplified Documentation
Each component should document what it does on it's own in the simplest demo possible. Simple examples focused on the most typical output should be the goal for each component. Therefore, higher order concepts around Theming can be isolated and documented separately in the Theme component docs. All theming documentation was removed in favor of consolidation as recommended here: Theming documentation should be separate as recommended here: https://github.com/square/maker/pull/216#issuecomment-1040790471

### Updated documentation that was missing / incorrect
- Updated Heading reference from `h1` to `Heading Elements`
- Removed references to unrelated supported events
- Added `@values` for properties that weren't generated from ranges
- Added links for descriptions using JSDoc format [not yet supported in our doc generation]
- Moved properties so font-family / font-weight are together (similar to css linting property order)

### Updated prop names
Since we're adding some new props we should start to standardize how we name the options we support that provide styling closer to the CSS properties that are being used.

- Renamed `weight` to `font-weight`
- Renamed `text-color` to `color`

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
