### PR TITLE
fix(popover): update popover color styles

### DIFF
--- a/lab/experiments/Popover.vue
+++ b/lab/experiments/Popover.vue
@@ -1,0 +1,196 @@
+<template>
+	<div
+		:class="$s.Wrapper"
+	>
+		<m-theme
+			:class="$s.Preview"
+			:theme="theme(backgroundColor)"
+		>
+			<m-heading
+				:size="0"
+			>
+				Parent Site MTheme
+			</m-heading>
+			<input
+				v-model="backgroundColor"
+				type="color"
+			>
+			<m-popover>
+				<template #action="popover">
+					<m-button
+						:class="$s.Button"
+						@click="popover.toggle()"
+					>
+						Popover Toggle
+					</m-button>
+				</template>
+				<template #content>
+					<m-popover-content
+						:class="$s.Popover"
+					>
+						<m-heading>
+							Popover content
+						</m-heading>
+						<m-text>
+							Content for a basic popover
+						</m-text>
+						<m-divider />
+						<m-text>
+							Content for a basic popover
+						</m-text>
+						<m-input
+							variant="outline"
+							placeholder="Delivery address"
+						/>
+					</m-popover-content>
+				</template>
+			</m-popover>
+			<m-text>
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+				sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+				Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+				nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+				reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+				pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa
+				qui officia deserunt mollit anim id est laborum.
+			</m-text>
+			<m-theme
+				:class="$s.Block"
+				:theme="theme(blockColor)"
+			>
+				<m-heading
+					:size="0"
+				>
+					Nested Block MTheme
+				</m-heading>
+				<input
+					v-model="blockColor"
+					type="color"
+				>
+				<m-popover>
+					<template #action="popover">
+						<m-button
+							:class="$s.Button"
+							@click="popover.toggle()"
+						>
+							Popover Toggle
+						</m-button>
+					</template>
+					<template #content>
+						<m-popover-content
+							:class="$s.Popover"
+						>
+							<m-heading>
+								Popover content
+							</m-heading>
+							<m-text>
+								Content for a basic popover
+							</m-text>
+							<m-divider />
+							<m-text>
+								Content for a basic popover
+							</m-text>
+							<m-input
+								variant="outline"
+								placeholder="Delivery address"
+							/>
+						</m-popover-content>
+					</template>
+				</m-popover>
+				<m-text>
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+					sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+					Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+					nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+					reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+					pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa
+					qui officia deserunt mollit anim id est laborum.
+				</m-text>
+			</m-theme>
+			<m-popover-layer />
+		</m-theme>
+	</div>
+</template>
+
+<script>
+import { MTheme } from '@square/maker/components/Theme';
+import { MHeading } from '@square/maker/components/Heading';
+import { MText } from '@square/maker/components/Text';
+import { MInput } from '@square/maker/components/Input';
+import { MButton } from '@square/maker/components/Button';
+import { MDivider } from '@square/maker/components/Divider';
+import { MPopoverLayer, MPopover, MPopoverContent } from '@square/maker/components/Popover';
+import { generateNeutralColors } from './Themes/utils/colors';
+
+export default {
+	components: {
+		MTheme,
+		MHeading,
+		MText,
+		MInput,
+		MButton,
+		MDivider,
+		MPopoverLayer,
+		MPopover,
+		MPopoverContent,
+	},
+
+	mixins: [
+		MPopoverLayer.popoverMixin,
+	],
+
+	data() {
+		return {
+			backgroundColor: '#000000',
+			blockColor: '#fff',
+		};
+	},
+
+	methods: {
+		theme(background) {
+			const colors = generateNeutralColors(background);
+			return {
+				colors: {
+					background,
+					heading: colors['neutral-90'],
+					text: colors['neutral-90'],
+					...colors,
+				},
+				button: {
+					color: colors['neutral-100'],
+				},
+			};
+		},
+	},
+};
+</script>
+
+<style module="$s">
+.Wrapper {
+	display: flex;
+	gap: 32px;
+	box-sizing: border-box;
+	min-height: 100vh;
+	padding: 32px;
+	font-family: Helvetica, sans-serif;
+	background: #e1e1e1;
+}
+
+.Button {
+	width: 400px;
+}
+
+.Preview,
+.Block,
+.Popover {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	gap: 16px;
+	padding: 32px;
+}
+
+.Block {
+	margin: 0 -32px;
+}
+</style>

--- a/src/components/Popover/src/PopoverContent.vue
+++ b/src/components/Popover/src/PopoverContent.vue
@@ -10,8 +10,16 @@
 
 <script>
 import chroma from 'chroma-js';
+import { MThemeKey, defaultTheme } from '@square/maker/components/Theme';
 
 export default {
+	inject: {
+		theme: {
+			default: defaultTheme(),
+			from: MThemeKey,
+		},
+	},
+
 	props: {
 		/**
 		 * Text color within the popover
@@ -33,9 +41,19 @@ export default {
 
 	computed: {
 		computedStyles() {
+			// PopoverContent can be rendered outside the current Mtheme wrapper
+			// depending on placement of MPopoverLayer so we need to make sure
+			// it receives the correct Mtheme color variables
+			const themeColorVars = {};
+			Object.entries(this.theme.colors).forEach(([color, hex]) => {
+				const name = color.includes('neutral') ? `--${color}` : `--color-${color}`;
+				themeColorVars[name] = hex;
+			});
+
 			return {
 				'--popover-color': this.color,
 				'--popover-bg-color': this.bgColor,
+				...themeColorVars,
 			};
 		},
 	},
@@ -45,9 +63,10 @@ export default {
 <style module="$s">
 .PopoverContent {
 	padding: 24px;
-	color: var(--popover-color, var(--neutral-90, black));
-	background-color: var(--popover-bg-color, var(--color-elevation, white));
+	color: var(--popover-color, var(--color-text, black));
+	background-color: var(--popover-bg-color, var(--color-background, white));
+	border: 1px solid var(--neutral-10);
 	border-radius: 8px;
-	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.16);
+	box-shadow: 0 0 18px 6px rgba(0, 0, 0, 0.2);
 }
 </style>


### PR DESCRIPTION
Changes to Popover color styles as well as lab to demo them.

<img width="466" alt="Screen Shot 2022-04-13 at 4 35 01 PM" src="https://user-images.githubusercontent.com/1486885/163266065-8c3d724c-6031-411f-9662-5a21803439c6.png">
<img width="464" alt="Screen Shot 2022-04-13 at 4 35 16 PM" src="https://user-images.githubusercontent.com/1486885/163266091-f4eed3a6-8dfe-4b50-be91-83f6e53da2b2.png">

