### PR TITLE
feat(shapes): theming support for shapes

### DIFF
--- a/lab/experiments/ThemeTest.vue
+++ b/lab/experiments/ThemeTest.vue
@@ -70,6 +70,24 @@
 								<span :style="{ backgroundColor : 'var(--neutral-100)' }" /> Neutral 100
 							</div>
 						</div>
+						<m-divider />
+						<m-heading
+							:size="0"
+						>
+							Shape
+						</m-heading>
+						<select
+							v-model="shape"
+						>
+							<template v-for="(value, index) in shapes">
+								<option
+									:key="index"
+									:value="value"
+								>
+									{{ value }}
+								</option>
+							</template>
+						</select>
 					</div>
 				</div>
 				<div
@@ -474,6 +492,12 @@ export default {
 			selected: 'medium',
 			images: [],
 			item: storeData.items[0],
+			shape: 'rounded',
+			shapes: [
+				'squared',
+				'rounded',
+				'pill',
+			],
 		};
 	},
 
@@ -494,8 +518,8 @@ export default {
 				modal: {
 					bgColor: this.backgroundColor,
 				},
-				actionbarbutton: {
-					shape: 'rounded',
+				shapes: {
+					default: this.shape,
 				},
 			};
 		},

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -171,10 +171,14 @@ export default {
 					textColor: this.textColor || this.resolvedColor,
 				});
 			}
