### PR TITLE
fix(notice): background color for variant block

### DIFF
--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -185,6 +185,6 @@ export default {
 
 .variant_block {
 	padding: 16px;
-	background-color: var(--neutral-10, var(--color-bg));
+	background-color: var(--color-bg);
 }
 </style>


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
![CleanShot 2022-04-20 at 15 50 42](https://user-images.githubusercontent.com/129122/164337561-e019de36-eadf-4528-90a1-1db502f9f589.png)

When notice component was used in a theme with the block variant it was always gray.

The notice background color has the incorrect CSS property fallback, setting to a neutral color (when used in the theme) as the default.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
Removes the neutral color as the primary css property, instead relying on the color-bg variable set in each of the notice types. It's always there so don't need to have a fallback.


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
This wasn't caught in doc dev testing for the notice since there's no theme to set the neutral colors. We should consider setting up some testing environments with doc dev to easily switch between a theme context and no theme context.