### PR TITLE
feat: adds text-align prop to MText & MHeading

### DIFF
--- a/src/components/Heading/README.md
+++ b/src/components/Heading/README.md
@@ -40,6 +40,7 @@ Supports attributes from [`<Heading_Elements>`](https://developer.mozilla.org/en
 | color          | `string` | —           | —                                                             | Color                                                                   |
 | font-style     | `string` | `'inherit'` | `inherit`, `normal`, `italic`                                 | font style                                                              |
 | text-transform | `string` | `'inherit'` | `inherit`, `none`, `uppercase`                                | text transform                                                          |
+| text-align     | `string` | `'inherit'` | `inherit`, `left`, `right`, `center`                          | text align                                                              |
 
 
 ## Slots

--- a/src/components/Heading/src/Heading.vue
+++ b/src/components/Heading/src/Heading.vue
@@ -83,6 +83,15 @@ export default {
 			default: 'inherit',
 			validator: (textTransform) => ['inherit', 'none', 'uppercase'].includes(textTransform),
 		},
+		/**
+		 * text align
+		 * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/text-align}
+		 */
+		textAlign: {
+			type: String,
+			default: 'inherit',
+			validator: (textAlign) => ['inherit', 'left', 'right', 'center'].includes(textAlign),
+		},
 	},
 
 	computed: {
@@ -140,6 +149,7 @@ export default {
 			inlineStyles,
 			fontStyle,
 			textTransform,
+			textAlign,
 		} = this;
 		/**
 		 * @slot heading content
@@ -152,6 +162,7 @@ export default {
 				{
 					[$s[`fontstyle_${fontStyle}`]]: fontStyle !== 'inherit',
 					[$s[`texttransform_${textTransform}`]]: textTransform !== 'inherit',
+					[$s[`textalign_${textAlign}`]]: textAlign !== 'inherit',
 				},
 			],
 			style: inlineStyles,
@@ -259,6 +270,18 @@ export default {
 
 .texttransform_uppercase {
 	text-transform: uppercase;
+}
+
+.textalign_left {
+	text-align: left;
+}
+
+.textalign_right {
+	text-align: right;
+}
+
+.textalign_center {
+	text-align: center;
 }
 
 @media (min-width: 1200px) {

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -40,6 +40,7 @@ Supports attributes from [`<p>`](https://developer.mozilla.org/en-US/docs/Web/HT
 | color          | `string` | —           | —                                                             | Color                                            |
 | font-style     | `string` | `'inherit'` | `inherit`, `normal`, `italic`                                 | font style                                       |
 | text-transform | `string` | `'inherit'` | `inherit`, `none`, `uppercase`                                | text transform                                   |
+| text-align     | `string` | `'inherit'` | `inherit`, `left`, `right`, `center`                          | text align                                       |
 
 
 ## Slots

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -82,6 +82,15 @@ export default {
 			default: 'inherit',
 			validator: (textTransform) => ['inherit', 'none', 'uppercase'].includes(textTransform),
 		},
+		/**
+		 * text align
+		 * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/text-align}
+		 */
+		textAlign: {
+			type: String,
+			default: 'inherit',
+			validator: (textAlign) => ['inherit', 'left', 'right', 'center'].includes(textAlign),
+		},
 	},
 
 	computed: {
@@ -113,6 +122,7 @@ export default {
 			inlineStyles,
 			fontStyle,
 			textTransform,
+			textAlign,
 		} = this;
 		/**
 		 * @slot text content
@@ -125,6 +135,7 @@ export default {
 				{
 					[$s[`fontstyle_${fontStyle}`]]: fontStyle !== 'inherit',
 					[$s[`texttransform_${textTransform}`]]: textTransform !== 'inherit',
+					[$s[`textalign_${textAlign}`]]: textAlign !== 'inherit',
 				},
 			],
 			attrs: this.$attrs,
@@ -200,6 +211,18 @@ export default {
 
 .texttransform_uppercase {
 	text-transform: uppercase;
+}
+
+.textalign_left {
+	text-align: left;
+}
+
+.textalign_right {
+	text-align: right;
+}
+
+.textalign_center {
+	text-align: center;
 }
 
 @media (min-width: 1200px) {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
no prop to customize text alignment in MText & MHeading

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
adds `textAlign` prop to MText & MHeading which supports values: `inherit`, `left`, `right`, `center`

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
nope