-			return fill({
-				color: this.resolvedColor,
-				textColor: this.resolvedTextColor,
-			});
+			return {
+				...fill({
+					color: this.resolvedColor,
+					textColor: this.resolvedTextColor,
+				}),
+				'--border-radius-small': this.theme.shapes.radii.small,
+				'--border-radius-large': this.theme.shapes.radii.large,
+			};
 		},
 
 		isDisabled() {
@@ -238,7 +242,6 @@ export default {
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;
-	border-radius: 32px;
 	outline: none;
 	box-shadow:
 		var(--outline-border, 0 0),
@@ -295,11 +298,11 @@ export default {
 	}
 
 	&.shape_rounded {
-		border-radius: 8px;
+		border-radius: var(--border-radius-small, 8px);
 	}
 
 	&.shape_pill {
-		border-radius: 32px;
+		border-radius: var(--border-radius-large, 32px);
 	}
 
 	&:disabled {

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -230,10 +230,14 @@ export default {
 	computed: {
 		...resolveThemeableProps('button', ['color', 'size', 'textColor', 'variant', 'shape', 'align', 'fullWidth']),
 		style() {
-			return VARIANTS[this.resolvedVariant]({
-				color: this.resolvedColor,
-				textColor: this.resolvedTextColor,
-			});
+			return {
+				...VARIANTS[this.resolvedVariant]({
+					color: this.resolvedColor,
+					textColor: this.resolvedTextColor,
+				}),
+				'--border-radius-small': this.theme.shapes.radii.small,
+				'--border-radius-large': this.theme.shapes.radii.large,
+			};
 		},
 		isDisabled() {
 			return this.disabled || this.loading;
@@ -269,7 +273,6 @@ export default {
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;
-	border-radius: 8px;
 	outline: none;
 	box-shadow:
 		var(--outline-border, 0 0),
@@ -283,12 +286,16 @@ export default {
 	touch-action: manipulation;
 	fill: currentColor;
 
-	&.shape_pill {
-		border-radius: 32px;
-	}
-
 	&.shape_squared {
 		border-radius: 0;
+	}
+
+	&.shape_rounded {
+		border-radius: var(--border-radius-small, 8px);
+	}
+
+	&.shape_pill {
+		border-radius: var(--border-radius-large, 32px);
 	}
 
 	&.iconButton {

--- a/src/components/Card/src/Card.vue
+++ b/src/components/Card/src/Card.vue
@@ -2,7 +2,9 @@
 	<div
 		:class="[
 			$s.Card,
+			$s[`shape_${resolvedShape}`],
 		]"
+		:style="style"
 		v-bind="$attrs"
 		v-on="$listeners"
 	>
@@ -12,13 +14,41 @@
 </template>
 
 <script>
+import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
 
 /**
  * @inheritAttrs div
  * @inheritListeners div
  */
 export default {
+	inject: {
+		theme: {
+			default: defaultTheme(),
+			from: MThemeKey,
+		},
+	},
+
 	inheritAttrs: false,
+
+	props: {
+		/**
+		 * card shape
+		 */
+		shape: {
+			type: String,
+			default: undefined,
+			validator: (shape) => ['squared', 'rounded'].includes(shape),
+		},
+	},
+
+	computed: {
+		...resolveThemeableProps('card', ['shape']),
+		style() {
+			return {
+				'--border-radius-small': this.theme.shapes.radii.small,
+			};
+		},
+	},
 };
 </script>
 
@@ -27,6 +57,14 @@ export default {
 	padding: 16px 24px;
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--neutral-20, #eaeaea);
-	border-radius: 8px;
+
+	&.shape_rounded,
+	&.shape_pill {
+		border-radius: var(--border-radius-small, 8px);
+	}
+
+	&.shape_squared {
+		border-radius: 0;
+	}
 }
 </style>

--- a/src/components/Choice/src/ChoiceOption.vue
+++ b/src/components/Choice/src/ChoiceOption.vue
@@ -57,7 +57,6 @@ export default {
 	--selected-disabled-text-color
 */
 .Button {
-	--border-radius: 8px;
 	--button-padding: 12px 24px;
 
 	flex-shrink: 0;
@@ -70,7 +69,7 @@ export default {
 	text-align: left;
 	background-color: var(--neutral-10, #f2f2f2);
 	border: none;
-	border-radius: var(--border-radius);
+	border-radius: var(--maker-border-radius, 8px);
 	outline: none;
 	box-shadow: var(--focus-border, 0 0);
 	cursor: pointer;

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -1,5 +1,8 @@
 <template>
-	<div :class="$s.ImageWrapper">
+	<div
+		:class="$s.ImageWrapper"
+		:style="style"
+	>
 		<template v-if="isIntersecting">
 			<m-transition-fade-in>
 				<m-skeleton-block
@@ -7,7 +10,10 @@
 				/>
 				<img
 					v-else
-					:class="$s.Image"
+					:class="[
+						$s.Image,
+						$s[`shape_${resolvedShape}`],
+					]"
 					:src="src"
 					:srcset="srcset"
 					v-bind="$attrs"
@@ -21,6 +27,7 @@
 <script>
 import { MTransitionFadeIn } from '@square/maker/components/TransitionFadeIn';
 import { MSkeletonBlock } from '@square/maker/components/Skeleton';
+import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
 
 function SharedIntersectionObserver() {
 	const callbacks = new WeakMap();
@@ -54,6 +61,13 @@ export default {
 		MSkeletonBlock,
 	},
 
+	inject: {
+		theme: {
+			default: defaultTheme(),
+			from: MThemeKey,
+		},
+	},
+
 	inheritAttrs: false,
 
 	props: {
@@ -65,6 +79,11 @@ export default {
 			type: String,
 			default: undefined,
 		},
+		shape: {
+			type: String,
+			default: undefined,
+			validator: (shape) => ['squared', 'rounded'].includes(shape),
+		},
 	},
 
 	data() {
@@ -72,6 +91,15 @@ export default {
 			isIntersecting: true,
 			loaded: imgCache.has(this.src + this.srcset),
 		};
+	},
+
+	computed: {
+		...resolveThemeableProps('image', ['shape']),
+		style() {
+			return {
+				'--border-radius-medium': this.theme.shapes.radii.medium,
+			};
+		},
 	},
 
 	watch: {
@@ -135,5 +163,13 @@ export default {
 	height: 100%;
 	object-fit: cover;
 	object-position: center;
+
+	&.shape_rounded {
+		border-radius: var(--border-radius-medium, 16px);
+	}
+
+	&.shape_squared {
+		border-radius: 0;
+	}
 }
 </style>

--- a/src/components/ImageUploader/src/ImagePicker.vue
+++ b/src/components/ImageUploader/src/ImagePicker.vue
@@ -189,7 +189,7 @@ export default {
 	height: 96px;
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--neutral-20, rgba(0, 0, 0, 0.15));
-	border-radius: 8px;
+	border-radius: var(--maker-border-radius, 8px);
 	cursor: pointer;
 	transition: background-color 150ms linear;
 }

--- a/src/components/ImageUploader/src/ImageSelection.vue
+++ b/src/components/ImageUploader/src/ImageSelection.vue
@@ -119,7 +119,7 @@ export default {
 	background-position: center;
 	background-size: cover;
 	border: 1px solid var(--neutral-20, rgba(0, 0, 0, 0.15));
-	border-radius: 8px;
+	border-radius: var(--maker-border-radius, 8px);
 	transition: background-image linear 150ms;
 
 	--color-error: rgba(206, 50, 23, 1);

--- a/src/components/Input/src/InputControl.vue
+++ b/src/components/Input/src/InputControl.vue
@@ -154,7 +154,6 @@ export default {
 	--color-foreground: var(--neutral-90, rgba(107, 107, 107, 0.9));
 	--color-border-active: var(--neutral-80, #222);
 	--color-error: rgba(206, 50, 23, 1);
-	--border-radius: 8px;
 
 	display: flex;
 	align-items: center;
@@ -168,7 +167,7 @@ export default {
 	font-family: var(--font-family);
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--color-border);
-	border-radius: var(--border-radius);
+	border-radius: var(--maker-border-radius, 8px);
 	transition: border-color 0.2s ease;
 
 	&:not(.disabled, .invalid):hover,

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -126,7 +126,7 @@ export default {
 	font-size: 14px;
 	font-family: inherit;
 	line-height: 24px;
-	border-radius: 8px;
+	border-radius: var(--maker-border-radius, 8px);
 }
 
 .IconContentWrapper {

--- a/src/components/PinInput/src/PinInput.vue
+++ b/src/components/PinInput/src/PinInput.vue
@@ -238,7 +238,7 @@ export default {
 	text-align: center;
 	background: #fff;
 	border: 1px solid #d3d3d3;
-	border-radius: 8px;
+	border-radius: var(--maker-border-radius, 8px);
 	outline: none;
 	caret-color: black;
 	cursor: pointer;

--- a/src/components/Popover/src/PopoverContent.vue
+++ b/src/components/Popover/src/PopoverContent.vue
@@ -81,7 +81,7 @@ export default {
 	color: var(--popover-color, var(--color-text, black));
 	background-color: var(--popover-bg-color, var(--color-background, white));
 	border: 1px solid var(--neutral-10);
-	border-radius: 8px;
+	border-radius: var(--maker-border-radius, 8px);
 	box-shadow: 0 0 18px 6px rgba(0, 0, 0, 0.2);
 }
 </style>

--- a/src/components/ProgressBar/src/ProgressBar.vue
+++ b/src/components/ProgressBar/src/ProgressBar.vue
@@ -32,14 +32,6 @@ export default {
 			validator: (size) => ['xsmall', 'small', 'medium', 'large'].includes(size),
 		},
 		/**
-		 * Shape of the progress bar
-		 */
-		shape: {
-			type: String,
-			default: 'rounded',
-			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
-		},
-		/**
 		 * Color of the progress bar (not background)
 		 */
 		color: {
@@ -73,12 +65,14 @@ export default {
 	width: 100%;
 	overflow: hidden;
 	background-color: #f5f4f4;
+	border-radius: var(--maker-border-radius, 0);
 }
 
 .ProgressBar {
 	width: var(--fill-percent, 0);
 	height: 100%;
 	background-color: var(--bar-color);
+	border-radius: var(--maker-border-radius, 0);
 	transition: width 100ms linear;
 }
 
@@ -96,17 +90,5 @@ export default {
 
 .ProgressBarContainer.size_large {
 	height: 16px;
-}
-
-.ProgressBarContainer.shape_squared,
-.ProgressBarContainer.shape_squared .ProgressBar {
-	border-radius: 0;
-}
-
-.ProgressBarContainer.shape_rounded,
-.ProgressBarContainer.shape_rounded .ProgressBar,
-.ProgressBarContainer.shape_pill,
-.ProgressBarContainer.shape_pill .ProgressBar {
-	border-radius: 16px;
 }
 </style>

--- a/src/components/SegmentedControl/src/Segment.vue
+++ b/src/components/SegmentedControl/src/Segment.vue
@@ -2,7 +2,6 @@
 	<button
 		:class="[
 			$s.Button,
-			$s[`shape_${controlState.shapeInner}`],
 			$s[`size_${controlState.sizeInner}`],
 			{ [$s.selected]: isSelected },
 		]"
@@ -48,17 +47,9 @@ export default {
 	line-height: inherit;
 	background-color: transparent;
 	border: none;
-	border-radius: 4px;
+	border-radius: var(--maker-border-radius-button, 8px);
 	outline: none;
 	cursor: pointer;
-}
-
-.shape_pill {
-	border-radius: 32px;
-}
-
-.shape_squared {
-	border-radius: 0;
 }
 
 .selected {

--- a/src/components/SegmentedControl/src/SegmentedControl.vue
+++ b/src/components/SegmentedControl/src/SegmentedControl.vue
@@ -2,7 +2,6 @@
 	<div
 		:class="[
 			$s.Container,
-			$s[`shape_${shapeInner}`],
 			$s[`size_${sizeInner}`],
 		]"
 	>
@@ -32,14 +31,6 @@ export default {
 			required: true,
 		},
 		/**
-		 * Shape of Control & Segments
-		 */
-		shape: {
-			type: String,
-			default: 'rounded',
-			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
-		},
-		/**
 		 * Size of Control & Segments
 		 */
 		size: {
@@ -51,7 +42,6 @@ export default {
 	data() {
 		return {
 			currentValue: this.selected,
-			shapeInner: this.shape,
 			sizeInner: this.size,
 		};
 	},
@@ -72,15 +62,7 @@ export default {
 	font-size: 14px;
 	line-height: 24px;
 	background-color: var(--neutral-10, #f6f7f9);
-	border-radius: 4px;
-}
-
-.shape_pill {
-	border-radius: 32px;
-}
-
-.shape_squared {
-	border-radius: 0;
+	border-radius: var(--maker-border-radius-button, 8px);
 }
 
 .size_small {

--- a/src/components/Select/src/SelectControl.vue
+++ b/src/components/Select/src/SelectControl.vue
@@ -180,7 +180,6 @@ export default {
 	--color-foreground: var(--neutral-90, rgba(2, 1, 1, 0.9));
 	--color-border-active: var(--neutral-80, #222);
 	--color-error: rgba(206, 50, 23, 1);
-	--border-radius: 8px;
 
 	position: relative;
 	box-sizing: border-box;
@@ -188,7 +187,7 @@ export default {
 	font-size: 16px;
 	font-family: inherit;
 	font-family: var(--font-family);
-	border-radius: var(--border-radius);
+	border-radius: var(--maker-border-radius, 8px);
 }
 
 .Prefix {

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -7,7 +7,6 @@
 			size="small"
 			:color="resolvedColor"
 			:text-color="resolvedTextColor"
-			:shape="resolvedShape"
 			:disabled="value === minVal"
 			@click="decrement"
 		>
@@ -21,7 +20,6 @@
 			size="small"
 			:color="resolvedColor"
 			:text-color="resolvedTextColor"
-			:shape="resolvedShape"
 			:disabled="value === maxVal"
 			@click="increment"
 		>
@@ -96,18 +94,10 @@ export default {
 			default: undefined,
 			validator: (color) => chroma.valid(color),
 		},
-		/**
-		 * stepper button shape
-		 */
-		shape: {
-			type: String,
-			default: undefined,
-			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
-		},
 	},
 
 	computed: {
-		...resolveThemeableProps('stepper', ['color', 'textColor', 'shape']),
+		...resolveThemeableProps('stepper', ['color', 'textColor']),
 
 		maxVal() {
 			return Number.parseInt(this.max, 10);

--- a/src/components/Textarea/src/TextareaControl.vue
+++ b/src/components/Textarea/src/TextareaControl.vue
@@ -111,7 +111,6 @@ export default {
 	--color-foreground: var(--neutral-90, rgba(0, 0, 0, 0.9));
 	--color-border-active: var(--neutral-80, #222);
 	--color-error: rgba(206, 50, 23, 1);
-	--border-radius: 8px;
 
 	box-sizing: border-box;
 	width: 100%;
@@ -126,7 +125,7 @@ export default {
 	line-height: 24px;
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--color-border);
-	border-radius: var(--border-radius);
+	border-radius: var(--maker-border-radius, 8px);
 	outline: none;
 	transition:
 		border 0.2s ease,

--- a/src/components/Theme/src/Theme.vue
+++ b/src/components/Theme/src/Theme.vue
@@ -56,7 +56,14 @@ export default {
 	},
 	computed: {
 		styles() {
-			const { colors } = this;
+			const { colors, shapes } = this;
+			const { radii } = shapes;
+			radii.default = shapes.default === 'squared' ? 0 : radii.small;
+			radii.button = {
+				squared: 0,
+				rounded: radii.small,
+				pill: radii.large,
+			}[shapes.default];
 
 			return {
 				'--neutral-0': colors['neutral-0'],
@@ -70,6 +77,8 @@ export default {
 				'--color-text': colors.text,
 				'--color-elevation': colors['color-elevation'],
 				'--color-overlay': colors['color-overlay'],
+				'--maker-border-radius': radii.default,
+				'--maker-border-radius-button': radii.button,
 			};
 		},
 	},

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -20,6 +20,14 @@ export default function defaultTheme() {
 			baseSize: 16,
 			sizeScale: 1.17,
 		},
+		shapes: {
+			default: 'rounded',
+			radii: {
+				small: '8px',
+				medium: '16px',
+				large: '32px',
+			},
+		},
 		profiles: [
 			{
 				id: 'defaultProfile',
@@ -28,7 +36,7 @@ export default function defaultTheme() {
 		button: {
 			size: 'medium',
 			variant: 'primary',
-			shape: 'rounded',
+			shape: '@shapes.default',
 			color: '@colors.primary',
 			textColor: undefined,
 			fullWidth: false,
@@ -40,10 +48,16 @@ export default function defaultTheme() {
 		},
 		actionbarbutton: {
 			color: '@colors.primary',
-			shape: 'pill',
+			shape: '@shapes.default',
 			textColor: undefined,
 			fullWidth: false,
 			align: 'center',
+		},
+		image: {
+			shape: 'squared',
+		},
+		card: {
+			shape: '@shapes.default',
 		},
 		text: {
 			fontFamily: 'inherit',
@@ -63,7 +77,6 @@ export default function defaultTheme() {
 		stepper: {
 			color: '@colors["neutral-10"]',
 			textColor: '@colors["neutral-90"]',
-			shape: 'pill',
 		},
 		notice: {
 			color: undefined,


### PR DESCRIPTION
Adds theming support for shape across multiple maker components.

- `shapes` prop on default theme where default component shape and theme border radius sizes are defined
```
		shapes: {
			default: 'rounded',
			radii: {
				small: '8px',
				medium: '16px',
				large: '32px',
			},
		},
```
- Add global maker border radius variables to `Theme`, `--maker-border-radius` and `--maker-border-radius-button` for all shape components that don't have a local `shape` override.
- Update component styles to reflect new shape updates.
- Update `ThemeTest` lab to demo changes in shape controls