### PR TITLE
feat(text): add support for all text sizes (#265)

### DIFF
--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -1,6 +1,6 @@
 # Text
 
-Use the Text component for regular body text. There are 10 text sizes: -2 to 7. The font family, font weight, and text color are customizable.
+Use the Text component for regular body text. There are 4 text sizes. The font family, font weight, and text color are customizable.
 
 ```vue
 <template>
@@ -34,7 +34,7 @@ Supports attributes from [`<p>`](https://developer.mozilla.org/en-US/docs/Web/HT
 | Prop           | Type     | Default     | Possible values                                               | Description                                                                                 |
 | -------------- | -------- | ----------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | element        | `string` | `'p'`       | `p`, `span`, `div`, `li`                                      | HTML Element wrapper                                                                        |
-| size           | `number` | —           | `7`, `6`, `5`, `4`, `3`, `2`, `1`, `0`, `-1`, `-2`            | Size of text                                                                                |
+| size           | `number` | —           | `1`, `0`, `-1`, `-2`                                          | Size of text                                                                                |
 | font-family    | `string` | —           | —                                                             | Font family                                                                                 |
 | font-weight    | `number` | —           | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values                                            |
 | font-size      | `string` | —           | —                                                             | Font size, as a valid CSS value. This overrides the 'size' prop, and disables type scaling. |

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -1,12 +1,12 @@
 # Text
 
-Use the Text component for regular body text. There are 10 text sizes: -2 to 7. The font family, font weight, and text color are customizable.
+Use the Text component for regular body text. There are 4 text sizes. The font family, font weight, and text color are customizable.
 
 ```vue
 <template>
 	<div>
 		<m-text
-			v-for="size in [7, 6, 5, 4, 3, 2, 1, 0, -1, -2]"
+			v-for="size in [1, 0, -1, -2]"
 			:key="size"
 			:size="size"
 		>
@@ -34,7 +34,7 @@ Supports attributes from [`<p>`](https://developer.mozilla.org/en-US/docs/Web/HT
 | Prop           | Type     | Default     | Possible values                                               | Description                                                                                 |
 | -------------- | -------- | ----------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | element        | `string` | `'p'`       | `p`, `span`, `div`, `li`                                      | HTML Element wrapper                                                                        |
-| size           | `number` | —           | `7`, `6`, `5`, `4`, `3`, `2`, `1`, `0`, `-1`, `-2`            | Size of text                                                                                |
+| size           | `number` | —           | `1`, `0`, `-1`, `-2`                                          | Size of text                                                                                |
 | font-family    | `string` | —           | —                                                             | Font family                                                                                 |
 | font-weight    | `number` | —           | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values                                            |
 | font-size      | `string` | —           | —                                                             | Font size, as a valid CSS value. This overrides the 'size' prop, and disables type scaling. |

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -1,6 +1,6 @@
 # Text
 
-Use the Text component for regular body text. There are 4 text sizes. The font family, font weight, and text color are customizable.
+Use the Text component for regular body text. There are 10 text sizes: -2 to 7. The font family, font weight, and text color are customizable.
 
 ```vue
 <template>
@@ -34,7 +34,7 @@ Supports attributes from [`<p>`](https://developer.mozilla.org/en-US/docs/Web/HT
 | Prop           | Type     | Default     | Possible values                                               | Description                                                                                 |
 | -------------- | -------- | ----------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | element        | `string` | `'p'`       | `p`, `span`, `div`, `li`                                      | HTML Element wrapper                                                                        |
-| size           | `number` | —           | `1`, `0`, `-1`, `-2`                                          | Size of text                                                                                |
+| size           | `number` | —           | `7`, `6`, `5`, `4`, `3`, `2`, `1`, `0`, `-1`, `-2`            | Size of text                                                                                |
 | font-family    | `string` | —           | —                                                             | Font family                                                                                 |
 | font-weight    | `number` | —           | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values                                            |
 | font-size      | `string` | —           | —                                                             | Font size, as a valid CSS value. This overrides the 'size' prop, and disables type scaling. |

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -1,12 +1,12 @@
 # Text
 
-Use the Text component for regular body text. There are 4 text sizes. The font family, font weight, and text color are customizable.
+Use the Text component for regular body text. There are 10 text sizes: -2 to 7. The font family, font weight, and text color are customizable.
 
 ```vue
 <template>
 	<div>
 		<m-text
-			v-for="size in [1, 0, -1, -2]"
+			v-for="size in [7, 6, 5, 4, 3, 2, 1, 0, -1, -2]"
 			:key="size"
 			:size="size"
 		>
@@ -34,7 +34,7 @@ Supports attributes from [`<p>`](https://developer.mozilla.org/en-US/docs/Web/HT
 | Prop           | Type     | Default     | Possible values                                               | Description                                                                                 |
 | -------------- | -------- | ----------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | element        | `string` | `'p'`       | `p`, `span`, `div`, `li`                                      | HTML Element wrapper                                                                        |
-| size           | `number` | —           | `1`, `0`, `-1`, `-2`                                          | Size of text                                                                                |
+| size           | `number` | —           | `7`, `6`, `5`, `4`, `3`, `2`, `1`, `0`, `-1`, `-2`            | Size of text                                                                                |
 | font-family    | `string` | —           | —                                                             | Font family                                                                                 |
 | font-weight    | `number` | —           | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values                                            |
 | font-size      | `string` | —           | —                                                             | Font size, as a valid CSS value. This overrides the 'size' prop, and disables type scaling. |

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -3,7 +3,7 @@ import chroma from 'chroma-js';
 import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
 
 const MIN_SIZE = -2;
-const MAX_SIZE = 7;
+const MAX_SIZE = 1;
 const MIN_WEIGHT = 100;
 const MAX_WEIGHT = 900;
 
@@ -31,7 +31,7 @@ export default {
 		},
 		/**
 		 * Size of text
-		 * @values 7, 6, 5, 4, 3, 2, 1, 0, -1, -2
+		 * @values 1, 0, -1, -2
 		 */
 		size: {
 			type: Number,
@@ -134,6 +134,7 @@ export default {
 		const {
 			$s,
 			sizeClass,
+			element,
 			inlineStyles,
 			fontStyle,
 			textTransform,
@@ -143,9 +144,6 @@ export default {
 		 * @slot text content
 		 */
 		const defaultSlot = this.$slots.default;
-
-		const element = this.element || 'p';
-
 		return createElement(element, {
 			class: [
 				$s.Paragraph,
@@ -176,12 +174,6 @@ export default {
 	--min-fs--1: calc(var(--min-fs-0) / var(--min-font-size-scale));
 	--min-fs-0: var(--min-font-size);
 	--min-fs-1: calc(var(--min-fs-0) * var(--min-font-size-scale));
-	--min-fs-2: calc(var(--min-fs-1) * var(--min-font-size-scale));
-	--min-fs-3: calc(var(--min-fs-2) * var(--min-font-size-scale));
-	--min-fs-4: calc(var(--min-fs-3) * var(--min-font-size-scale));
-	--min-fs-5: calc(var(--min-fs-4) * var(--min-font-size-scale));
-	--min-fs-6: calc(var(--min-fs-5) * var(--min-font-size-scale));
-	--min-fs-7: calc(var(--min-fs-6) * var(--min-font-size-scale));
 
 	/* max breakpoint config */
 	--max-resolution: 1280; /* arbitrary value */
@@ -193,12 +185,6 @@ export default {
 	--max-fs--1: calc(var(--max-fs-0) / var(--max-font-size-scale));
 	--max-fs-0: var(--max-font-size);
 	--max-fs-1: calc(var(--max-fs-0) * var(--max-font-size-scale));
-	--max-fs-2: calc(var(--max-fs-1) * var(--max-font-size-scale));
-	--max-fs-3: calc(var(--max-fs-2) * var(--max-font-size-scale));
-	--max-fs-4: calc(var(--max-fs-3) * var(--max-font-size-scale));
-	--max-fs-5: calc(var(--max-fs-4) * var(--max-font-size-scale));
-	--max-fs-6: calc(var(--max-fs-5) * var(--max-font-size-scale));
-	--max-fs-7: calc(var(--max-fs-6) * var(--max-font-size-scale));
 
 	/* interpolation variables */
 	--resolution-range: calc(var(--max-resolution) - var(--min-resolution));
@@ -209,24 +195,12 @@ export default {
 	--range-fs--1: calc(var(--max-fs--1) - var(--min-fs--1));
 	--range-fs-0: calc(var(--max-fs-0) - var(--min-fs-0));
 	--range-fs-1: calc(var(--max-fs-1) - var(--min-fs-1));
-	--range-fs-2: calc(var(--max-fs-2) - var(--min-fs-2));
-	--range-fs-3: calc(var(--max-fs-3) - var(--min-fs-3));
-	--range-fs-4: calc(var(--max-fs-4) - var(--min-fs-4));
-	--range-fs-5: calc(var(--max-fs-5) - var(--min-fs-5));
-	--range-fs-6: calc(var(--max-fs-6) - var(--min-fs-6));
-	--range-fs-7: calc(var(--max-fs-7) - var(--min-fs-7));
 
 	/* fluid type scale */
 	--fs--2: max(12px, calc(var(--min-fs--2) * 1px + var(--range-fs--2) * var(--interpolate-by)));
 	--fs--1: max(14px, calc(var(--min-fs--1) * 1px + var(--range-fs--1) * var(--interpolate-by)));
 	--fs-0: calc(var(--min-fs-0) * 1px + var(--range-fs-0) * var(--interpolate-by));
 	--fs-1: calc(var(--min-fs-1) * 1px + var(--range-fs-1) * var(--interpolate-by));
-	--fs-2: calc(var(--min-fs-2) * 1px + var(--range-fs-2) * var(--interpolate-by));
-	--fs-3: calc(var(--min-fs-3) * 1px + var(--range-fs-3) * var(--interpolate-by));
-	--fs-4: calc(var(--min-fs-4) * 1px + var(--range-fs-4) * var(--interpolate-by));
-	--fs-5: calc(var(--min-fs-5) * 1px + var(--range-fs-5) * var(--interpolate-by));
-	--fs-6: calc(var(--min-fs-6) * 1px + var(--range-fs-6) * var(--interpolate-by));
-	--fs-7: calc(var(--min-fs-7) * 1px + var(--range-fs-7) * var(--interpolate-by));
 
 	/* line height config */
 	--line-height: 1.5;
@@ -237,12 +211,6 @@ export default {
 	--lh--1: calc(var(--lh-0) / var(--line-height-scale));
 	--lh-0: var(--line-height);
 	--lh-1: calc(var(--lh-0) * var(--line-height-scale));
-	--lh-2: calc(var(--lh-1) * var(--line-height-scale));
-	--lh-3: calc(var(--lh-2) * var(--line-height-scale));
-	--lh-4: calc(var(--lh-3) * var(--line-height-scale));
-	--lh-5: calc(var(--lh-4) * var(--line-height-scale));
-	--lh-6: calc(var(--lh-5) * var(--line-height-scale));
-	--lh-7: calc(var(--lh-6) * var(--line-height-scale));
 }
 
 .fontstyle_normal {
@@ -298,35 +266,4 @@ export default {
 	font-size: var(--fs-1);
 	line-height: var(--lh-1);
 }
-
-.Paragraph.size_2 {
-	font-size: var(--fs-2);
-	line-height: var(--lh-2);
-}
-
-.Paragraph.size_3 {
-	font-size: var(--fs-3);
-	line-height: var(--lh-3);
-}
-
-.Paragraph.size_4 {
-	font-size: var(--fs-4);
-	line-height: var(--lh-4);
-}
-
-.Paragraph.size_5 {
-	font-size: var(--fs-5);
-	line-height: var(--lh-5);
-}
-
-.Paragraph.size_6 {
-	font-size: var(--fs-6);
-	line-height: var(--lh-6);
-}
-
-.Paragraph.size_7 {
-	font-size: var(--fs-7);
-	line-height: var(--lh-7);
-}
-
 </style>

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -3,7 +3,7 @@ import chroma from 'chroma-js';
 import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
 
 const MIN_SIZE = -2;
-const MAX_SIZE = 1;
+const MAX_SIZE = 7;
 const MIN_WEIGHT = 100;
 const MAX_WEIGHT = 900;
 
@@ -31,7 +31,7 @@ export default {
 		},
 		/**
 		 * Size of text
-		 * @values 1, 0, -1, -2
+		 * @values 7, 6, 5, 4, 3, 2, 1, 0, -1, -2
 		 */
 		size: {
 			type: Number,
@@ -134,7 +134,6 @@ export default {
 		const {
 			$s,
 			sizeClass,
-			element,
 			inlineStyles,
 			fontStyle,
 			textTransform,
@@ -144,6 +143,8 @@ export default {
 		 * @slot text content
 		 */
 		const defaultSlot = this.$slots.default;
+		const element = this.element || 'p';
+
 		return createElement(element, {
 			class: [
 				$s.Paragraph,
@@ -174,6 +175,12 @@ export default {
 	--min-fs--1: calc(var(--min-fs-0) / var(--min-font-size-scale));
 	--min-fs-0: var(--min-font-size);
 	--min-fs-1: calc(var(--min-fs-0) * var(--min-font-size-scale));
+	--min-fs-2: calc(var(--min-fs-1) * var(--min-font-size-scale));
+	--min-fs-3: calc(var(--min-fs-2) * var(--min-font-size-scale));
+	--min-fs-4: calc(var(--min-fs-3) * var(--min-font-size-scale));
+	--min-fs-5: calc(var(--min-fs-4) * var(--min-font-size-scale));
+	--min-fs-6: calc(var(--min-fs-5) * var(--min-font-size-scale));
+	--min-fs-7: calc(var(--min-fs-6) * var(--min-font-size-scale));
 
 	/* max breakpoint config */
 	--max-resolution: 1280; /* arbitrary value */
@@ -185,6 +192,12 @@ export default {
 	--max-fs--1: calc(var(--max-fs-0) / var(--max-font-size-scale));
 	--max-fs-0: var(--max-font-size);
 	--max-fs-1: calc(var(--max-fs-0) * var(--max-font-size-scale));
+	--max-fs-2: calc(var(--max-fs-1) * var(--max-font-size-scale));
+	--max-fs-3: calc(var(--max-fs-2) * var(--max-font-size-scale));
+	--max-fs-4: calc(var(--max-fs-3) * var(--max-font-size-scale));
+	--max-fs-5: calc(var(--max-fs-4) * var(--max-font-size-scale));
+	--max-fs-6: calc(var(--max-fs-5) * var(--max-font-size-scale));
+	--max-fs-7: calc(var(--max-fs-6) * var(--max-font-size-scale));
 
 	/* interpolation variables */
 	--resolution-range: calc(var(--max-resolution) - var(--min-resolution));
@@ -195,12 +208,24 @@ export default {
 	--range-fs--1: calc(var(--max-fs--1) - var(--min-fs--1));
 	--range-fs-0: calc(var(--max-fs-0) - var(--min-fs-0));
 	--range-fs-1: calc(var(--max-fs-1) - var(--min-fs-1));
+	--range-fs-2: calc(var(--max-fs-2) - var(--min-fs-2));
+	--range-fs-3: calc(var(--max-fs-3) - var(--min-fs-3));
+	--range-fs-4: calc(var(--max-fs-4) - var(--min-fs-4));
+	--range-fs-5: calc(var(--max-fs-5) - var(--min-fs-5));
+	--range-fs-6: calc(var(--max-fs-6) - var(--min-fs-6));
+	--range-fs-7: calc(var(--max-fs-7) - var(--min-fs-7));
 
 	/* fluid type scale */
 	--fs--2: max(12px, calc(var(--min-fs--2) * 1px + var(--range-fs--2) * var(--interpolate-by)));
 	--fs--1: max(14px, calc(var(--min-fs--1) * 1px + var(--range-fs--1) * var(--interpolate-by)));
 	--fs-0: calc(var(--min-fs-0) * 1px + var(--range-fs-0) * var(--interpolate-by));
 	--fs-1: calc(var(--min-fs-1) * 1px + var(--range-fs-1) * var(--interpolate-by));
+	--fs-2: calc(var(--min-fs-2) * 1px + var(--range-fs-2) * var(--interpolate-by));
+	--fs-3: calc(var(--min-fs-3) * 1px + var(--range-fs-3) * var(--interpolate-by));
+	--fs-4: calc(var(--min-fs-4) * 1px + var(--range-fs-4) * var(--interpolate-by));
+	--fs-5: calc(var(--min-fs-5) * 1px + var(--range-fs-5) * var(--interpolate-by));
+	--fs-6: calc(var(--min-fs-6) * 1px + var(--range-fs-6) * var(--interpolate-by));
+	--fs-7: calc(var(--min-fs-7) * 1px + var(--range-fs-7) * var(--interpolate-by));
 
 	/* line height config */
 	--line-height: 1.5;
@@ -211,6 +236,12 @@ export default {
 	--lh--1: calc(var(--lh-0) / var(--line-height-scale));
 	--lh-0: var(--line-height);
 	--lh-1: calc(var(--lh-0) * var(--line-height-scale));
+	--lh-2: calc(var(--lh-1) * var(--line-height-scale));
+	--lh-3: calc(var(--lh-2) * var(--line-height-scale));
+	--lh-4: calc(var(--lh-3) * var(--line-height-scale));
+	--lh-5: calc(var(--lh-4) * var(--line-height-scale));
+	--lh-6: calc(var(--lh-5) * var(--line-height-scale));
+	--lh-7: calc(var(--lh-6) * var(--line-height-scale));
 }
 
 .fontstyle_normal {
@@ -265,5 +296,35 @@ export default {
 .Paragraph.size_1 {
 	font-size: var(--fs-1);
 	line-height: var(--lh-1);
+}
+
+.Paragraph.size_2 {
+	font-size: var(--fs-2);
+	line-height: var(--lh-2);
+}
+
+.Paragraph.size_3 {
+	font-size: var(--fs-3);
+	line-height: var(--lh-3);
+}
+
+.Paragraph.size_4 {
+	font-size: var(--fs-4);
+	line-height: var(--lh-4);
+}
+
+.Paragraph.size_5 {
+	font-size: var(--fs-5);
+	line-height: var(--lh-5);
+}
+
+.Paragraph.size_6 {
+	font-size: var(--fs-6);
+	line-height: var(--lh-6);
+}
+
+.Paragraph.size_7 {
+	font-size: var(--fs-7);
+	line-height: var(--lh-7);
 }
 </style>

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -3,7 +3,7 @@ import chroma from 'chroma-js';
 import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
 
 const MIN_SIZE = -2;
-const MAX_SIZE = 7;
+const MAX_SIZE = 1;
 const MIN_WEIGHT = 100;
 const MAX_WEIGHT = 900;
 
@@ -31,7 +31,7 @@ export default {
 		},
 		/**
 		 * Size of text
-		 * @values 7, 6, 5, 4, 3, 2, 1, 0, -1, -2
+		 * @values 1, 0, -1, -2
 		 */
 		size: {
 			type: Number,
@@ -134,6 +134,7 @@ export default {
 		const {
 			$s,
 			sizeClass,
+			element,
 			inlineStyles,
 			fontStyle,
 			textTransform,
@@ -143,8 +144,6 @@ export default {
 		 * @slot text content
 		 */
 		const defaultSlot = this.$slots.default;
-		const element = this.element || 'p';
-
 		return createElement(element, {
 			class: [
 				$s.Paragraph,
@@ -175,12 +174,6 @@ export default {
 	--min-fs--1: calc(var(--min-fs-0) / var(--min-font-size-scale));
 	--min-fs-0: var(--min-font-size);
 	--min-fs-1: calc(var(--min-fs-0) * var(--min-font-size-scale));
-	--min-fs-2: calc(var(--min-fs-1) * var(--min-font-size-scale));
-	--min-fs-3: calc(var(--min-fs-2) * var(--min-font-size-scale));
-	--min-fs-4: calc(var(--min-fs-3) * var(--min-font-size-scale));
-	--min-fs-5: calc(var(--min-fs-4) * var(--min-font-size-scale));
-	--min-fs-6: calc(var(--min-fs-5) * var(--min-font-size-scale));
-	--min-fs-7: calc(var(--min-fs-6) * var(--min-font-size-scale));
 
 	/* max breakpoint config */
 	--max-resolution: 1280; /* arbitrary value */
@@ -192,12 +185,6 @@ export default {
 	--max-fs--1: calc(var(--max-fs-0) / var(--max-font-size-scale));
 	--max-fs-0: var(--max-font-size);
 	--max-fs-1: calc(var(--max-fs-0) * var(--max-font-size-scale));
-	--max-fs-2: calc(var(--max-fs-1) * var(--max-font-size-scale));
-	--max-fs-3: calc(var(--max-fs-2) * var(--max-font-size-scale));
-	--max-fs-4: calc(var(--max-fs-3) * var(--max-font-size-scale));
-	--max-fs-5: calc(var(--max-fs-4) * var(--max-font-size-scale));
-	--max-fs-6: calc(var(--max-fs-5) * var(--max-font-size-scale));
-	--max-fs-7: calc(var(--max-fs-6) * var(--max-font-size-scale));
 
 	/* interpolation variables */
 	--resolution-range: calc(var(--max-resolution) - var(--min-resolution));
@@ -208,24 +195,12 @@ export default {
 	--range-fs--1: calc(var(--max-fs--1) - var(--min-fs--1));
 	--range-fs-0: calc(var(--max-fs-0) - var(--min-fs-0));
 	--range-fs-1: calc(var(--max-fs-1) - var(--min-fs-1));
-	--range-fs-2: calc(var(--max-fs-2) - var(--min-fs-2));
-	--range-fs-3: calc(var(--max-fs-3) - var(--min-fs-3));
-	--range-fs-4: calc(var(--max-fs-4) - var(--min-fs-4));
-	--range-fs-5: calc(var(--max-fs-5) - var(--min-fs-5));
-	--range-fs-6: calc(var(--max-fs-6) - var(--min-fs-6));
-	--range-fs-7: calc(var(--max-fs-7) - var(--min-fs-7));
 
 	/* fluid type scale */
 	--fs--2: max(12px, calc(var(--min-fs--2) * 1px + var(--range-fs--2) * var(--interpolate-by)));
 	--fs--1: max(14px, calc(var(--min-fs--1) * 1px + var(--range-fs--1) * var(--interpolate-by)));
 	--fs-0: calc(var(--min-fs-0) * 1px + var(--range-fs-0) * var(--interpolate-by));
 	--fs-1: calc(var(--min-fs-1) * 1px + var(--range-fs-1) * var(--interpolate-by));
-	--fs-2: calc(var(--min-fs-2) * 1px + var(--range-fs-2) * var(--interpolate-by));
-	--fs-3: calc(var(--min-fs-3) * 1px + var(--range-fs-3) * var(--interpolate-by));
-	--fs-4: calc(var(--min-fs-4) * 1px + var(--range-fs-4) * var(--interpolate-by));
-	--fs-5: calc(var(--min-fs-5) * 1px + var(--range-fs-5) * var(--interpolate-by));
-	--fs-6: calc(var(--min-fs-6) * 1px + var(--range-fs-6) * var(--interpolate-by));
-	--fs-7: calc(var(--min-fs-7) * 1px + var(--range-fs-7) * var(--interpolate-by));
 
 	/* line height config */
 	--line-height: 1.5;
@@ -236,12 +211,6 @@ export default {
 	--lh--1: calc(var(--lh-0) / var(--line-height-scale));
 	--lh-0: var(--line-height);
 	--lh-1: calc(var(--lh-0) * var(--line-height-scale));
-	--lh-2: calc(var(--lh-1) * var(--line-height-scale));
-	--lh-3: calc(var(--lh-2) * var(--line-height-scale));
-	--lh-4: calc(var(--lh-3) * var(--line-height-scale));
-	--lh-5: calc(var(--lh-4) * var(--line-height-scale));
-	--lh-6: calc(var(--lh-5) * var(--line-height-scale));
-	--lh-7: calc(var(--lh-6) * var(--line-height-scale));
 }
 
 .fontstyle_normal {
@@ -296,35 +265,5 @@ export default {
 .Paragraph.size_1 {
 	font-size: var(--fs-1);
 	line-height: var(--lh-1);
-}
-
-.Paragraph.size_2 {
-	font-size: var(--fs-2);
-	line-height: var(--lh-2);
-}
-
-.Paragraph.size_3 {
-	font-size: var(--fs-3);
-	line-height: var(--lh-3);
-}
-
-.Paragraph.size_4 {
-	font-size: var(--fs-4);
-	line-height: var(--lh-4);
-}
-
-.Paragraph.size_5 {
-	font-size: var(--fs-5);
-	line-height: var(--lh-5);
-}
-
-.Paragraph.size_6 {
-	font-size: var(--fs-6);
-	line-height: var(--lh-6);
-}
-
-.Paragraph.size_7 {
-	font-size: var(--fs-7);
-	line-height: var(--lh-7);
 }
 </style>

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -3,7 +3,7 @@ import chroma from 'chroma-js';
 import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
 
 const MIN_SIZE = -2;
-const MAX_SIZE = 1;
+const MAX_SIZE = 7;
 const MIN_WEIGHT = 100;
 const MAX_WEIGHT = 900;
 
@@ -31,7 +31,7 @@ export default {
 		},
 		/**
 		 * Size of text
-		 * @values 1, 0, -1, -2
+		 * @values 7, 6, 5, 4, 3, 2, 1, 0, -1, -2
 		 */
 		size: {
 			type: Number,
@@ -134,7 +134,6 @@ export default {
 		const {
 			$s,
 			sizeClass,
-			element,
 			inlineStyles,
 			fontStyle,
 			textTransform,
@@ -144,6 +143,9 @@ export default {
 		 * @slot text content
 		 */
 		const defaultSlot = this.$slots.default;
+
+		const element = this.element || 'p';
+
 		return createElement(element, {
 			class: [
 				$s.Paragraph,
@@ -174,6 +176,12 @@ export default {
 	--min-fs--1: calc(var(--min-fs-0) / var(--min-font-size-scale));
 	--min-fs-0: var(--min-font-size);
 	--min-fs-1: calc(var(--min-fs-0) * var(--min-font-size-scale));
+	--min-fs-2: calc(var(--min-fs-1) * var(--min-font-size-scale));
+	--min-fs-3: calc(var(--min-fs-2) * var(--min-font-size-scale));
+	--min-fs-4: calc(var(--min-fs-3) * var(--min-font-size-scale));
+	--min-fs-5: calc(var(--min-fs-4) * var(--min-font-size-scale));
+	--min-fs-6: calc(var(--min-fs-5) * var(--min-font-size-scale));
+	--min-fs-7: calc(var(--min-fs-6) * var(--min-font-size-scale));
 
 	/* max breakpoint config */
 	--max-resolution: 1280; /* arbitrary value */
@@ -185,6 +193,12 @@ export default {
 	--max-fs--1: calc(var(--max-fs-0) / var(--max-font-size-scale));
 	--max-fs-0: var(--max-font-size);
 	--max-fs-1: calc(var(--max-fs-0) * var(--max-font-size-scale));
+	--max-fs-2: calc(var(--max-fs-1) * var(--max-font-size-scale));
+	--max-fs-3: calc(var(--max-fs-2) * var(--max-font-size-scale));
+	--max-fs-4: calc(var(--max-fs-3) * var(--max-font-size-scale));
+	--max-fs-5: calc(var(--max-fs-4) * var(--max-font-size-scale));
+	--max-fs-6: calc(var(--max-fs-5) * var(--max-font-size-scale));
+	--max-fs-7: calc(var(--max-fs-6) * var(--max-font-size-scale));
 
 	/* interpolation variables */
 	--resolution-range: calc(var(--max-resolution) - var(--min-resolution));
@@ -195,12 +209,24 @@ export default {
 	--range-fs--1: calc(var(--max-fs--1) - var(--min-fs--1));
 	--range-fs-0: calc(var(--max-fs-0) - var(--min-fs-0));
 	--range-fs-1: calc(var(--max-fs-1) - var(--min-fs-1));
+	--range-fs-2: calc(var(--max-fs-2) - var(--min-fs-2));
+	--range-fs-3: calc(var(--max-fs-3) - var(--min-fs-3));
+	--range-fs-4: calc(var(--max-fs-4) - var(--min-fs-4));
+	--range-fs-5: calc(var(--max-fs-5) - var(--min-fs-5));
+	--range-fs-6: calc(var(--max-fs-6) - var(--min-fs-6));
+	--range-fs-7: calc(var(--max-fs-7) - var(--min-fs-7));
 
 	/* fluid type scale */
 	--fs--2: max(12px, calc(var(--min-fs--2) * 1px + var(--range-fs--2) * var(--interpolate-by)));
 	--fs--1: max(14px, calc(var(--min-fs--1) * 1px + var(--range-fs--1) * var(--interpolate-by)));
 	--fs-0: calc(var(--min-fs-0) * 1px + var(--range-fs-0) * var(--interpolate-by));
 	--fs-1: calc(var(--min-fs-1) * 1px + var(--range-fs-1) * var(--interpolate-by));
+	--fs-2: calc(var(--min-fs-2) * 1px + var(--range-fs-2) * var(--interpolate-by));
+	--fs-3: calc(var(--min-fs-3) * 1px + var(--range-fs-3) * var(--interpolate-by));
+	--fs-4: calc(var(--min-fs-4) * 1px + var(--range-fs-4) * var(--interpolate-by));
+	--fs-5: calc(var(--min-fs-5) * 1px + var(--range-fs-5) * var(--interpolate-by));
+	--fs-6: calc(var(--min-fs-6) * 1px + var(--range-fs-6) * var(--interpolate-by));
+	--fs-7: calc(var(--min-fs-7) * 1px + var(--range-fs-7) * var(--interpolate-by));
 
 	/* line height config */
 	--line-height: 1.5;
@@ -211,6 +237,12 @@ export default {
 	--lh--1: calc(var(--lh-0) / var(--line-height-scale));
 	--lh-0: var(--line-height);
 	--lh-1: calc(var(--lh-0) * var(--line-height-scale));
+	--lh-2: calc(var(--lh-1) * var(--line-height-scale));
+	--lh-3: calc(var(--lh-2) * var(--line-height-scale));
+	--lh-4: calc(var(--lh-3) * var(--line-height-scale));
+	--lh-5: calc(var(--lh-4) * var(--line-height-scale));
+	--lh-6: calc(var(--lh-5) * var(--line-height-scale));
+	--lh-7: calc(var(--lh-6) * var(--line-height-scale));
 }
 
 .fontstyle_normal {
@@ -266,4 +298,35 @@ export default {
 	font-size: var(--fs-1);
 	line-height: var(--lh-1);
 }
+
+.Paragraph.size_2 {
+	font-size: var(--fs-2);
+	line-height: var(--lh-2);
+}
+
+.Paragraph.size_3 {
+	font-size: var(--fs-3);
+	line-height: var(--lh-3);
+}
+
+.Paragraph.size_4 {
+	font-size: var(--fs-4);
+	line-height: var(--lh-4);
+}
+
+.Paragraph.size_5 {
+	font-size: var(--fs-5);
+	line-height: var(--lh-5);
+}
+
+.Paragraph.size_6 {
+	font-size: var(--fs-6);
+	line-height: var(--lh-6);
+}
+
+.Paragraph.size_7 {
+	font-size: var(--fs-7);
+	line-height: var(--lh-7);
+}
+
 </style>


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
- The text component supports a limited amount of sizes
- When using the text component, there are scenarios where the `element` could be a null value preventing default rendering.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
- Adds all supported sizes. duplicating from the Heading component
- Adds conditional for element rendering in case of a `null` value.


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
This replicates work that happened in this PR https://github.com/square/maker/pull/263, but which had some rebase issues and triggered a major release. Due to that rebase / revert I couldn't cherry-pick -- original author of this work is @bashunaimiroy 

