### PR TITLE
fix(actionbarbutton): center align for main and label text

### DIFF
--- a/lab/experiments/ActionBarButtons.vue
+++ b/lab/experiments/ActionBarButtons.vue
@@ -97,7 +97,7 @@
 				>
 					Confirm
 					<template #information>
-						Label
+						Label with longer text
 					</template>
 				</m-action-bar-button>
 			</m-inline-action-bar>

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -350,10 +350,9 @@ export default {
 .TruncateText {
 	/* -webkit-box is supported by all modern browsers */
 	display: -webkit-box;
-	flex: 1;
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
-	max-width: 100%;
+	width: max-content;
 	overflow: hidden;
 	line-height: 1.1;
 	text-overflow: ellipsis;


### PR DESCRIPTION
This fixes https://jira.sqprod.co/browse/MAKER-43

Bug:
<img width="404" alt="Screen Shot 2022-03-02 at 12 04 28 PM" src="https://user-images.githubusercontent.com/1486885/156414314-9c65346e-b698-456c-bc81-54d4dc3017c0.png">

Fixed:
<img width="407" alt="Screen Shot 2022-03-02 at 12 03 34 PM" src="https://user-images.githubusercontent.com/1486885/156414330-66f9e5ad-15d1-4d1b-b256-e6082474427c.png">

Other alignments and wrapping styles are not impacted by this change:
https://square.github.io/maker/lab/actionbarbutton-align/#/ActionBarButtons
