### PR TITLE
feat(popover): add theme colors to popover styles

### DIFF
--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -504,10 +504,10 @@ export default {
 
 ## PopoverContent Props
 
-| Prop     | Type     | Default  | Possible values | Description                     |
-| -------- | -------- | -------- | --------------- | ------------------------------- |
-| color    | `string` | `'#000'` | —               | Text color within the popover   |
-| bg-color | `string` | `'#fff'` | —               | Background color of the popover |
+| Prop     | Type     | Default | Possible values | Description                     |
+| -------- | -------- | ------- | --------------- | ------------------------------- |
+| color    | `string` | —       | —               | Text color within the popover   |
+| bg-color | `string` | —       | —               | Background color of the popover |
 
 
 ## PopoverContent Slots

--- a/src/components/Popover/src/PopoverContent.vue
+++ b/src/components/Popover/src/PopoverContent.vue
@@ -18,7 +18,7 @@ export default {
 		 */
 		color: {
 			type: String,
-			default: '#000',
+			default: undefined,
 			validator: (color) => chroma.valid(color),
 		},
 		/**
@@ -26,7 +26,7 @@ export default {
 		 */
 		bgColor: {
 			type: String,
-			default: '#fff',
+			default: undefined,
 			validator: (color) => chroma.valid(color),
 		},
 	},
@@ -45,8 +45,8 @@ export default {
 <style module="$s">
 .PopoverContent {
 	padding: 24px;
-	color: var(--popover-color);
-	background-color: var(--popover-bg-color);
+	color: var(--popover-color, var(--neutral-90, black));
+	background-color: var(--popover-bg-color, var(--color-elevation, white));
 	border-radius: 8px;
 	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.16);
 }


### PR DESCRIPTION
Adds theme colors to popover styles.
<img width="864" alt="Screen Shot 2022-03-29 at 4 25 15 PM" src="https://user-images.githubusercontent.com/1486885/160700733-f416a8a9-4aa7-42c6-b8cf-3ec0b1250d6a.png">

