### PR TITLE
feat: add fontSize and lineHeight props 

### DIFF
--- a/src/components/Dialog/README.md
+++ b/src/components/Dialog/README.md
@@ -492,6 +492,14 @@ export default {
 
 
 <!-- api-tables:start -->
+## Dialog Props
+
+| Prop     | Type     | Default | Possible values | Description                   |
+| -------- | -------- | ------- | --------------- | ----------------------------- |
+| bg-color | `string` | —       | —               | Background color of container |
+| color    | `string` | —       | —               | Text color of container       |
+
+
 ## Dialog Slots
 
 | Slot    | Description    |

--- a/src/components/Heading/README.md
+++ b/src/components/Heading/README.md
@@ -31,16 +31,18 @@ export default {
 
 Supports attributes from [`<Heading_Elements>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements).
 
-| Prop           | Type     | Default     | Possible values                                               | Description                                                             |
-| -------------- | -------- | ----------- | ------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| size           | `number` | —           | `7`, `6`, `5`, `4`, `3`, `2`, `1`, `0`, `-1`, `-2`            | Size of heading. Influences which element is used.                      |
-| element        | `string` | —           | `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `div`                     | Override Heading element. By default, the element is derived from size. |
-| font-family    | `string` | —           | —                                                             | Font family                                                             |
-| font-weight    | `number` | —           | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values                        |
-| color          | `string` | —           | —                                                             | Color                                                                   |
-| font-style     | `string` | `'inherit'` | `inherit`, `normal`, `italic`                                 | font style                                                              |
-| text-transform | `string` | `'inherit'` | `inherit`, `none`, `uppercase`                                | text transform                                                          |
-| text-align     | `string` | `'inherit'` | `inherit`, `left`, `right`, `center`                          | text align                                                              |
+| Prop           | Type     | Default     | Possible values                                               | Description                                                                              |
+| -------------- | -------- | ----------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| size           | `number` | —           | `7`, `6`, `5`, `4`, `3`, `2`, `1`, `0`, `-1`, `-2`            | Size of heading. Influences which element is used.                                       |
+| element        | `string` | —           | `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `div`                     | Override Heading element. By default, the element is derived from size.                  |
+| font-family    | `string` | —           | —                                                             | Font family                                                                              |
+| font-weight    | `number` | —           | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values                                         |
+| font-size      | `string` | —           | —                                                             | Font size, as a valid CSS value. This overrides the 'size' prop.                         |
+| line-height    | `number` | —           | —                                                             | Line Height, as a valid CSS value. This overrides the internally calculated line-height. |
+| color          | `string` | —           | —                                                             | Color                                                                                    |
+| font-style     | `string` | `'inherit'` | `inherit`, `normal`, `italic`                                 | font style                                                                               |
+| text-transform | `string` | `'inherit'` | `inherit`, `none`, `uppercase`                                | text transform                                                                           |
+| text-align     | `string` | `'inherit'` | `inherit`, `left`, `right`, `center`                          | text align                                                                               |
 
 
 ## Slots

--- a/src/components/Heading/src/Heading.vue
+++ b/src/components/Heading/src/Heading.vue
@@ -57,6 +57,20 @@ export default {
 			validator: (weight) => weight >= MIN_WEIGHT && weight <= MAX_WEIGHT,
 		},
 		/**
+		 * Font size, as a valid CSS value. This overrides the 'size' prop.
+		 */
+		fontSize: {
+			type: String,
+			default: undefined,
+		},
+		/**
+		 * Line Height, as a valid CSS value. This overrides the internally calculated line-height.
+		 */
+		lineHeight: {
+			type: Number,
+			default: undefined,
+		},
+		/**
 		 * Color
 		 * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color}
 		 */
@@ -135,6 +149,8 @@ export default {
 				fontFamily: this.resolvedFontFamily,
 				fontWeight: this.resolvedFontWeight,
 				color: this.resolvedColor,
+				fontSize: this.fontSize,
+				lineHeight: this.lineHeight,
 				'--mobile-base-font-size': fonts.baseSize,
 				'--mobile-font-size-scale': fonts.sizeScale,
 			};

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -31,16 +31,18 @@ export default {
 
 Supports attributes from [`<p>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p).
 
-| Prop           | Type     | Default     | Possible values                                               | Description                                      |
-| -------------- | -------- | ----------- | ------------------------------------------------------------- | ------------------------------------------------ |
-| element        | `string` | `'p'`       | `p`, `span`, `li`                                             | HTML Element wrapper                             |
-| size           | `number` | —           | `1`, `0`, `-1`, `-2`                                          | Size of text                                     |
-| font-family    | `string` | —           | —                                                             | Font family                                      |
-| font-weight    | `number` | —           | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values |
-| color          | `string` | —           | —                                                             | Color                                            |
-| font-style     | `string` | `'inherit'` | `inherit`, `normal`, `italic`                                 | font style                                       |
-| text-transform | `string` | `'inherit'` | `inherit`, `none`, `uppercase`                                | text transform                                   |
-| text-align     | `string` | `'inherit'` | `inherit`, `left`, `right`, `center`                          | text align                                       |
+| Prop           | Type     | Default     | Possible values                                               | Description                                                                              |
+| -------------- | -------- | ----------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| element        | `string` | `'p'`       | `p`, `span`, `li`                                             | HTML Element wrapper                                                                     |
+| size           | `number` | —           | `1`, `0`, `-1`, `-2`                                          | Size of text                                                                             |
+| font-family    | `string` | —           | —                                                             | Font family                                                                              |
+| font-weight    | `number` | —           | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values                                         |
+| font-size      | `string` | —           | —                                                             | Font size, as a valid CSS value. This overrides the 'size' prop.                         |
+| line-height    | `number` | —           | —                                                             | Line Height, as a valid CSS value. This overrides the internally calculated line-height. |
+| color          | `string` | —           | —                                                             | Color                                                                                    |
+| font-style     | `string` | `'inherit'` | `inherit`, `normal`, `italic`                                 | font style                                                                               |
+| text-transform | `string` | `'inherit'` | `inherit`, `none`, `uppercase`                                | text transform                                                                           |
+| text-align     | `string` | `'inherit'` | `inherit`, `left`, `right`, `center`                          | text align                                                                               |
 
 
 ## Slots

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -56,6 +56,20 @@ export default {
 			validator: (fontWeight) => fontWeight >= MIN_WEIGHT && fontWeight <= MAX_WEIGHT,
 		},
 		/**
+		 * Font size, as a valid CSS value. This overrides the 'size' prop.
+		 */
+		fontSize: {
+			type: String,
+			default: undefined,
+		},
+		/**
+		 * Line Height, as a valid CSS value. This overrides the internally calculated line-height.
+		 */
+		lineHeight: {
+			type: Number,
+			default: undefined,
+		},
+		/**
 		 * Color
 		 * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/color}
 		 */
@@ -108,6 +122,8 @@ export default {
 				fontFamily: this.resolvedFontFamily,
 				fontWeight: this.resolvedFontWeight,
 				color: this.resolvedColor,
+				fontSize: this.fontSize,
+				lineHeight: this.lineHeight,
 				'--mobile-base-font-size': fonts.baseSize,
 				'--mobile-font-size-scale': fonts.sizeScale,
 			};


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

We occasionally need individual components to opt out of Maker Text / Maker Heading's scale-based `size` prop and internal `line-height` calculations. E.g. Site Logo, etc. Slack conversation [here](https://square.slack.com/archives/C02NYVDM0JU/p1646860034936189) for context.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
Adds a lineHeight and a fontSize prop to Maker Text and Maker Heading. These are directly applied as inline styles on the element, overriding the `font-size` and `line-height` CSS rules that are calculated in the `style` tag and applied via a class.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
No other information sorry
