### PR TITLE
refactor!: prefix public css vars

### DIFF
--- a/lab/experiments/ThemeTest.vue
+++ b/lab/experiments/ThemeTest.vue
@@ -132,22 +132,22 @@
 						<m-divider :class="$s.Divider" />
 						<div :class="$s.palette">
 							<div :class="$s.color">
-								<span :style="{ backgroundColor : 'var(--neutral-0)' }" /> Neutral 0
+								<span :style="{ backgroundColor : 'var(--maker-color-neutral-0)' }" /> Neutral 0
 							</div>
 							<div :class="$s.color">
-								<span :style="{ backgroundColor : 'var(--neutral-10)' }" /> Neutral 10
+								<span :style="{ backgroundColor : 'var(--maker-color-neutral-10)' }" /> Neutral 10
 							</div>
 							<div :class="$s.color">
-								<span :style="{ backgroundColor : 'var(--neutral-20)' }" /> Neutral 20
+								<span :style="{ backgroundColor : 'var(--maker-color-neutral-20)' }" /> Neutral 20
 							</div>
 							<div :class="$s.color">
-								<span :style="{ backgroundColor : 'var(--neutral-80)' }" /> Neutral 80
+								<span :style="{ backgroundColor : 'var(--maker-color-neutral-80)' }" /> Neutral 80
 							</div>
 							<div :class="$s.color">
-								<span :style="{ backgroundColor : 'var(--neutral-90)' }" /> Neutral 90
+								<span :style="{ backgroundColor : 'var(--maker-color-neutral-90)' }" /> Neutral 90
 							</div>
 							<div :class="$s.color">
-								<span :style="{ backgroundColor : 'var(--neutral-100)' }" /> Neutral 100
+								<span :style="{ backgroundColor : 'var(--maker-color-neutral-100)' }" /> Neutral 100
 							</div>
 						</div>
 					</div>
