### PR TITLE
feat(theme): Global font theme data

### DIFF
--- a/lab/experiments/Themes/index.vue
+++ b/lab/experiments/Themes/index.vue
@@ -276,10 +276,10 @@ export default {
 		background: (store) => store.theme.colors.background,
 		fontLoad() {
 			const fonts = [];
-			const fontHeading = themeStore.$state.theme.heading.fontFamily;
-			const fontWeightsHeading = themeStore.$state.theme.heading.fontWeight;
-			const fontText = themeStore.$state.theme.text.fontFamily;
-			const fontWeightsText = themeStore.$state.theme.text.fontWeight;
+			const fontHeading = themeStore.$state.theme.fonts.heading;
+			const fontWeightsHeading = themeStore.$state.theme.fontWeights.heading;
+			const fontText = themeStore.$state.theme.fonts.body;
+			const fontWeightsText = themeStore.$state.theme.fontWeights.body;
 
 			// Can optimize this later
 			fonts.push(`${fontHeading}:${fontWeightsHeading}`);
@@ -326,8 +326,6 @@ export default {
 
 	methods: {
 		loadWebFont(fonts) {
-			// eslint-disable-next-line no-console
-			console.log(fonts);
 			WebFont.load({
 				google: {
 					families: fonts,
@@ -338,8 +336,6 @@ export default {
 			this.loadWebFont(this.fontLoad);
 		},
 		changeTheme(theme) {
-			// eslint-disable-next-line no-console
-			console.log(theme);
 			themeStore.theme = themes[theme];
 			this.updateFont();
 		},

--- a/lab/experiments/Themes/index.vue
+++ b/lab/experiments/Themes/index.vue
@@ -144,7 +144,7 @@
 				</h3>
 				<div :class="$s.fontChoice">
 					<select
-						v-model="theme.heading.fontFamily"
+						v-model="theme.fonts.heading"
 						:class="$s.familyChoice"
 						@change="updateFont"
 					>
@@ -158,7 +158,7 @@
 						</template>
 					</select>
 					<select
-						v-model="theme.heading.fontWeight"
+						v-model="theme.fontWeights.heading"
 						@change="updateFont"
 					>
 						<template v-for="(value, index) in defaultWeights">
@@ -178,7 +178,7 @@
 				</h3>
 				<div :class="$s.fontChoice">
 					<select
-						v-model="theme.text.fontFamily"
+						v-model="theme.fonts.body"
 						:class="$s.familyChoice"
 						@change="updateFont"
 					>
@@ -192,7 +192,7 @@
 						</template>
 					</select>
 					<select
-						v-model="theme.text.fontWeight"
+						v-model="theme.fontWeights.body"
 						@change="updateFont"
 					>
 						<template v-for="(value, index) in defaultWeights">

--- a/lab/experiments/Themes/preview.vue
+++ b/lab/experiments/Themes/preview.vue
@@ -613,9 +613,6 @@ export default {
 	padding: 20px 10px;
 	overflow: hidden;
 	color: var(--color-text);
-	font-weight: var(--font-weights-text, normal);
-	font-size: var(--font-base-size);
-	font-family: var(--font-text, inherit);
 	background-color: var(--color-background);
 	border-radius: 30px;
 	box-shadow:

--- a/lab/experiments/Themes/themes.js
+++ b/lab/experiments/Themes/themes.js
@@ -138,6 +138,12 @@ export const websiteTheme = {
 	fonts: {
 		baseSize: 16,
 		sizeScale: 1.17,
+		body: 'Open Sans',
+		heading: 'Open Sans',
+	},
+	fontWeights: {
+		body: 400,
+		heading: 600,
 	},
 	text: {
 		color: '@colors.text',

--- a/lab/experiments/Themes/themes.js
+++ b/lab/experiments/Themes/themes.js
@@ -147,13 +147,13 @@ export const websiteTheme = {
 	},
 	text: {
 		color: '@colors.text',
-		fontWeight: 400,
-		fontFamily: 'Open Sans',
+		fontWeight: '@fontWeights.body',
+		fontFamily: '@fonts.body',
 	},
 	heading: {
 		color: '@colors.heading',
-		fontWeight: 600,
-		fontFamily: 'Open Sans',
+		fontWeight: '@fontWeights.heading',
+		fontFamily: '@fonts.heading',
 	},
 	button: {
 		color: '@colors.button',

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -234,7 +234,6 @@ export default {
 	color: var(--text-color);
 	font-weight: 500;
 	font-size: var(--medium-font-size);
-	font-family: inherit;
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -265,7 +265,6 @@ export default {
 	min-width: 0;
 	color: var(--color-contrast);
 	font-weight: 500;
-	font-family: inherit;
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;

--- a/src/components/Calendar/src/Calendar.vue
+++ b/src/components/Calendar/src/Calendar.vue
@@ -327,7 +327,6 @@ export default {
 	min-width: min-content;
 	padding: 16px;
 	font-size: var(--font-size);
-	font-family: inherit;
 	line-height: var(--line-height);
 	background-color: var(--color-background, #fff);
 	border-radius: 4px;

--- a/src/components/Choice/src/Choice.vue
+++ b/src/components/Choice/src/Choice.vue
@@ -137,7 +137,6 @@ export default {
 	box-sizing: border-box;
 	font-weight: var(--font-weight);
 	font-size: var(--font-size);
-	font-family: inherit;
 	line-height: var(--line-height);
 }
 </style>

--- a/src/components/Choice/src/ChoiceOption.vue
+++ b/src/components/Choice/src/ChoiceOption.vue
@@ -73,7 +73,6 @@ export default {
 	color: var(--neutral-90, #222);
 	font-weight: inherit;
 	font-size: inherit;
-	font-family: inherit;
 	line-height: inherit;
 	text-align: left;
 	background-color: var(--neutral-10, #f2f2f2);

--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -142,7 +142,6 @@ export default {
 .Container {
 	padding: 16px 24px;
 	color: var(--color, var(--neutral-80, inherit));
-	font-family: inherit;
 	background-color: var(--bg-color, inherit);
 }
 

--- a/src/components/Input/src/InputControl.vue
+++ b/src/components/Input/src/InputControl.vue
@@ -164,8 +164,6 @@ export default {
 	padding: 0 16px;
 	color: var(--color-foreground);
 	font-size: 16px;
-	font-family: inherit;
-	font-family: var(--font-family);
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--color-border);
 	border-radius: var(--border-radius);
@@ -191,7 +189,6 @@ export default {
 	box-sizing: inherit;
 	color: inherit;
 	font-size: inherit;
-	font-family: inherit;
 	text-overflow: ellipsis;
 	background-color: transparent;
 	border: none;

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -124,7 +124,6 @@ export default {
 .Notice {
 	color: var(--color);
 	font-size: 14px;
-	font-family: inherit;
 	line-height: 24px;
 	border-radius: 8px;
 }

--- a/src/components/SegmentedControl/src/Segment.vue
+++ b/src/components/SegmentedControl/src/Segment.vue
@@ -44,7 +44,6 @@ export default {
 	color: var(--neutral-90, black);
 	font-weight: 500;
 	font-size: inherit;
-	font-family: inherit;
 	line-height: inherit;
 	background-color: transparent;
 	border: none;

--- a/src/components/Select/src/SelectControl.vue
+++ b/src/components/Select/src/SelectControl.vue
@@ -170,7 +170,6 @@ export default {
 	box-sizing: border-box;
 	min-width: 80px;
 	font-size: 16px;
-	font-family: inherit;
 	font-family: var(--font-family);
 	border-radius: var(--border-radius);
 }
@@ -192,7 +191,6 @@ export default {
 	overflow: hidden;
 	color: var(--color-foreground);
 	font-size: inherit;
-	font-family: inherit;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	background-color: var(--color-background, #fff);

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -158,7 +158,6 @@ export default {
 	margin: 0 16px;
 	color: var(--neutral-90, inherit);
 	font-weight: 500;
-	font-family: inherit;
 	font-feature-settings: "tnum";
 	font-variant-numeric: tabular-nums;
 }

--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -123,7 +123,6 @@ export default {
 	min-width: 0;
 	color: var(--neutral-90);
 	font-weight: 500;
-	font-family: inherit;
 	vertical-align: middle;
 	background-color: transparent;
 	border: none;

--- a/src/components/Textarea/src/TextareaControl.vue
+++ b/src/components/Textarea/src/TextareaControl.vue
@@ -121,8 +121,6 @@ export default {
 	padding: 12px 16px;
 	color: var(--color-foreground);
 	font-size: 16px;
-	font-family: inherit;
-	font-family: var(--font-family);
 	line-height: 24px;
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--color-border);

--- a/src/components/Theme/src/Theme.vue
+++ b/src/components/Theme/src/Theme.vue
@@ -84,19 +84,12 @@ export default {
 	},
 };
 </script>
-
 <style module="$s">
-:root {
-	--theme-font-weight: var(--fontWeights-body, normal);
-	--theme-font-size: calc(var(--fonts-baseSize, 16) * 1px);
-	--theme-font-family: var(--fonts-body, sans-serif);
-}
-
 .Theme {
 	color: var(--color-text);
-	font-weight: var(--theme-font-weight);
-	font-size: var(--theme-font-size);
-	font-family: var(--theme-font-family);
+	font-weight: var(--fontWeights-body, normal);
+	font-size: calc(var(--fonts-baseSize, 16) * 1px);
+	font-family: var(--fonts-body, sans-serif);
 	background-color: var(--color-background);
 }
 </style>

--- a/src/components/Theme/src/Theme.vue
+++ b/src/components/Theme/src/Theme.vue
@@ -56,7 +56,7 @@ export default {
 	},
 	computed: {
 		styles() {
-			const { colors } = this;
+			const { colors, fonts, fontWeights } = this;
 
 			return {
 				'--neutral-0': colors['neutral-0'],
@@ -70,6 +70,11 @@ export default {
 				'--color-text': colors.text,
 				'--color-elevation': colors['color-elevation'],
 				'--color-overlay': colors['color-overlay'],
+				'--fonts-baseSize': fonts.baseSize,
+				'--fonts-body': fonts.body,
+				'--fonts-heading': fonts.heading,
+				'--fontWeights-body': fontWeights.body,
+				'--fontWeights-heading': fontWeights.heading,
 			};
 		},
 	},
@@ -81,8 +86,17 @@ export default {
 </script>
 
 <style module="$s">
+:root {
+	--theme-font-weight: var(--fontWeights-body, normal);
+	--theme-font-size: calc(var(--fonts-baseSize, 16) * 1px);
+	--theme-font-family: var(--fonts-body, sans-serif);
+}
+
 .Theme {
 	color: var(--color-text);
+	font-weight: var(--theme-font-weight);
+	font-size: var(--theme-font-size);
+	font-family: var(--theme-font-family);
 	background-color: var(--color-background);
 }
 </style>

--- a/src/utils/InlineFormControlLayout/src/InlineFormControlLayout.vue
+++ b/src/utils/InlineFormControlLayout/src/InlineFormControlLayout.vue
@@ -46,7 +46,6 @@ export default {
 .LayoutContainer {
 	display: inline-flex;
 	font-size: 14px;
-	font-family: inherit;
 	line-height: 24px;
 	cursor: pointer;
 }


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
![image](https://user-images.githubusercontent.com/129122/163046336-ce48d744-9e05-4ef3-b137-99bdfaba077f.png)

The theme data only allowed passing font family / weight to the Heading and Text component.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
This PR allows for passing global font data for the family and weight to theme. The theme applies the body family / weight as a default as a style for overall theme. Any components in the theme will inherit that as a default.

The data is compliant with the [Theme UI Spec](https://theme-ui.com/theme-spec):
```
fonts: {
	baseSize: 16, // existing data
	sizeScale: 1.17, // existing data
	body: 'Open Sans',
	heading: 'Open Sans',
},
fontWeights: {
	body: 400,
	heading: 600,
},
```

This is also backwards compatible with the existing component data we're passing for the heading and text component. If users want to keep it the same they could reference the font data the same way they reference global colors like so:

```
text: {
	color: '@colors.text',
	fontWeight: '@fontWeights.body',
	fontFamily: '@fonts.body',
},
heading: {
	color: '@colors.heading',
	fontWeight: '@fontWeights.heading',
	fontFamily: '@fonts.heading',
},
```

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
This is PR is part of a larger effort to support all the typography options that are needed. Originally, the bulk of this work was done here (https://github.com/square/maker/pull/279) but this PR was modified to address feedback and implement changes in a non-breaking way.

You can test the changes in a branched version of the Theme Lab here: https://square.github.io/maker/lab/font-theme-data/#/Themes/