### PR TITLE
feat: Additional Theme font options

### DIFF
--- a/lab/experiments/Themes/index.vue
+++ b/lab/experiments/Themes/index.vue
@@ -140,6 +140,40 @@
 				<h3
 					:class="$s.subsectionTitle"
 				>
+					Headline
+				</h3>
+				<div :class="$s.fontChoice">
+					<select
+						v-model="theme.fonts.headline"
+						:class="$s.familyChoice"
+						@change="updateFont"
+					>
+						<template v-for="(value, index) in fontOptions">
+							<option
+								:key="index"
+								:value="value.name"
+							>
+								{{ value.name }}
+							</option>
+						</template>
+					</select>
+					<select
+						v-model="theme.fontWeights.headline"
+						@change="updateFont"
+					>
+						<template v-for="(value, index) in defaultWeights">
+							<option
+								:key="index"
+								:value="value"
+							>
+								{{ value }}
+							</option>
+						</template>
+					</select>
+				</div>
+				<h3
+					:class="$s.subsectionTitle"
+				>
 					Heading
 				</h3>
 				<div :class="$s.fontChoice">
@@ -174,7 +208,7 @@
 				<h3
 					:class="$s.subsectionTitle"
 				>
-					Text
+					Body
 				</h3>
 				<div :class="$s.fontChoice">
 					<select
@@ -193,6 +227,40 @@
 					</select>
 					<select
 						v-model="theme.fontWeights.body"
+						@change="updateFont"
+					>
+						<template v-for="(value, index) in defaultWeights">
+							<option
+								:key="index"
+								:value="value"
+							>
+								{{ value }}
+							</option>
+						</template>
+					</select>
+				</div>
+				<h3
+					:class="$s.subsectionTitle"
+				>
+					Label
+				</h3>
+				<div :class="$s.fontChoice">
+					<select
+						v-model="theme.fonts.label"
+						:class="$s.familyChoice"
+						@change="updateFont"
+					>
+						<template v-for="(value, index) in fontOptions">
+							<option
+								:key="index"
+								:value="value.name"
+							>
+								{{ value.name }}
+							</option>
+						</template>
+					</select>
+					<select
+						v-model="theme.fontWeights.label"
 						@change="updateFont"
 					>
 						<template v-for="(value, index) in defaultWeights">
@@ -225,6 +293,11 @@
 					>
 					Contrast
 				</label>
+				<p>
+					The preview of the text sizes are based on the browser viewport.
+					&nbsp;Since each canvas isn't an iframe, the contrast option is calculating
+					&nbsp;for desktop instead of mobile.
+				</p>
 				<!-- eslint-disable vue/no-textarea-mustache -->
 				<textarea rows="20">
 {{ theme }}
@@ -280,10 +353,16 @@ export default {
 			const fontWeightsHeading = themeStore.$state.theme.fontWeights.heading;
 			const fontText = themeStore.$state.theme.fonts.body;
 			const fontWeightsText = themeStore.$state.theme.fontWeights.body;
+			const fontHeadline = themeStore.$state.theme.fonts.headline;
+			const fontWeightsHeadline = themeStore.$state.theme.fontWeights.headline;
+			const fontLabel = themeStore.$state.theme.fonts.label;
+			const fontWeightsLabel = themeStore.$state.theme.fontWeights.label;
 
 			// Can optimize this later
 			fonts.push(`${fontHeading}:${fontWeightsHeading}`);
 			fonts.push(`${fontText}:${fontWeightsText}`);
+			fonts.push(`${fontHeadline}:${fontWeightsHeadline}`);
+			fonts.push(`${fontLabel}:${fontWeightsLabel}`);
 
 			return fonts;
 		},

--- a/lab/experiments/Themes/preview.vue
+++ b/lab/experiments/Themes/preview.vue
@@ -18,6 +18,17 @@
 						Headline (variant) +5
 					</m-text>
 					<m-text
+						variant="headline"
+						color="green"
+					>
+						Headline (color green)
+					</m-text>
+					<m-text
+						variant="heading"
+					>
+						Heading (variant)
+					</m-text>
+					<m-text
 						:size="-1"
 						variant="label"
 					>

