### PR TITLE
fix(action-bar-button): make ActionBarButton disabled when loading

### DIFF
--- a/src/components/ActionBar/README.md
+++ b/src/components/ActionBar/README.md
@@ -332,6 +332,17 @@ export default {
 					</m-action-bar-button>
 				</m-inline-action-bar>
 			</div>
+			<div>
+				<m-inline-action-bar>
+					<m-action-bar-button
+						key="confirm"
+						loading
+						full-width
+					>
+						Loading
+					</m-action-bar-button>
+				</m-inline-action-bar>
+			</div>
 		</div>
 	</div>
 </template>

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -12,7 +12,7 @@
 			}
 		]"
 		:type="type"
-		:disabled="disabled"
+		:disabled="isDisabled"
 		:style="style"
 		v-bind="$attrs"
 		v-on="$listeners"
@@ -155,6 +155,10 @@ export default {
 				color: this.color,
 				textColor: this.textColor,
 			});
+		},
+
+		isDisabled() {
+			return this.disabled || this.loading;
 		},
 	},
 


### PR DESCRIPTION
## Describe the problem this PR addresses
See #248.

## Describe the changes in this PR

- Makes ActionBarButton disabled when loading. This was already added to Button and TextButton in #250.
- also added a loading example in the ActionBar styleguide
<img width="600" alt="Screen Shot 2022-03-16 at 2 30 08 PM" src="https://user-images.githubusercontent.com/20190589/158694377-bea1192e-66cd-472c-8834-c6891c0a83ab.png">


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
