### PR TITLE
fix(text-button): Fix line-height and accessibility outline

### DIFF
--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -120,7 +120,6 @@ export default {
 	background-color: var(--color-main);
 	border: none;
 	border-radius: 8px;
-	outline: none;
 	box-shadow:
 		var(--outline-border, 0 0),
 		var(--focus-border, 0 0);
@@ -179,7 +178,7 @@ export default {
 	width: max-content;
 	max-width: 100%;
 	overflow: hidden;
-	line-height: 1;
+	line-height: 1.5;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 }

--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -119,15 +119,10 @@ export default {
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;
-	border-radius: 8px;
-	box-shadow:
-		var(--outline-border, 0 0),
-		var(--focus-border, 0 0);
+	border-radius: 4px;
+	outline-color: currentColor;
 	cursor: pointer;
-	transition:
-		color 0.2s ease-in,
-		background-color 0.2s ease-in,
-		box-shadow 0.2s ease-in;
+	transition: box-shadow 0.2s ease-in;
 	user-select: none;
 	touch-action: manipulation;
 	fill: currentColor;
@@ -142,6 +137,11 @@ export default {
 
 	&.size_large {
 		font-size: 16px;
+	}
+
+	&:active,
+	&:focus {
+		box-shadow: 0 0 0 1px currentColor;
 	}
 
 	&:disabled {


### PR DESCRIPTION
## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
https://github.com/square/maker/issues/252
https://github.com/square/maker/issues/254

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
- Changed line-height to 1.5 which reflects the 24px line height for a font-size of 16px from Figma
![image](https://user-images.githubusercontent.com/18740390/159332084-6bf42d15-7056-46a4-8f29-038492efa9c5.png)
- Removed outline:none in order to support having a visible outline when button is focused via tabbing
![image](https://user-images.githubusercontent.com/18740390/159332454-eeb7dde3-92fc-40b2-9734-0057c5bbfcee.png)
