### PR TITLE
fix(text-button): Fix line-height and accessibility outline

### DIFF
--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -119,15 +119,10 @@ export default {
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;
-	border-radius: 8px;
-	box-shadow:
-		var(--outline-border, 0 0),
-		var(--focus-border, 0 0);
+	border-radius: 4px;
+	outline-color: currentColor;
 	cursor: pointer;
-	transition:
-		color 0.2s ease-in,
-		background-color 0.2s ease-in,
-		box-shadow 0.2s ease-in;
+	transition: box-shadow 0.2s ease-in;
 	user-select: none;
 	touch-action: manipulation;
 	fill: currentColor;
@@ -142,6 +137,11 @@ export default {
 
 	&.size_large {
 		font-size: 16px;
+	}
+
+	&:active,
+	&:focus {
+		box-shadow: 0 0 0 1px currentColor;
 	}
 
 	&:disabled {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
Missing some states output and we weren't using the same color as the button.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
![CleanShot 2022-03-21 at 11 16 48](https://user-images.githubusercontent.com/129122/159338150-ebf17009-d00d-4980-b1de-236a60ed93c6.png)
active / focus

![CleanShot 2022-03-21 at 11 16 54](https://user-images.githubusercontent.com/129122/159338138-8e93647d-95bd-45f4-92bb-2cfbdeeb1af5.png)
just outline-color change


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->