### PR TITLE
feat: text-transform prop for MText & MHeading to uppercase text

### DIFF
--- a/src/components/Heading/README.md
+++ b/src/components/Heading/README.md
@@ -31,13 +31,15 @@ export default {
 
 Supports attributes from [`<Heading_Elements>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements).
 
-| Prop        | Type     | Default | Possible values                                               | Description                                                             |
-| ----------- | -------- | ------- | ------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| size        | `number` | —       | `7`, `6`, `5`, `4`, `3`, `2`, `1`, `0`, `-1`, `-2`            | Size of heading. Influences which element is used.                      |
-| element     | `string` | —       | `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `div`                     | Override Heading element. By default, the element is derived from size. |
-| font-family | `string` | —       | —                                                             | Font family                                                             |
-| font-weight | `number` | —       | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values                        |
-| color       | `string` | —       | —                                                             | Color                                                                   |
+| Prop           | Type     | Default     | Possible values                                               | Description                                                             |
+| -------------- | -------- | ----------- | ------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| size           | `number` | —           | `7`, `6`, `5`, `4`, `3`, `2`, `1`, `0`, `-1`, `-2`            | Size of heading. Influences which element is used.                      |
+| element        | `string` | —           | `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `div`                     | Override Heading element. By default, the element is derived from size. |
+| font-family    | `string` | —           | —                                                             | Font family                                                             |
+| font-weight    | `number` | —           | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values                        |
+| color          | `string` | —           | —                                                             | Color                                                                   |
+| font-style     | `string` | `'inherit'` | `inherit`, `normal`, `italic`                                 | font style                                                              |
+| text-transform | `string` | `'inherit'` | `inherit`, `none`, `uppercase`                                | text transform                                                          |
 
 
 ## Slots

--- a/src/components/Heading/README.md
+++ b/src/components/Heading/README.md
@@ -40,6 +40,7 @@ Supports attributes from [`<Heading_Elements>`](https://developer.mozilla.org/en
 | color          | `string` | —           | —                                                             | Color                                                                   |
 | font-style     | `string` | `'inherit'` | `inherit`, `normal`, `italic`                                 | font style                                                              |
 | text-transform | `string` | `'inherit'` | `inherit`, `none`, `uppercase`                                | text transform                                                          |
+| text-align     | `string` | `'inherit'` | `inherit`, `left`, `right`, `center`                          | text align                                                              |
 
 
 ## Slots

--- a/src/components/Heading/src/Heading.vue
+++ b/src/components/Heading/src/Heading.vue
@@ -149,8 +149,10 @@ export default {
 			class: [
 				$s.Heading,
 				$s[`size_${sizeClass}`],
-				$s[`fontstyle_${fontStyle}`],
-				$s[`texttransform_${textTransform}`],
+				{
+					[$s[`fontstyle_${fontStyle}`]]: fontStyle !== 'inherit',
+					[$s[`texttransform_${textTransform}`]]: textTransform !== 'inherit',
+				},
 			],
 			style: inlineStyles,
 			attrs: this.$attrs,
@@ -243,20 +245,12 @@ export default {
 	--lh-7: calc(var(--lh-6) * var(--line-height-scale));
 }
 
-.fontstyle_inherit {
-	font-style: inherit;
-}
-
 .fontstyle_normal {
 	font-style: normal;
 }
 
 .fontstyle_italic {
 	font-style: italic;
-}
-
-.texttransform_inherit {
-	text-transform: inherit;
 }
 
 .texttransform_none {

--- a/src/components/Heading/src/Heading.vue
+++ b/src/components/Heading/src/Heading.vue
@@ -83,6 +83,15 @@ export default {
 			default: 'inherit',
 			validator: (textTransform) => ['inherit', 'none', 'uppercase'].includes(textTransform),
 		},
+		/**
+		 * text align
+		 * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/text-align}
+		 */
+		textAlign: {
+			type: String,
+			default: 'inherit',
+			validator: (textAlign) => ['inherit', 'left', 'right', 'center'].includes(textAlign),
+		},
 	},
 
 	computed: {
@@ -140,6 +149,7 @@ export default {
 			inlineStyles,
 			fontStyle,
 			textTransform,
+			textAlign,
 		} = this;
 		/**
 		 * @slot heading content
@@ -152,6 +162,7 @@ export default {
 				{
 					[$s[`fontstyle_${fontStyle}`]]: fontStyle !== 'inherit',
 					[$s[`texttransform_${textTransform}`]]: textTransform !== 'inherit',
+					[$s[`textalign_${textAlign}`]]: textAlign !== 'inherit',
 				},
 			],
 			style: inlineStyles,
@@ -259,6 +270,18 @@ export default {
 
 .texttransform_uppercase {
 	text-transform: uppercase;
+}
+
+.textalign_left {
+	text-align: left;
+}
+
+.textalign_right {
+	text-align: right;
+}
+
+.textalign_center {
+	text-align: center;
 }
 
 @media (min-width: 1200px) {

--- a/src/components/Heading/src/Heading.vue
+++ b/src/components/Heading/src/Heading.vue
@@ -74,6 +74,15 @@ export default {
 			default: 'inherit',
 			validator: (fontStyle) => ['inherit', 'normal', 'italic'].includes(fontStyle),
 		},
+		/**
+		 * text transform
+		 * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform}
+		 */
+		textTransform: {
+			type: String,
+			default: 'inherit',
+			validator: (textTransform) => ['inherit', 'none', 'uppercase'].includes(textTransform),
+		},
 	},
 
 	computed: {
@@ -130,6 +139,7 @@ export default {
 			tag,
 			inlineStyles,
 			fontStyle,
+			textTransform,
 		} = this;
 		/**
 		 * @slot heading content
@@ -140,6 +150,7 @@ export default {
 				$s.Heading,
 				$s[`size_${sizeClass}`],
 				$s[`fontstyle_${fontStyle}`],
+				$s[`texttransform_${textTransform}`],
 			],
 			style: inlineStyles,
 			attrs: this.$attrs,
@@ -242,6 +253,18 @@ export default {
 
 .fontstyle_italic {
 	font-style: italic;
+}
+
+.texttransform_inherit {
+	text-transform: inherit;
+}
+
+.texttransform_none {
+	text-transform: none;
+}
+
+.texttransform_uppercase {
+	text-transform: uppercase;
 }
 
 @media (min-width: 1200px) {

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -31,13 +31,15 @@ export default {
 
 Supports attributes from [`<p>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p).
 
-| Prop        | Type     | Default | Possible values                                               | Description                                      |
-| ----------- | -------- | ------- | ------------------------------------------------------------- | ------------------------------------------------ |
-| element     | `string` | `'p'`   | `p`, `span`, `li`                                             | HTML Element wrapper                             |
-| size        | `number` | —       | `1`, `0`, `-1`, `-2`                                          | Size of text                                     |
-| font-family | `string` | —       | —                                                             | Font family                                      |
-| font-weight | `number` | —       | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values |
-| color       | `string` | —       | —                                                             | Color                                            |
+| Prop           | Type     | Default     | Possible values                                               | Description                                      |
+| -------------- | -------- | ----------- | ------------------------------------------------------------- | ------------------------------------------------ |
+| element        | `string` | `'p'`       | `p`, `span`, `li`                                             | HTML Element wrapper                             |
+| size           | `number` | —           | `1`, `0`, `-1`, `-2`                                          | Size of text                                     |
+| font-family    | `string` | —           | —                                                             | Font family                                      |
+| font-weight    | `number` | —           | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values |
+| color          | `string` | —           | —                                                             | Color                                            |
+| font-style     | `string` | `'inherit'` | `inherit`, `normal`, `italic`                                 | font style                                       |
+| text-transform | `string` | `'inherit'` | `inherit`, `none`, `uppercase`                                | text transform                                   |
 
 
 ## Slots

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -40,6 +40,7 @@ Supports attributes from [`<p>`](https://developer.mozilla.org/en-US/docs/Web/HT
 | color          | `string` | —           | —                                                             | Color                                            |
 | font-style     | `string` | `'inherit'` | `inherit`, `normal`, `italic`                                 | font style                                       |
 | text-transform | `string` | `'inherit'` | `inherit`, `none`, `uppercase`                                | text transform                                   |
+| text-align     | `string` | `'inherit'` | `inherit`, `left`, `right`, `center`                          | text align                                       |
 
 
 ## Slots

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -122,8 +122,10 @@ export default {
 			class: [
 				$s.Paragraph,
 				$s[`size_${sizeClass}`],
-				$s[`fontstyle_${fontStyle}`],
-				$s[`texttransform_${textTransform}`],
+				{
+					[$s[`fontstyle_${fontStyle}`]]: fontStyle !== 'inherit',
+					[$s[`texttransform_${textTransform}`]]: textTransform !== 'inherit',
+				},
 			],
 			attrs: this.$attrs,
 			style: inlineStyles,
@@ -184,20 +186,12 @@ export default {
 	--lh-1: calc(var(--lh-0) * var(--line-height-scale));
 }
 
-.fontstyle_inherit {
-	font-style: inherit;
-}
-
 .fontstyle_normal {
 	font-style: normal;
 }
 
 .fontstyle_italic {
 	font-style: italic;
-}
-
-.texttransform_inherit {
-	text-transform: inherit;
 }
 
 .texttransform_none {

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -73,6 +73,15 @@ export default {
 			default: 'inherit',
 			validator: (fontStyle) => ['inherit', 'normal', 'italic'].includes(fontStyle),
 		},
+		/**
+		 * text transform
+		 * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform}
+		 */
+		textTransform: {
+			type: String,
+			default: 'inherit',
+			validator: (textTransform) => ['inherit', 'none', 'uppercase'].includes(textTransform),
+		},
 	},
 
 	computed: {
@@ -103,6 +112,7 @@ export default {
 			element,
 			inlineStyles,
 			fontStyle,
+			textTransform,
 		} = this;
 		/**
 		 * @slot text content
@@ -113,6 +123,7 @@ export default {
 				$s.Paragraph,
 				$s[`size_${sizeClass}`],
 				$s[`fontstyle_${fontStyle}`],
+				$s[`texttransform_${textTransform}`],
 			],
 			attrs: this.$attrs,
 			style: inlineStyles,
@@ -183,6 +194,18 @@ export default {
 
 .fontstyle_italic {
 	font-style: italic;
+}
+
+.texttransform_inherit {
+	text-transform: inherit;
+}
+
+.texttransform_none {
+	text-transform: none;
+}
+
+.texttransform_uppercase {
+	text-transform: uppercase;
 }
 
 @media (min-width: 1200px) {

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -82,6 +82,15 @@ export default {
 			default: 'inherit',
 			validator: (textTransform) => ['inherit', 'none', 'uppercase'].includes(textTransform),
 		},
+		/**
+		 * text align
+		 * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/text-align}
+		 */
+		textAlign: {
+			type: String,
+			default: 'inherit',
+			validator: (textAlign) => ['inherit', 'left', 'right', 'center'].includes(textAlign),
+		},
 	},
 
 	computed: {
@@ -113,6 +122,7 @@ export default {
 			inlineStyles,
 			fontStyle,
 			textTransform,
+			textAlign,
 		} = this;
 		/**
 		 * @slot text content
@@ -125,6 +135,7 @@ export default {
 				{
 					[$s[`fontstyle_${fontStyle}`]]: fontStyle !== 'inherit',
 					[$s[`texttransform_${textTransform}`]]: textTransform !== 'inherit',
+					[$s[`textalign_${textAlign}`]]: textAlign !== 'inherit',
 				},
 			],
 			attrs: this.$attrs,
@@ -200,6 +211,18 @@ export default {
 
 .texttransform_uppercase {
 	text-transform: uppercase;
+}
+
+.textalign_left {
+	text-align: left;
+}
+
+.textalign_right {
+	text-align: right;
+}
+
+.textalign_center {
+	text-align: center;
 }
 
 @media (min-width: 1200px) {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
no prop to uppercase all text in MText & MHeading (needed for website)

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
adds `textTransform` prop which supports the values: `inherit`, `none`, `uppercase`

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
nope
