### PR TITLE
ci: fix github branch filtering syntax for release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [master, next, next-major, beta, alpha, '[1-9][0-9]*.x']
+    branches: [master, next, next-major, beta, alpha, '[0-9]+.x']
 
 jobs:
   release:


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
I tried backporting a bugfix from v9 to v8 but the release action never ran: https://github.com/square/maker/pull/281#issuecomment-1087768768

i think it's because i didn't read github docs closely enough. I thought `*` meant _"match zero or more of the **preceeding** character"_ which is what it means in regex... but how github interprets it as is _"match zero or more of **any** character"_ 🤦 .

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
fixes the github branch filtering syntax so that it hopefully works this time

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
nope