--- a/lab/experiments/Themes/preview.vue
+++ b/lab/experiments/Themes/preview.vue
@@ -10,6 +10,20 @@
 						<shopping-bag-icon class="icon" />
 					</div>
 				</div>
+				<div :class="[$s.Section, $s.textVariantDemo]">
+					<m-text
+						variant="headline"
+						:size="5"
+					>
+						Headline (variant) +5
+					</m-text>
+					<m-text
+						:size="-1"
+						variant="label"
+					>
+						Label (variant) -1
+					</m-text>
+				</div>
 				<m-theme
 					:class="$s.Section"
 					:profile="nestedThemeProfile"
@@ -594,6 +608,7 @@ export default {
 	display: grid;
 	grid-template-columns: repeat(3, minmax(360px, 1fr));
 	gap: 40px;
+	height: 100%;
 	max-height: calc(100vh - 80px);
 	padding: 40px;
 	background-color: #f8f8f8;
@@ -640,5 +655,10 @@ export default {
 
 .Section {
 	padding: 2vh 1vw;
+}
+
+.textVariantDemo {
+	padding: 1vh 1vw;
+	border: 1px solid black;
 }
 </style>

--- a/lab/experiments/Themes/themes.js
+++ b/lab/experiments/Themes/themes.js
@@ -140,10 +140,14 @@ export const websiteTheme = {
 		sizeScale: 1.17,
 		body: 'Open Sans',
 		heading: 'Open Sans',
+		headline: 'Open Sans',
+		label: 'Open Sans',
 	},
 	fontWeights: {
 		body: 400,
 		heading: 600,
+		headline: 300,
+		label: 500,
 	},
 	text: {
 		color: '@colors.text',

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -232,8 +232,9 @@ export default {
 	height: var(--medium-height);
 	padding: 0 var(--medium-padding);
 	color: var(--text-color);
-	font-weight: 500;
+	font-weight: var(--fontWeights-label, var(--fontWeights-body, 500));
 	font-size: var(--medium-font-size);
+	font-family: var(--fonts-label, var(--fonts-body, sans-serif));
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -264,7 +264,8 @@ export default {
 	align-items: center;
 	min-width: 0;
 	color: var(--color-contrast);
-	font-weight: 500;
+	font-weight: var(--fontWeights-label, var(--fontWeights-body, 500));
+	font-family: var(--fonts-label, var(--fonts-body, sans-serif));
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -35,7 +35,7 @@ Supports attributes from [`<p>`](https://developer.mozilla.org/en-US/docs/Web/HT
 | -------------- | -------- | ----------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | element        | `string` | `'p'`       | `p`, `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `span`, `div`, `li`  | HTML Element wrapper                                                                        |
 | size           | `number` | —           | `7`, `6`, `5`, `4`, `3`, `2`, `1`, `0`, `-1`, `-2`            | Size of text                                                                                |
-| variant        | `string` | `'body'`    | `body`, `title`, `headline`, `label`                          | Variant, allows four custom font styles through the Theme component                         |
+| variant        | `string` | `'body'`    | `body`, `heading`, `headline`, `label`                        | Variant, allows four custom font styles through the Theme component                         |
 | font-family    | `string` | —           | —                                                             | Font family                                                                                 |
 | font-weight    | `number` | —           | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values                                            |
 | font-size      | `string` | —           | —                                                             | Font size, as a valid CSS value. This overrides the 'size' prop, and disables type scaling. |

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -33,8 +33,9 @@ Supports attributes from [`<p>`](https://developer.mozilla.org/en-US/docs/Web/HT
 
 | Prop           | Type     | Default     | Possible values                                               | Description                                                                                 |
 | -------------- | -------- | ----------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| element        | `string` | `'p'`       | `p`, `span`, `div`, `li`                                      | HTML Element wrapper                                                                        |
+| element        | `string` | `'p'`       | `p`, `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `span`, `div`, `li`  | HTML Element wrapper                                                                        |
 | size           | `number` | —           | `7`, `6`, `5`, `4`, `3`, `2`, `1`, `0`, `-1`, `-2`            | Size of text                                                                                |
+| variant        | `string` | `'body'`    | `body`, `title`, `headline`, `label`                          | Variant, allows four custom font styles through the Theme component                         |
 | font-family    | `string` | —           | —                                                             | Font family                                                                                 |
 | font-weight    | `number` | —           | `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900` | Font weight with standard numeric keyword values                                            |
 | font-size      | `string` | —           | —                                                             | Font size, as a valid CSS value. This overrides the 'size' prop, and disables type scaling. |

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -39,12 +39,12 @@ export default {
 		},
 		/**
 		 * Variant, allows four custom font styles through the Theme component
-		 * @values body, title, headline, label
+		 * @values body, heading, headline, label
 		 */
 		variant: {
 			type: String,
 			default: 'body',
-			validator: (variant) => ['body', 'title', 'headline', 'label'].includes(variant),
+			validator: (variant) => ['body', 'heading', 'headline', 'label'].includes(variant),
 		},
 		/**
 		 * Font family
@@ -122,7 +122,7 @@ export default {
 	},
 
 	computed: {
-		...resolveThemeableProps('text', ['size', 'fontFamily', 'fontWeight', 'color']),
+		...resolveThemeableProps('text', ['size', 'fontFamily', 'fontWeight']),
 		sizeClass() {
 			const minNonNegativeSize = 0;
 			if (this.resolvedSize >= minNonNegativeSize) {
@@ -136,7 +136,7 @@ export default {
 			return {
 				fontFamily: this.useThemeComponentData ? this.resolvedFontFamily : this.fontFamily,
 				fontWeight: this.useThemeComponentData ? this.resolvedFontWeight : this.fontWeight,
-				color: this.resolvedColor,
+				color: this.color,
 				fontSize: this.fontSize,
 				lineHeight: this.lineHeight,
 				'--mobile-base-font-size': fonts.baseSize,
@@ -280,14 +280,18 @@ export default {
 	font-family: var(--fonts-body, inherit);
 }
 
-.text_title {
+.text_heading,
+.text_headline {
 	margin: 0;
+	color: var(--color-heading, #000);
+}
+
+.text_heading {
 	font-weight: var(--fontWeights-heading, 600);
 	font-family: var(--fonts-heading, inherit);
 }
 
 .text_headline {
-	margin: 0;
 	font-weight: var(--fontWeights-headline, var(--fontWeights-heading, 600));
 	font-family: var(--fonts-headline, var(--fonts-heading, inherit));
 }

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -26,7 +26,7 @@ export default {
 		element: {
 			type: String,
 			default: 'p',
-			validator: (element) => ['p', 'span', 'div', 'li'].includes(element),
+			validator: (element) => ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'div', 'li'].includes(element),
 		},
 		/**
 		 * Size of text
@@ -36,6 +36,15 @@ export default {
 			type: Number,
 			default: undefined,
 			validator: (size) => size >= MIN_SIZE && size <= MAX_SIZE,
+		},
+		/**
+		 * Variant, allows four custom font styles through the Theme component
+		 * @values body, title, headline, label
+		 */
+		variant: {
+			type: String,
+			default: 'body',
+			validator: (variant) => ['body', 'title', 'headline', 'label'].includes(variant),
 		},
 		/**
 		 * Font family
@@ -123,9 +132,11 @@ export default {
 		},
 		inlineStyles() {
 			const { fonts } = this.theme;
+			const resolveProps = this.resolveVariant();
+
 			return {
-				fontFamily: this.resolvedFontFamily,
-				fontWeight: this.resolvedFontWeight,
+				fontFamily: resolveProps ? this.resolvedFontFamily : this.fontFamily,
+				fontWeight: resolveProps ? this.resolvedFontWeight : this.fontWeight,
 				color: this.resolvedColor,
 				fontSize: this.fontSize,
 				lineHeight: this.lineHeight,
@@ -135,9 +146,16 @@ export default {
 		},
 	},
 
+	methods: {
+		resolveVariant() {
+			return !(this.variant === 'headline' || this.variant === 'label');
+		},
+	},
+
 	render(createElement) {
 		const {
 			$s,
+			variant,
 			sizeClass,
 			inlineStyles,
 			fontStyle,
@@ -152,7 +170,8 @@ export default {
 
 		return createElement(element, {
 			class: [
-				$s.Paragraph,
+				$s.Text,
+				$s[`text_${variant}`],
 				$s[`size_${sizeClass}`],
 				{
 					[$s[`fontstyle_${fontStyle}`]]: fontStyle !== 'inherit',
@@ -169,7 +188,7 @@ export default {
 </script>
 
 <style module="$s">
-.Paragraph {
+.Text {
 	/* min breakpoint config */
 	--min-resolution: 320; /* arbitrary value */
 	--min-font-size: var(--mobile-base-font-size);
@@ -249,6 +268,30 @@ export default {
 	--lh-7: calc(var(--lh-6) * var(--line-height-scale));
 }
 
+/* Variant defaults */
+.text_body,
+.text_label {
+	font-weight: var(--fontWeights-body, 400);
+	font-family: var(--fonts-body, sans-serif);
+}
+
+.text_title {
+	margin: 0;
+	font-weight: var(--fontWeights-heading, 600);
+	font-family: var(--fonts-heading, sans-serif);
+}
+
+.text_headline {
+	margin: 0;
+	font-weight: var(--fontWeights-headline, var(--fontWeights-heading, 600));
+	font-family: var(--fonts-headline, var(--fonts-heading, sans-serif));
+}
+
+.text_label {
+	font-weight: var(--fontWeights-label, var(--fontWeights-body, 500));
+	font-family: var(--fonts-label, var(--fonts-body, sans-serif));
+}
+
 .fontstyle_normal {
 	font-style: normal;
 }
@@ -278,57 +321,57 @@ export default {
 }
 
 @media (min-width: 1200px) {
-	.Paragraph {
+	.Text {
 		--resolution: 1200px;
 	}
 }
 
-.Paragraph.size_minus-2 {
+.Text.size_minus-2 {
 	font-size: var(--fs--2);
 	line-height: var(--lh--2);
 }
 
-.Paragraph.size_minus-1 {
+.Text.size_minus-1 {
 	font-size: var(--fs--1);
 	line-height: var(--lh--1);
 }
 
-.Paragraph.size_0 {
+.Text.size_0 {
 	font-size: var(--fs-0);
 	line-height: var(--lh-0);
 }
 
-.Paragraph.size_1 {
+.Text.size_1 {
 	font-size: var(--fs-1);
 	line-height: var(--lh-1);
 }
 
-.Paragraph.size_2 {
+.Text.size_2 {
 	font-size: var(--fs-2);
 	line-height: var(--lh-2);
 }
 
-.Paragraph.size_3 {
+.Text.size_3 {
 	font-size: var(--fs-3);
 	line-height: var(--lh-3);
 }
 
-.Paragraph.size_4 {
+.Text.size_4 {
 	font-size: var(--fs-4);
 	line-height: var(--lh-4);
 }
 
-.Paragraph.size_5 {
+.Text.size_5 {
 	font-size: var(--fs-5);
 	line-height: var(--lh-5);
 }
 
-.Paragraph.size_6 {
+.Text.size_6 {
 	font-size: var(--fs-6);
 	line-height: var(--lh-6);
 }
 
-.Paragraph.size_7 {
+.Text.size_7 {
 	font-size: var(--fs-7);
 	line-height: var(--lh-7);
 }

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -132,11 +132,10 @@ export default {
 		},
 		inlineStyles() {
 			const { fonts } = this.theme;
-			const resolveProps = this.resolveVariant();
 
 			return {
-				fontFamily: resolveProps ? this.resolvedFontFamily : this.fontFamily,
-				fontWeight: resolveProps ? this.resolvedFontWeight : this.fontWeight,
+				fontFamily: this.useThemeComponentData ? this.resolvedFontFamily : this.fontFamily,
+				fontWeight: this.useThemeComponentData ? this.resolvedFontWeight : this.fontWeight,
 				color: this.resolvedColor,
 				fontSize: this.fontSize,
 				lineHeight: this.lineHeight,
@@ -144,12 +143,18 @@ export default {
 				'--mobile-font-size-scale': fonts.sizeScale,
 			};
 		},
-	},
-
-	methods: {
-		resolveVariant() {
-			return !(this.variant === 'headline' || this.variant === 'label');
+		/*
+		 * Text and heading have component definitions in the theme
+		 * This conditional check allows for fontFamily prop to work
+		 * when the component props are not defined in the theme data.
+		 *
+		 * The two other variants: headline and label are set with CSS
+		 * at the parent level and used in styling below
+		 */
+		useThemeComponentData() {
+			return (this.variant === 'text' || this.variant === 'heading');
 		},
+
 	},
 
 	render(createElement) {
@@ -272,24 +277,24 @@ export default {
 .text_body,
 .text_label {
 	font-weight: var(--fontWeights-body, 400);
-	font-family: var(--fonts-body, sans-serif);
+	font-family: var(--fonts-body, inherit);
 }
 
 .text_title {
 	margin: 0;
 	font-weight: var(--fontWeights-heading, 600);
-	font-family: var(--fonts-heading, sans-serif);
+	font-family: var(--fonts-heading, inherit);
 }
 
 .text_headline {
 	margin: 0;
 	font-weight: var(--fontWeights-headline, var(--fontWeights-heading, 600));
-	font-family: var(--fonts-headline, var(--fonts-heading, sans-serif));
+	font-family: var(--fonts-headline, var(--fonts-heading, inherit));
 }
 
 .text_label {
 	font-weight: var(--fontWeights-label, var(--fontWeights-body, 500));
-	font-family: var(--fonts-label, var(--fonts-body, sans-serif));
+	font-family: var(--fonts-label, var(--fonts-body, inherit));
 }
 
 .fontstyle_normal {

--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -122,7 +122,8 @@ export default {
 	align-items: center;
 	min-width: 0;
 	color: var(--neutral-90);
-	font-weight: 500;
+	font-weight: var(--fontWeights-label, var(--fontWeights-body, 500));
+	font-family: var(--fonts-label, var(--fonts-body, sans-serif));
 	vertical-align: middle;
 	background-color: transparent;
 	border: none;

--- a/src/components/Theme/src/Theme.vue
+++ b/src/components/Theme/src/Theme.vue
@@ -73,8 +73,12 @@ export default {
 				'--fonts-baseSize': fonts.baseSize,
 				'--fonts-body': fonts.body,
 				'--fonts-heading': fonts.heading,
+				'--fonts-headline': fonts.headline,
+				'--fonts-label': fonts.label,
 				'--fontWeights-body': fontWeights.body,
 				'--fontWeights-heading': fontWeights.heading,
+				'--fontWeights-headline': fontWeights.headline,
+				'--fontWeights-label': fontWeights.label,
 			};
 		},
 	},

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -19,6 +19,16 @@ export default function defaultTheme() {
 		fonts: {
 			baseSize: 16,
 			sizeScale: 1.17,
+			body: 'inherit',
+			heading: 'inherit',
+			headline: 'inherit',
+			label: 'inherit',
+		},
+		fontWeights: {
+			body: 400,
+			heading: 600,
+			headline: 300,
+			label: 500,
 		},
 		profiles: [
 			{


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
https://github.com/square/maker/issues/269

We currently have the ability to pass font data related to Heading and Text, but there's a desire to support more font options to allow for a greater range of customization of typography output.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
![CleanShot 2022-04-12 at 15 46 29](https://user-images.githubusercontent.com/129122/163066925-92a318be-e631-4673-96fd-861713f86787.png)

- Theme: Adds data and properties for two new font options: `headline` and `label`
- Text: 
	- Updates component to support leveraging any of the four supported font options through a variant prop: `headline`, `label`, `heading`, and `body`. Body is the default font style.
	- Expands the supported `element` options so that the Text component could be used in place of where the Heading component is used. (We're planning on consolidating the Heading and Text component into Text and remove Heading in a future release)
- Buttons: Updates default to leverage the label font styles with a fallback to the body if not set.
- Theme Lab: Adds controls and preview output for Headline and Label font styles.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
This is PR is part of a larger effort to support all the typography options that are needed. Originally, the bulk of this work was done here (https://github.com/square/maker/pull/279) but this PR was modified to address feedback and implement changes in a non-breaking way.

This is based on existing work in this PR: https://github.com/square/maker/pull/294

You can test the feature additions in this theme lab: https://square.github.io/maker/lab/new-font-data/#/Themes/