### PR TITLE
fix(dialog): fix position bug on desktop dialog layer

### DIFF
--- a/src/components/Dialog/src/DialogLayer.vue
+++ b/src/components/Dialog/src/DialogLayer.vue
@@ -191,4 +191,11 @@ export default {
 	position: fixed;
 	overflow: hidden;
 }
+
+@media (--for-desktop-up) {
+	.disableScroll {
+		position: initial;
+	}
+}
+
 </style>


### PR DESCRIPTION
Fixes dialog layer bug on desktop. Typically, adding `position: fixed` causes the body to collapse if its contents are not as wide as the viewport. This `position: fixed` style is needed on mobile devices in order to use Dialog with the PinInput component but this resets the position on desktop.