### PR TITLE
fix(actionbar): fix bottom padding for action bars

### DIFF
--- a/src/components/ActionBar/src/ActionBarLayer.vue
+++ b/src/components/ActionBar/src/ActionBarLayer.vue
@@ -90,7 +90,7 @@ export default {
 /* stylelint-disable length-zero-no-unit */
 .ActionBarLayer {
 	--actionbar-top-padding: 24px;
-	--actionbar-size: 64px;
+	--actionbar-size: 48px;
 	--actionbar-bottom-padding:
 		calc(
 			24px

--- a/src/components/ActionBar/src/InlineActionBar.vue
+++ b/src/components/ActionBar/src/InlineActionBar.vue
@@ -54,9 +54,11 @@ export default {
 /* tempfix: chrome-bottom-offset - value set outside of maker */
 /* stylelint-disable length-zero-no-unit */
 .ActionBarWrapper {
+	--actionbar-size: 48px;
 	--actionbar-bottom-padding:
 		calc(
 			24px
+			+ var(--actionbar-size)
 			+ env(safe-area-inset-bottom, 24px)
 			+ var(--chrome-bottom-offset, 0px)
 		);


### PR DESCRIPTION
This corrects the bottom padding for both types of action bars.

**InlineActionBar**
Before:
<img width="643" alt="Screen Shot 2022-03-03 at 4 29 28 PM" src="https://user-images.githubusercontent.com/1486885/156656883-a03b9950-31da-4938-90cb-69164773410c.png">
<img width="407" alt="Screen Shot 2022-03-03 at 4 29 20 PM" src="https://user-images.githubusercontent.com/1486885/156656885-3941c613-d1f0-4483-9433-a78bdb89c537.png">

After:
<img width="659" alt="Screen Shot 2022-03-03 at 4 27 55 PM" src="https://user-images.githubusercontent.com/1486885/156656926-b59e5c1c-3e2f-4c60-80cb-167290670688.png">
<img width="398" alt="Screen Shot 2022-03-03 at 4 27 46 PM" src="https://user-images.githubusercontent.com/1486885/156656929-23c41026-d30d-4da2-93a9-e757560a3f1a.png">

**(Global) ActionBar**
Before:
<img width="413" alt="Screen Shot 2022-03-03 at 4 28 51 PM" src="https://user-images.githubusercontent.com/1486885/156657000-d775247d-2e40-4a5e-98d8-1e00e0ade773.png">

After:
<img width="396" alt="Screen Shot 2022-03-03 at 4 27 20 PM" src="https://user-images.githubusercontent.com/1486885/156657015-efe831e5-8aa6-4e07-bc5c-008434ce7328.png">

