### PR TITLE
fix(input): remove invisible border radius

### DIFF
--- a/src/components/Input/src/InputControl.vue
+++ b/src/components/Input/src/InputControl.vue
@@ -225,7 +225,6 @@ export default {
 	text-overflow: ellipsis;
 	background-color: transparent;
 	border: none;
-	border-radius: inherit;
 	outline: none;
 	box-shadow: none;
 	cursor: inherit;


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
As discussed in #244, `MInput`'s internal `<input>` has `border-radius: inherit`, causing it to take on the `border-radius` of its container and clip text at the start and end of the input, even though the `<input>` has no visible border.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
This PR simply removes the `border-radius: inherit` directive.
