### PR TITLE
fix(stepper): remove default stepper shape to enable theming

### DIFF
--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -101,7 +101,7 @@ export default {
 		 */
 		shape: {
 			type: String,
-			default: 'pill',
+			default: undefined,
 			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
 		},
 	},


### PR DESCRIPTION
Removes default `shape` prop on to enable theme props to apply.