### PR TITLE
fix(dialog): add style variables to dialog template

### DIFF
--- a/src/components/Dialog/src/Dialog.vue
+++ b/src/components/Dialog/src/Dialog.vue
@@ -1,5 +1,8 @@
 <template>
-	<div :class="$s.Container">
+	<div
+		:class="$s.Container"
+		:style="style"
+	>
 		<div :class="$s.Dialog">
 			<!-- @slot Dialog content -->
 			<slot />

--- a/src/components/Dialog/src/DialogLayer.vue
+++ b/src/components/Dialog/src/DialogLayer.vue
@@ -191,4 +191,11 @@ export default {
 	position: fixed;
 	overflow: hidden;
 }
+
+@media (--for-desktop-up) {
+	.disableScroll {
+		position: initial;
+	}
+}
+
 </style>


### PR DESCRIPTION
Forgot to add the styles computed prop to the dialog template. Also, limited the `position: fixed` on Dialog's `disableScroll` class to phone/tablet displays. Adding the style to body on desktop can cause site width to collapse.