### PR TITLE
feat(dialog): maker theme support for dialog

### DIFF
--- a/src/components/Dialog/src/Dialog.vue
+++ b/src/components/Dialog/src/Dialog.vue
@@ -7,6 +7,52 @@
 	</div>
 </template>
 
+<script>
+import chroma from 'chroma-js';
+import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
+
+export default {
+	name: 'Dialog',
+
+	inject: {
+		theme: {
+			default: defaultTheme(),
+			from: MThemeKey,
+		},
+	},
+
+	props: {
+		/**
+		 * Background color of container
+		 */
+		bgColor: {
+			type: String,
+			default: undefined,
+			validator: (color) => chroma.valid(color),
+		},
+		/**
+		 * Text color of container
+		 */
+		color: {
+			type: String,
+			default: undefined,
+			validator: (color) => chroma.valid(color),
+		},
+	},
+
+	computed: {
+		...resolveThemeableProps('dialog', ['bgColor', 'color']),
+
+		style() {
+			return {
+				'--bg-color': this.resolvedBgColor,
+				'--color': this.resolvedColor,
+			};
+		},
+	},
+};
+</script>
+
 <style module="$s">
 .Container {
 	position: relative;
@@ -18,7 +64,8 @@
 
 .Dialog {
 	overflow: scroll;
-	background: #f5f6f7;
+	color: var(--color, inherit);
+	background: var(--bg-color, #f5f6f7);
 }
 
 @media screen and (--for-tablet-landscape-up) {

--- a/src/components/Dialog/src/DialogLayer.vue
+++ b/src/components/Dialog/src/DialogLayer.vue
@@ -179,7 +179,7 @@ export default {
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background-color: rgba(0, 0, 0, 0.3);
+	background-color: var(--color-overlay, rgba(0, 0, 0, 0.3));
 }
 
 /**

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -72,6 +72,10 @@ export default function defaultTheme() {
 			color: undefined,
 			bgColor: undefined,
 		},
+		dialog: {
+			color: undefined,
+			bgColor: undefined,
+		},
 		container: {
 			color: undefined,
 			bgColor: undefined,


### PR DESCRIPTION
In a lot of places on website, dialog and modal are used in similar contexts. Dialog should be themeable to apply the same styles to both.