@@ -774,7 +774,7 @@ hr.Divider {
 }
 
 .Preview {
-	border: 1px solid var(--neutral-20);
+	border: 1px solid var(--maker-color-neutral-20);
 
 	/* stylelint-disable-next-line no-descending-specificity */
 	& > div {

--- a/lab/experiments/Themes/preview.vue
+++ b/lab/experiments/Themes/preview.vue
@@ -623,11 +623,11 @@ export default {
 	max-height: calc(100% - 40px);
 	padding: 20px 10px;
 	overflow: hidden;
-	color: var(--color-paragraph);
+	color: var(--maker-color-paragraph);
 	font-weight: var(--font-weights-text, normal);
 	font-size: var(--font-base-size);
 	font-family: var(--font-text, inherit);
-	background-color: var(--color-background);
+	background-color: var(--maker-color-background);
 	border-radius: 30px;
 	box-shadow:
 		4.8px 6.4px 10.8px -40px rgba(0, 0, 0, 0.34),

--- a/lab/experiments/Themes/preview.vue
+++ b/lab/experiments/Themes/preview.vue
@@ -626,7 +626,7 @@ export default {
 	color: var(--maker-color-paragraph);
 	font-weight: var(--font-weights-text, normal);
 	font-size: var(--font-base-size);
-	font-family: var(--font-text, inherit);
+	font-family: var(--maker-font-family-paragraph, inherit);
 	background-color: var(--maker-color-background);
 	border-radius: 30px;
 	box-shadow:

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -232,9 +232,9 @@ export default {
 	height: var(--medium-height);
 	padding: 0 var(--medium-padding);
 	color: var(--text-color);
-	font-weight: var(--font-weight-label, 500);
+	font-weight: var(--maker-font-weight-label, 500);
 	font-size: var(--medium-font-size);
-	font-family: var(--font-family-label, inherit);
+	font-family: var(--maker-font-family-label, inherit);
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;
@@ -312,7 +312,7 @@ export default {
 
 	&:focus {
 		--focus-border:
-			0 0 0 1px var(--neutral-20, #fff),
+			0 0 0 1px var(--maker-color-neutral-20, #fff),
 			0 0 0 3px var(--color-focus);
 	}
 

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -282,8 +282,8 @@ export default {
 	align-items: center;
 	min-width: 0;
 	color: var(--color-contrast);
-	font-weight: var(--font-weight-label, 500);
-	font-family: var(--font-family-label, inherit);
+	font-weight: var(--maker-font-weight-label, 500);
+	font-family: var(--maker-font-family-label, inherit);
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;
@@ -386,7 +386,7 @@ export default {
 
 	&:focus {
 		--focus-border:
-			0 0 0 1px var(--neutral-20, #fff),
+			0 0 0 1px var(--maker-color-neutral-20, #fff),
 			0 0 0 3px var(--color-focus);
 	}
 

--- a/src/components/Calendar/src/Calendar.vue
+++ b/src/components/Calendar/src/Calendar.vue
@@ -329,7 +329,7 @@ export default {
 	font-size: var(--font-size);
 	font-family: inherit;
 	line-height: var(--line-height);
-	background-color: var(--color-background, #fff);
+	background-color: var(--maker-color-background, #fff);
 	border-radius: 4px;
 }
 
@@ -341,9 +341,9 @@ export default {
 }
 
 .CalendarHeaderTitle {
-	color: var(--color-primary, #000);
-	font-weight: var(--font-weight-label, 500);
-	font-family: var(--font-family-label, inherit);
+	color: var(--maker-color-primary, #000);
+	font-weight: var(--maker-font-weight-label, 500);
+	font-family: var(--maker-font-family-label, inherit);
 }
 
 .CalendarHeaderButtonIcon {
@@ -391,8 +391,8 @@ export default {
 	touch-action: manipulation;
 
 	&.selected {
-		color: var(--color-background, #fff);
-		background-color: var(--color-primary, #000);
+		color: var(--maker-color-background, #fff);
+		background-color: var(--maker-color-primary, #000);
 	}
 
 	&.today {
@@ -406,6 +406,6 @@ export default {
 }
 
 .DateCell:hover .DateCellButton:not(.selected):not(.disabled) {
-	background-color: var(--neutral-10, rgba(0, 0, 0, 0.1));
+	background-color: var(--maker-color-neutral-10, rgba(0, 0, 0, 0.1));
 }
 </style>

--- a/src/components/Card/src/Card.vue
+++ b/src/components/Card/src/Card.vue
@@ -25,8 +25,8 @@ export default {
 <style module="$s">
 .Card {
 	padding: 16px 24px;
-	background-color: var(--color-background, #fff);
-	border: 1px solid var(--neutral-20, #eaeaea);
+	background-color: var(--maker-color-background, #fff);
+	border: 1px solid var(--maker-color-neutral-20, #eaeaea);
 	border-radius: 8px;
 }
 </style>

--- a/src/components/Checkbox/src/CheckboxControl.vue
+++ b/src/components/Checkbox/src/CheckboxControl.vue
@@ -99,8 +99,8 @@ export default {
 
 	/* these should later be pulled from
 	the ThemeProvider component */
-	--color-border: var(--neutral-20, rgba(0, 0, 0, 0.3));
-	--color-border-focus: var(--neutral-90, rgba(0, 0, 0, 0.9));
+	--color-border: var(--maker-color-neutral-20, rgba(0, 0, 0, 0.3));
+	--color-border-focus: var(--maker-color-neutral-90, rgba(0, 0, 0, 0.9));
 	--color-active: var(--color-text, rgba(0, 0, 0, 0.9));
 	--color-error: rgba(206, 50, 23, 1);
 }
@@ -111,7 +111,7 @@ export default {
 	height: 20px;
 	margin: 0;
 	padding: 0;
-	background-color: var(--color-background, #fff);
+	background-color: var(--maker-color-background, #fff);
 	border: 1px solid var(--color-border);
 	border-radius: 4px;
 	outline: none;
@@ -150,7 +150,7 @@ export default {
 	transition: opacity 0.2s ease;
 	pointer-events: none;
 	fill: none;
-	stroke: var(--color-background, #fff);
+	stroke: var(--maker-color-background, #fff);
 	stroke-width: 2px;
 	stroke-linecap: round;
 	stroke-linejoin: round;

--- a/src/components/Choice/src/Choice.vue
+++ b/src/components/Choice/src/Choice.vue
@@ -161,9 +161,9 @@ export default {
 
 	display: flex;
 	box-sizing: border-box;
-	font-weight: var(--font-weight-label, 500);
+	font-weight: var(--maker-font-weight-label, 500);
 	font-size: var(--font-size);
-	font-family: var(--font-family-label, inherit);
+	font-family: var(--maker-font-family-label, inherit);
 	line-height: var(--line-height);
 }
 </style>

--- a/src/components/Choice/src/ChoiceOption.vue
+++ b/src/components/Choice/src/ChoiceOption.vue
@@ -62,13 +62,13 @@ export default {
 
 	flex-shrink: 0;
 	padding: var(--button-padding);
-	color: var(--neutral-90, #222);
+	color: var(--maker-color-neutral-90, #222);
 	font-weight: inherit;
 	font-size: inherit;
 	font-family: inherit;
 	line-height: inherit;
 	text-align: left;
-	background-color: var(--neutral-10, #f2f2f2);
+	background-color: var(--maker-color-neutral-10, #f2f2f2);
 	border: none;
 	border-radius: var(--border-radius);
 	outline: none;
@@ -81,8 +81,8 @@ export default {
 
 	&:focus {
 		--focus-border:
-			0 0 0 1px var(--neutral-10, #fff),
-			0 0 0 3px var(--neutral-20, rgba(0, 0, 0, 0.3));
+			0 0 0 1px var(--maker-color-neutral-10, #fff),
+			0 0 0 3px var(--maker-color-neutral-20, rgba(0, 0, 0, 0.3));
 	}
 
 	&:disabled {
@@ -92,11 +92,11 @@ export default {
 }
 
 .selected {
-	color: var(--selected-text-color, var(--neutral-10, #f1f1f1));
-	background-color: var(--selected-background-color, var(--neutral-90, #222));
+	color: var(--selected-text-color, var(--maker-color-neutral-10, #f1f1f1));
+	background-color: var(--selected-background-color, var(--maker-color-neutral-90, #222));
 
 	&:disabled {
-		color: var(--selected-disabled-text-color, var(--neutral-20, #666));
+		color: var(--selected-disabled-text-color, var(--maker-color-neutral-20, #666));
 	}
 }
 </style>

--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -146,10 +146,10 @@ export default {
 
 .Label {
 	margin-bottom: 16px;
-	color: var(--color, var(--color-title, inherit));
-	font-weight: var(--font-weight-title, 500);
+	color: var(--color, var(--maker-color-title, inherit));
+	font-weight: var(--maker-font-weight-title, 500);
 	font-size: 14px;
-	font-family: var(--font-family-title, inherit);
+	font-family: var(--maker-font-family-title, inherit);
 	line-height: 20px;
 }
 
@@ -177,10 +177,10 @@ export default {
 }
 
 .Sublabel {
-	color: var(--color, var(--color-paragraph, inherit));
-	font-weight: var(--font-weight-paragraph, inherit);
+	color: var(--color, var(--maker-color-paragraph, inherit));
+	font-weight: var(--maker-font-weight-paragraph, inherit);
 	font-size: 14px;
-	font-family: var(--font-family-paragraph, inherit);
+	font-family: var(--maker-font-family-paragraph, inherit);
 	line-height: 24px;
 	letter-spacing: normal;
 	text-transform: none;

--- a/src/components/Dialog/src/DialogLayer.vue
+++ b/src/components/Dialog/src/DialogLayer.vue
@@ -189,7 +189,7 @@ export default {
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background-color: var(--color-overlay, rgba(0, 0, 0, 0.3));
+	background-color: var(--maker-color-overlay, rgba(0, 0, 0, 0.3));
 }
 
 /**

--- a/src/components/Divider/src/Divider.vue
+++ b/src/components/Divider/src/Divider.vue
@@ -26,7 +26,7 @@ hr.Divider {
 	height: 1px;
 	margin: 0;
 	padding: 0;
-	background-color: var(--neutral-20, rgba(0, 0, 0, 0.08));
+	background-color: var(--maker-color-neutral-20, rgba(0, 0, 0, 0.08));
 	border: none;
 }
 </style>

--- a/src/components/ImageUploader/src/ImagePicker.vue
+++ b/src/components/ImageUploader/src/ImagePicker.vue
@@ -187,15 +187,15 @@ export default {
 	box-sizing: border-box;
 	width: 96px;
 	height: 96px;
-	background-color: var(--color-background, #fff);
-	border: 1px solid var(--neutral-20, rgba(0, 0, 0, 0.15));
+	background-color: var(--maker-color-background, #fff);
+	border: 1px solid var(--maker-color-neutral-20, rgba(0, 0, 0, 0.15));
 	border-radius: 8px;
 	cursor: pointer;
 	transition: background-color 150ms linear;
 }
 
 .ImagePickerInputContainer.isDragged {
-	background-color: var(--neutral-10, #f5f4f4);
+	background-color: var(--maker-color-neutral-10, #f5f4f4);
 }
 
 .ImagePickerDragIcon {

--- a/src/components/ImageUploader/src/ImageSelection.vue
+++ b/src/components/ImageUploader/src/ImageSelection.vue
@@ -118,7 +118,7 @@ export default {
 	background-repeat: no-repeat;
 	background-position: center;
 	background-size: cover;
-	border: 1px solid var(--neutral-20, rgba(0, 0, 0, 0.15));
+	border: 1px solid var(--maker-color-neutral-20, rgba(0, 0, 0, 0.15));
 	border-radius: 8px;
 	transition: background-image linear 150ms;
 

--- a/src/components/Input/src/InputControl.vue
+++ b/src/components/Input/src/InputControl.vue
@@ -121,12 +121,12 @@ export default {
 	until we get a Theme Context component
 */
 .variant_fill {
-	--color-background: var(--neutral-10, #f6f7f9);
+	--color-background: var(--maker-color-neutral-10, #f6f7f9);
 	--color-border: transparent;
 }
 
 .variant_outline {
-	--color-border: var(--neutral-20, rgba(0, 0, 0, 0.3));
+	--color-border: var(--maker-color-neutral-20, rgba(0, 0, 0, 0.3));
 }
 
 .Affix {
@@ -150,9 +150,9 @@ export default {
 }
 
 .InputContainer {
-	--color-placeholder: var(--neutral-80, rgba(0, 0, 0, 0.55));
-	--color-foreground: var(--neutral-90, rgba(107, 107, 107, 0.9));
-	--color-border-active: var(--neutral-80, #222);
+	--color-placeholder: var(--maker-color-neutral-80, rgba(0, 0, 0, 0.55));
+	--color-foreground: var(--maker-color-neutral-90, rgba(107, 107, 107, 0.9));
+	--color-border-active: var(--maker-color-neutral-80, #222);
 	--color-error: rgba(206, 50, 23, 1);
 	--border-radius: 8px;
 

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -230,7 +230,7 @@ export default {
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background-color: var(--color-overlay, rgba(0, 0, 0, 0.3));
+	background-color: var(--maker-color-overlay, rgba(0, 0, 0, 0.3));
 }
 
 .Transparent {

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -177,13 +177,13 @@ export default {
 }
 
 .type_info {
-	--color: var(--neutral-90, #1b1b1b);
-	--color-icon: var(--neutral-80, #707070);
-	--color-bg: var(--neutral-10, #f1f1f1);
+	--color: var(--maker-color-neutral-90, #1b1b1b);
+	--color-icon: var(--maker-color-neutral-80, #707070);
+	--color-bg: var(--maker-color-neutral-10, #f1f1f1);
 }
 
 .variant_block {
 	padding: 16px;
-	background-color: var(--neutral-10, var(--color-bg));
+	background-color: var(--maker-color-neutral-10, var(--color-bg));
 }
 </style>

--- a/src/components/PinInput/src/PinInput.vue
+++ b/src/components/PinInput/src/PinInput.vue
@@ -219,8 +219,8 @@ export default {
 	flex-wrap: nowrap;
 	align-items: center;
 	justify-content: space-between;
-	font-weight: var(--font-weight-label, 500);
-	font-family: var(--font-family-label, inherit);
+	font-weight: var(--maker-font-weight-label, 500);
+	font-family: var(--maker-font-family-label, inherit);
 
 	&.error {
 		padding-bottom: 8px;

--- a/src/components/Popover/src/PopoverContent.vue
+++ b/src/components/Popover/src/PopoverContent.vue
@@ -64,8 +64,8 @@ export default {
 .PopoverContent {
 	padding: 24px;
 	color: var(--popover-color, var(--color-text, black));
-	background-color: var(--popover-bg-color, var(--color-background, white));
-	border: 1px solid var(--neutral-10);
+	background-color: var(--popover-bg-color, var(--maker-color-background, white));
+	border: 1px solid var(--maker-color-neutral-10);
 	border-radius: 8px;
 	box-shadow: 0 0 18px 6px rgba(0, 0, 0, 0.2);
 }

--- a/src/components/Radio/src/RadioControl.vue
+++ b/src/components/Radio/src/RadioControl.vue
@@ -99,8 +99,8 @@ export default {
 
 	/* these should later be pulled from
 	the ThemeProvider component */
-	--color-border: var(--neutral-20, rgba(0, 0, 0, 0.3));
-	--color-border-focus: var(--neutral-90, rgba(0, 0, 0, 0.9));
+	--color-border: var(--maker-color-neutral-20, rgba(0, 0, 0, 0.3));
+	--color-border-focus: var(--maker-color-neutral-90, rgba(0, 0, 0, 0.9));
 	--color-active: var(--color-text, rgba(0, 0, 0, 0.9));
 	--color-error: rgba(206, 50, 23, 1);
 }
@@ -112,7 +112,7 @@ export default {
 	margin: 0;
 	padding: 0;
 	vertical-align: middle;
-	background-color: var(--color-background, #fff);
+	background-color: var(--maker-color-background, #fff);
 	border: 1px solid var(--color-border);
 	border-radius: 50%;
 	outline: none;
@@ -128,7 +128,7 @@ export default {
 		width: 6px;
 		height: 6px;
 		margin: 6px;
-		background-color: var(--color-background, #fff);
+		background-color: var(--maker-color-background, #fff);
 		border-radius: 50%;
 	}
 

--- a/src/components/SegmentedControl/src/Segment.vue
+++ b/src/components/SegmentedControl/src/Segment.vue
@@ -41,7 +41,7 @@ export default {
 <style module="$s">
 .Segment {
 	flex: 1 0 0;
-	color: var(--neutral-90, black);
+	color: var(--maker-color-neutral-90, black);
 	font-weight: inherit;
 	font-size: inherit;
 	font-family: inherit;
@@ -62,8 +62,8 @@ export default {
 }
 
 .selected {
-	color: var(--neutral-90, black);
-	background-color: var(--color-elevation, white);
+	color: var(--maker-color-neutral-90, black);
+	background-color: var(--maker-color-elevation, white);
 	box-shadow: 0 1px 8px rgba(0, 0, 0, 0.15);
 }
 </style>

--- a/src/components/SegmentedControl/src/SegmentedControl.vue
+++ b/src/components/SegmentedControl/src/SegmentedControl.vue
@@ -69,11 +69,11 @@ export default {
 	box-sizing: border-box;
 	height: 56px;
 	padding: 4px;
-	font-weight: var(--font-weight-label, 500);
+	font-weight: var(--maker-font-weight-label, 500);
 	font-size: 14px;
-	font-family: var(--font-family-label, inherit);
+	font-family: var(--maker-font-family-label, inherit);
 	line-height: 24px;
-	background-color: var(--neutral-10, #f6f7f9);
+	background-color: var(--maker-color-neutral-10, #f6f7f9);
 	border-radius: 4px;
 }
 

--- a/src/components/Select/src/SelectControl.vue
+++ b/src/components/Select/src/SelectControl.vue
@@ -151,18 +151,18 @@ export default {
 	until we get a Theme Context component
 */
 .variant_fill {
-	--color-background: var(--neutral-10, #f6f7f9);
+	--color-background: var(--maker-color-neutral-10, #f6f7f9);
 	--color-border: transparent;
 }
 
 .variant_outline {
-	--color-border: var(--neutral-20, rgba(0, 0, 0, 0.3));
+	--color-border: var(--maker-color-neutral-20, rgba(0, 0, 0, 0.3));
 }
 
 .SelectContainer {
-	--color-placeholder: var(--neutral-80, rgba(0, 0, 0, 0.55));
-	--color-foreground: var(--neutral-90, rgba(2, 1, 1, 0.9));
-	--color-border-active: var(--neutral-80, #222);
+	--color-placeholder: var(--maker-color-neutral-80, rgba(0, 0, 0, 0.55));
+	--color-foreground: var(--maker-color-neutral-90, rgba(2, 1, 1, 0.9));
+	--color-border-active: var(--maker-color-neutral-80, #222);
 	--color-error: rgba(206, 50, 23, 1);
 	--border-radius: 8px;
 

--- a/src/components/Skeleton/src/SkeletonBlock.vue
+++ b/src/components/Skeleton/src/SkeletonBlock.vue
@@ -46,7 +46,7 @@ export default {
 }
 
 @keyframes pulsing {
-	0% { background-color: var(--neutral-10, #ebedef); }
-	100% { background-color: var(--neutral-20, #f5f6f7); }
+	0% { background-color: var(--maker-color-neutral-10, #ebedef); }
+	100% { background-color: var(--maker-color-neutral-20, #f5f6f7); }
 }
 </style>

--- a/src/components/Skeleton/src/SkeletonText.vue
+++ b/src/components/Skeleton/src/SkeletonText.vue
@@ -84,7 +84,7 @@ export default {
 }
 
 @keyframes pulsing {
-	0% { background-color: var(--neutral-10, #ebedef); }
-	100% { background-color: var(--neutral-20, #f5f6f7); }
+	0% { background-color: var(--maker-color-neutral-10, #ebedef); }
+	100% { background-color: var(--maker-color-neutral-20, #f5f6f7); }
 }
 </style>

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -156,9 +156,9 @@ export default {
 
 .Quantity {
 	margin: 0 16px;
-	color: var(--neutral-90, inherit);
-	font-weight: var(--font-weight-label, 500);
-	font-family: var(--font-family-label, inherit);
+	color: var(--maker-color-neutral-90, inherit);
+	font-weight: var(--maker-font-weight-label, 500);
+	font-family: var(--maker-font-family-label, inherit);
 	font-feature-settings: "tnum";
 	font-variant-numeric: tabular-nums;
 }

--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -121,9 +121,9 @@ export default {
 	display: inline-flex;
 	align-items: center;
 	min-width: 0;
-	color: var(--neutral-90);
-	font-weight: var(--font-weight-label, 500);
-	font-family: var(--font-family-label, inherit);
+	color: var(--maker-color-neutral-90);
+	font-weight: var(--maker-font-weight-label, 500);
+	font-family: var(--maker-font-family-label, inherit);
 	vertical-align: middle;
 	background-color: transparent;
 	border: none;
@@ -175,7 +175,7 @@ export default {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	color: var(--neutral-90);
+	color: var(--maker-color-neutral-90);
 	background-color: transparent;
 }
 

--- a/src/components/Textarea/src/TextareaControl.vue
+++ b/src/components/Textarea/src/TextareaControl.vue
@@ -98,18 +98,18 @@ export default {
 	until we get a Theme Context component
 */
 .variant_fill {
-	--color-background: var(--neutral-10, #f6f7f9);
+	--color-background: var(--maker-color-neutral-10, #f6f7f9);
 	--color-border: transparent;
 }
 
 .variant_outline {
-	--color-border: var(--neutral-20, rgba(0, 0, 0, 0.3));
+	--color-border: var(--maker-color-neutral-20, rgba(0, 0, 0, 0.3));
 }
 
 .Textarea {
-	--color-placeholder: var(--neutral-80, rgba(0, 0, 0, 0.55));
-	--color-foreground: var(--neutral-90, rgba(0, 0, 0, 0.9));
-	--color-border-active: var(--neutral-80, #222);
+	--color-placeholder: var(--maker-color-neutral-80, rgba(0, 0, 0, 0.55));
+	--color-foreground: var(--maker-color-neutral-90, rgba(0, 0, 0, 0.9));
+	--color-border-active: var(--maker-color-neutral-80, #222);
 	--color-error: rgba(206, 50, 23, 1);
 	--border-radius: 8px;
 
@@ -120,9 +120,9 @@ export default {
 	min-height: calc(12px * 2 + 24px * 3);
 	padding: 12px 16px;
 	color: var(--color-foreground);
-	font-weight: var(--font-weight-paragraph, inherit);
+	font-weight: var(--maker-font-weight-paragraph, inherit);
 	font-size: 16px;
-	font-family: var(--font-family-paragraph, inherit);
+	font-family: var(--maker-font-family-paragraph, inherit);
 	line-height: 24px;
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--color-border);

--- a/src/components/Theme/src/Theme.vue
+++ b/src/components/Theme/src/Theme.vue
@@ -59,24 +59,24 @@ export default {
 			const { colors, fonts } = this;
 
 			return {
-				'--neutral-0': colors['neutral-0'],
-				'--neutral-10': colors['neutral-10'],
-				'--neutral-20': colors['neutral-20'],
-				'--neutral-80': colors['neutral-80'],
-				'--neutral-90': colors['neutral-90'],
-				'--neutral-100': colors['neutral-100'],
-				'--color-primary': colors.primary,
-				'--color-background': colors.background,
-				'--color-title': colors.title,
-				'--color-paragraph': colors.paragraph,
-				'--color-elevation': colors['color-elevation'],
-				'--color-overlay': colors['color-overlay'],
-				'--font-family-title': fonts.title.fontFamily,
-				'--font-weight-title': fonts.title.fontWeight,
-				'--font-family-paragraph': fonts.paragraph.fontFamily,
-				'--font-weight-paragraph': fonts.paragraph.fontWeight,
-				'--font-family-label': fonts.label.fontFamily,
-				'--font-weight-label': fonts.label.fontWeight,
+				'--maker-color-neutral-0': colors['neutral-0'],
+				'--maker-color-neutral-10': colors['neutral-10'],
+				'--maker-color-neutral-20': colors['neutral-20'],
+				'--maker-color-neutral-80': colors['neutral-80'],
+				'--maker-color-neutral-90': colors['neutral-90'],
+				'--maker-color-neutral-100': colors['neutral-100'],
+				'--maker-color-primary': colors.primary,
+				'--maker-color-background': colors.background,
+				'--maker-color-title': colors.title,
+				'--maker-color-paragraph': colors.paragraph,
+				'--maker-color-elevation': colors['color-elevation'],
+				'--maker-color-overlay': colors['color-overlay'],
+				'--maker-font-family-title': fonts.title.fontFamily,
+				'--maker-font-weight-title': fonts.title.fontWeight,
+				'--maker-font-family-paragraph': fonts.paragraph.fontFamily,
+				'--maker-font-weight-paragraph': fonts.paragraph.fontWeight,
+				'--maker-font-family-label': fonts.label.fontFamily,
+				'--maker-font-weight-label': fonts.label.fontWeight,
 			};
 		},
 	},
@@ -89,9 +89,9 @@ export default {
 
 <style module="$s">
 .Theme {
-	color: var(--color-paragraph);
-	font-weight: var(--font-weight-paragraph);
-	font-family: var(--font-family-paragraph);
-	background-color: var(--color-background);
+	color: var(--maker-color-paragraph);
+	font-weight: var(--maker-font-weight-paragraph);
+	font-family: var(--maker-font-family-paragraph);
+	background-color: var(--maker-color-background);
 }
 </style>


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
when an app uses maker it can be confusing to tell which css vars are maker's or the app's 

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
prefixes maker's public css vars with `maker-`

## Migration Guide
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
if you used any `--neutral` vars in your app prefix them with `--maker-color-neutral` and if you used any other css vars prefix them with `--maker`