### PR TITLE
fix(input)!: focus states by dropping support for UC & Opera Mini

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,12 @@
 # ECOM supported browsers from https://go/EcomBrowserSupport
- 
-> 0.5%, last 2 Edge versions, last 2 Firefox versions, last 2 Chrome versions, last 2 Safari versions, last 2 iOS versions, last 2 ChromeAndroid versions, not IE 11
+
+> 0.5%
+last 2 Chrome versions
+last 2 ChromeAndroid versions
+last 2 Edge versions
+last 2 Firefox versions
+last 2 iOS versions
+last 2 Safari versions
+not IE 11
+not UCAndroid 12.12
+not OperaMini all

--- a/package-lock.json
+++ b/package-lock.json
@@ -4722,9 +4722,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001248",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz",
-      "integrity": "sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw==",
+      "version": "1.0.30001317",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001317.tgz",
+      "integrity": "sha512-xIZLh8gBm4dqNX0gkzrBeyI86J2eCjWzYAs40q88smG844YIrN4tVQl/RhquHvKEKImWWFIVh1Lxe5n1G/N+GQ==",
       "dev": true
     },
     "ccount": {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
https://github.com/square/maker/issues/226#issuecomment-1071061425

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
Drops support for UC Browser 12.12 and Opera Mini browsers so that our `:focus-within` CSS styles within the MInput component work again.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
This has been broken since v4.1.0 when [this line](https://github.com/square/maker/compare/v4.0.1...v4.1.0#diff-43302d1852d8010ee012aab4dda2d01abb664e11f73617fe625f2ba112a958edR3) was released 🤦 