### PR TITLE
fix!: renames global 'variants' to 'patterns' to avoid name collision with local 'variant' props

### DIFF
--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -2,38 +2,6 @@
 
 For a simplified text-only button with no padding or focus/active/hover states, see: [TextButton](#/TextButton).
 
-```vue
-<template>
-	<div>
-		<m-button
-			variant="primary"
-		>
-			primary
-		</m-button>
-		<m-button
-			variant="secondary"
-		>
-			secondary
-		</m-button>
-		<m-button
-			variant="tertiary"
-		>
-			tertiary
-		</m-button>
-	</div>
-</template>
-
-<script>
-import { MButton } from '@square/maker/components/Button';
-
-export default {
-	components: {
-		MButton,
-	},
-};
-</script>
-```
-
 ## Styles & Sizes
 
 ```vue
@@ -558,18 +526,19 @@ body {
 
 Supports attributes from [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button).
 
-| Prop       | Type      | Default    | Possible values                                                | Description                           |
-| ---------- | --------- | ---------- | -------------------------------------------------------------- | ------------------------------------- |
-| type       | `string`  | `'button'` | —                                                              | Type of the button                    |
-| size       | `string`  | —          | `small`, `medium`, `large`                                     | Size of the button                    |
-| full-width | `boolean` | —          | —                                                              | Whether to make the button full-width |
-| color      | `string`  | —          | —                                                              | Background color of button            |
-| text-color | `string`  | —          | —                                                              | Text color of button                  |
-| variant    | `string`  | —          | `primary`, `secondary`, `tertiary`, `variant defined in theme` | Variant                               |
-| shape      | `string`  | —          | `squared`, `rounded`, `pill`                                   | Shape of button                       |
-| disabled   | `boolean` | `false`    | —                                                              | Toggles button disabled state         |
-| align      | `string`  | —          | `center`, `stack`, `space-between`                             | How to align button's contents        |
-| loading    | `boolean` | `false`    | —                                                              | Toggles button loading state          |
+| Prop       | Type      | Default    | Possible values                    | Description                             |
+| ---------- | --------- | ---------- | ---------------------------------- | --------------------------------------- |
+| pattern    | `string`  | —          | `pattern defined in theme`         | patterns are defined at the theme level |
+| type       | `string`  | `'button'` | —                                  | Type of the button                      |
+| size       | `string`  | —          | `small`, `medium`, `large`         | Size of the button                      |
+| full-width | `boolean` | —          | —                                  | Whether to make the button full-width   |
+| color      | `string`  | —          | —                                  | Background color of button              |
+| text-color | `string`  | —          | —                                  | Text color of button                    |
+| variant    | `string`  | —          | `primary`, `secondary`, `tertiary` | Variant                                 |
+| shape      | `string`  | —          | `squared`, `rounded`, `pill`       | Shape of button                         |
+| disabled   | `boolean` | `false`    | —                                  | Toggles button disabled state           |
+| align      | `string`  | —          | `center`, `stack`, `space-between` | How to align button's contents          |
+| loading    | `boolean` | `false`    | —                                  | Toggles button loading state            |
 
 
 ## Slots

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -150,6 +150,14 @@ export default {
 
 	props: {
 		/**
+		 * patterns are defined at the theme level
+		 * @values pattern defined in theme
+		 */
+		pattern: {
+			type: String,
+			default: undefined,
+		},
+		/**
 		 * Type of the button
 		 */
 		type: {
@@ -189,11 +197,12 @@ export default {
 		},
 		/**
 		 * Variant
-		 * @values primary, secondary, tertiary, variant defined in theme
+		 * @values primary, secondary, tertiary
 		 */
 		variant: {
 			type: String,
 			default: undefined,
+			validator: (variant) => ['primary', 'secondary', 'tertiary'].includes(variant),
 		},
 		/**
 		 * Shape of button
@@ -228,7 +237,16 @@ export default {
 	},
 
 	computed: {
-		...resolveThemeableProps('button', ['color', 'size', 'textColor', 'variant', 'shape', 'align', 'fullWidth']),
+		...resolveThemeableProps('button', [
+			'color',
+			'size',
+			'textColor',
+			'variant',
+			'shape',
+			'align',
+			'fullWidth',
+			'pattern',
+		]),
 		style() {
 			return VARIANTS[this.resolvedVariant]({
 				color: this.resolvedColor,

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -6,7 +6,7 @@ Use the Text component for regular body text. There are 10 text sizes: -2 to 7. 
 <template>
 	<div>
 		<m-text
-			v-for="size in [1, 0, -1, -2]"
+			v-for="size in [7, 6, 5, 4, 3, 2, 1, 0, -1, -2]"
 			:key="size"
 			:size="size"
 		>
@@ -31,7 +31,7 @@ export default {
 
 | Prop           | Type     | Default | Possible values                                                  | Description                                                                                                                    |
 | -------------- | -------- | ------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| variant        | `string` | —       | `headline`, `title`, `body`, `label`, `variant defined in theme` | variants are defined at the theme level                                                                                        |
+| pattern        | `string` | —       | `headline`, `title`, `body`, `label`, `pattern defined in theme` | patterns are defined at the theme level                                                                                        |
 | element        | `string` | —       | `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `p`, `span`, `div`, `li`     | [HTML Element](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement)                                                   |
 | size           | `number` | —       | `7`, `6`, `5`, `4`, `3`, `2`, `1`, `0`, `-1`, `-2`               | Size of text as step in fluid scale                                                                                            |
 | font-family    | `string` | —       | —                                                                | [Font family](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family)                                                    |

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -17,10 +17,10 @@ export default {
 
 	props: {
 		/**
-		 * variants are defined at the theme level
-		 * @values headline, title, body, label, variant defined in theme
+		 * patterns are defined at the theme level
+		 * @values headline, title, body, label, pattern defined in theme
 		 */
-		variant: {
+		pattern: {
 			type: String,
 			default: undefined,
 		},
@@ -113,7 +113,7 @@ export default {
 
 	computed: {
 		...resolveThemeableProps('text', [
-			'variant',
+			'pattern',
 			'element',
 			'size',
 			'fontFamily',

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -33,10 +33,16 @@ export default function defaultTheme() {
 			textColor: undefined,
 			fullWidth: false,
 			align: 'center',
-			variants: {
-				primary: {},
-				secondary: {},
-				tertiary: {},
+			patterns: {
+				primary: {
+					variant: 'primary',
+				},
+				secondary: {
+					variant: 'secondary',
+				},
+				tertiary: {
+					variant: 'tertiary',
+				},
 			},
 		},
 		textbutton: {
@@ -59,7 +65,7 @@ export default function defaultTheme() {
 			fontStyle: 'inherit',
 			textTransform: 'inherit',
 			textAlign: 'inherit',
-			variants: {
+			patterns: {
 				headline: {
 					size: 7,
 					fontWeight: '700',

--- a/src/components/Theme/src/utils.js
+++ b/src/components/Theme/src/utils.js
@@ -62,42 +62,42 @@ function capitalizeFirstLetter(string) {
 export function resolveThemeableProps(componentKeyInTheme, propNames) {
 	const computedResolvedProps = {};
 	for (const propName of propNames) {
-		if (propName === 'variant') {
-			computedResolvedProps.resolvedVariant = function resolveThemeableVariant() {
-				// local variant set directly on component
-				// overrides variant set by theme
-				if (!isNil(this.variant)) {
+		if (propName === 'pattern') {
+			computedResolvedProps.resolvedPattern = function resolveThemeablePattern() {
+				// local pattern set directly on component
+				// overrides pattern set by theme
+				if (!isNil(this.pattern)) {
 					// if validator for this prop exists then
 					// Vue would have already validated it by this point
-					return this.variant;
+					return this.pattern;
 				}
 
-				let variantOrPath;
+				let patternOrPath;
 
-				// default theme variant for this component
-				const variantFromTheme = this.theme[componentKeyInTheme].variant;
-				if (!isNil(variantFromTheme)) {
-					variantOrPath = variantFromTheme;
+				// default theme pattern for this component
+				const patternFromTheme = this.theme[componentKeyInTheme].pattern;
+				if (!isNil(patternFromTheme)) {
+					patternOrPath = patternFromTheme;
 				}
 
-				if (isNil(variantOrPath)) {
+				if (isNil(patternOrPath)) {
 					return undefined;
 				}
 
-				const resolvedVariant = this.theme.resolve(variantOrPath);
-				const variantValidator = this.$vnode.componentOptions
-					.Ctor.extendOptions.props.variant.validator;
+				const resolvedPattern = this.theme.resolve(patternOrPath);
+				const patternValidator = this.$vnode.componentOptions
+					.Ctor.extendOptions.props.pattern.validator;
 
-				// validate using variant prop validator if exists
-				if (variantValidator) {
-					assert.error(variantValidator(resolvedVariant), `Invalid value "${resolvedVariant}" for prop "variant" for component "${componentKeyInTheme}" in theme.`);
+				// validate using pattern prop validator if exists
+				if (patternValidator) {
+					assert.error(patternValidator(resolvedPattern), `Invalid value "${resolvedPattern}" for prop "pattern" for component "${componentKeyInTheme}" in theme.`);
 
-				// otherwise try validating by checking variants config for component
+				// otherwise try validating by checking patterns config for component
 				} else {
-					const themeVariant = this.theme[componentKeyInTheme].variants?.[resolvedVariant];
-					assert.error(themeVariant, `Invalid variant "${resolvedVariant}" for component "${componentKeyInTheme}" in theme.`);
+					const themePattern = this.theme[componentKeyInTheme].patterns?.[resolvedPattern];
+					assert.error(themePattern, `Invalid pattern "${resolvedPattern}" for component "${componentKeyInTheme}" in theme.`);
 				}
-				return resolvedVariant;
+				return resolvedPattern;
 			};
 		} else {
 			computedResolvedProps[`resolved${capitalizeFirstLetter(propName)}`] = function resolveThemeableProp() {
@@ -117,12 +117,12 @@ export function resolveThemeableProps(componentKeyInTheme, propNames) {
 					valueOrPath = valueFromTheme;
 				}
 
-				// variant value, overrides default theme value
-				if (!isNil(this.resolvedVariant)) {
-					const valueFromThemeVariant = this.theme[componentKeyInTheme]
-						.variants?.[this.resolvedVariant]?.[propName];
-					if (!isNil(valueFromThemeVariant)) {
-						valueOrPath = valueFromThemeVariant;
+				// pattern value, overrides default theme value
+				if (!isNil(this.resolvedPattern)) {
+					const valueFromThemePattern = this.theme[componentKeyInTheme]
+						.patterns?.[this.resolvedPattern]?.[propName];
+					if (!isNil(valueFromThemePattern)) {
+						valueOrPath = valueFromThemePattern;
 					}
 				}
 


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
allows customizing existing "patterns" and creating new "patterns" for buttons, which was not possible previously while they were still called "variants" and there was a name collision with button's local "variant" prop

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
just did

## Migration Guide
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
- change all `<m-text variant="etc">` to `<m-text pattern="etc">`
- change all `<m-button variant="etc">` to `<m-button pattern="etc">`
- change any theme data from
```js
{
  button: {
    variants: {
       // etc
    },
  },
  text: {
    variants: {
      // etc
    },
  },
},
```
- to this
```js
{
  button: {
    patterns: {
       // etc
    },
  },
  text: {
    patterns: {
      // etc
    },
  },
},
```