### PR TITLE
fix(pininput): makes pininput shrink if it doesn't fit container

### DIFF
--- a/src/components/Menu/README.md
+++ b/src/components/Menu/README.md
@@ -190,7 +190,7 @@ export default {
 | toggle-select-prefix | Select toggle prefix                                       |
 | toggle-select        | Select toggle text                                         |
 | toggle               | Custom toggle slot (not rendered if toggle-select is used) |
-| menu                 | Menu options                                               |
+| menu                 | —                                                          |
 
 
 ## Menu Events

--- a/src/components/PinInput/README.md
+++ b/src/components/PinInput/README.md
@@ -8,7 +8,9 @@ an error state.
 
 To trigger the 'shake and clear' functionality add a ref value to your PinInput component, and then on the parent component
 call `shakeAndClearInputs()` on the referenced component.
+
 ### Filled variant
+
 ```vue
 <template>
 	<m-pin-input
@@ -57,6 +59,7 @@ export default {
 ```
 
 ### Outline variant
+
 ```vue
 <template>
 	<m-pin-input
@@ -106,6 +109,7 @@ export default {
 ```
 
 ### With mocked API latency
+
 ```vue
 <template>
 	<m-pin-input
@@ -164,6 +168,7 @@ export default {
 ```
 
 ### In a dialog for mobile testing
+
 ```vue
 <template>
 	<div>
@@ -280,6 +285,7 @@ export default {
 	},
 };
 </script>
+
 <style module="$s">
 .padding {
 	padding: 16px 0;

--- a/src/components/PinInput/src/PinInput.vue
+++ b/src/components/PinInput/src/PinInput.vue
@@ -1,7 +1,6 @@
 <template>
 	<div>
 		<div
-			:style="{ width: containerWidth }"
 			:class="{
 				[$s.PinInputContainer]: true,
 				[$s.shake]: isShaking,
@@ -18,7 +17,7 @@
 				:disabled="disabled"
 				:maxlength="i === 0 ? pinLength : 1"
 				:class="{
-					[$s.PinInput]: true,
+					[$s.PinInputCell]: true,
 					[$s.filled]: variant === 'fill',
 					[$s.error]: invalid,
 				}"
@@ -87,11 +86,6 @@ export default {
 	computed: {
 		currentPin() {
 			return this.pin.join('');
-		},
-
-		containerWidth() {
-			const SINGLE_CONTAINER_WIDTH = 58;
-			return `${this.pinLength * SINGLE_CONTAINER_WIDTH}px`;
 		},
 	},
 
@@ -217,20 +211,22 @@ export default {
 .PinInputContainer {
 	display: flex;
 	flex-wrap: nowrap;
+	gap: 8px;
 	align-items: center;
-	justify-content: space-between;
 
 	&.error {
 		padding-bottom: 8px;
 	}
 }
 
-.PinInput {
+.PinInputCell {
 	display: flex;
+	flex: 0 1 auto;
 	align-items: center;
 	justify-content: center;
 	box-sizing: border-box;
 	width: 50px;
+	min-width: 0;
 	height: 50px;
 	padding: 0;
 	font-weight: 500;


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
https://github.com/square/maker/issues/229

pininput overflows container instead of shrinking, this looks bad and make the pininput almost unusable

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
makes pininput shrink if it can't fit within its container
![image](https://user-images.githubusercontent.com/7769424/165302936-1faeb663-65e3-438f-9dab-6a426aa37cd6.png)


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
nope