### PR TITLE
docs(pininput): better example of how to disable pininput while validating code

### DIFF
--- a/src/components/PinInput/README.md
+++ b/src/components/PinInput/README.md
@@ -144,18 +144,18 @@ export default {
 	},
 	methods: {
 		onPinComplete(code) {
+			const DELAY_MS = 1000;
 			this.disableInput = true;
-			const DELAY_MS = 500;
 
 			// simulate API time for code validation
 			setTimeout(() => {
+				this.disableInput = false;
 				if (this.testCode === code) {
 					this.invalidEntry = false;
 				} else {
 					this.invalidEntry = true;
-					this.$refs.pinInput.shakeAndClearInputs();
+					this.$nextTick(this.$refs.pinInput.shakeAndClearInputs);
 				}
-				this.disableInput = false;
 			}, DELAY_MS);
 		},
 	},


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
https://github.com/square/maker/issues/258

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
ultimately it comes down to a race-condition issue, disabled inputs cannot be focused, so i updated the pininput styleguide example showing how to avoid the race-condition

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
nope