### PR TITLE
refactor!: some font-related config renames

### DIFF
--- a/lab/experiments/ThemeTest.vue
+++ b/lab/experiments/ThemeTest.vue
@@ -117,17 +117,17 @@
 						</label>
 						<label>
 							<input
-								v-model="titleColor"
+								v-model="headingColor"
 								type="color"
 							>
-							Title
+							Heading
 						</label>
 						<label>
 							<input
-								v-model="paragraphColor"
+								v-model="bodyColor"
 								type="color"
 							>
-							Paragraph
+							Body
 						</label>
 						<m-divider :class="$s.Divider" />
 						<div :class="$s.palette">
@@ -565,8 +565,8 @@ export default {
 		return {
 			backgroundColor: '#ffffff',
 			primaryColor: '#14433d',
-			titleColor: '#000000',
-			paragraphColor: '#000000',
+			headingColor: '#000000',
+			bodyColor: '#000000',
 			choice: '10am',
 			number: 0,
 			options: [
@@ -637,18 +637,18 @@ export default {
 				colors: {
 					primary: this.primaryColor,
 					background: this.backgroundColor,
-					title: this.titleColor,
-					paragraph: this.paragraphColor,
+					heading: this.headingColor,
+					body: this.bodyColor,
 					...colors,
 				},
 				fonts: {
 					baseSize: Number.parseInt(this.fontsBaseSize, baseTen),
 					sizeScale: Number.parseFloat(this.fontsTypeScale, baseTen),
-					title: {
+					heading: {
 						fontFamily: this.textPatterns.title.fontFamily,
 						fontWeight: this.textPatterns.title.fontWeight,
 					},
-					paragraph: {
+					body: {
 						fontFamily: this.textPatterns.paragraph.fontFamily,
 						fontWeight: this.textPatterns.paragraph.fontWeight,
 					},

--- a/lab/experiments/ThemeTest.vue
+++ b/lab/experiments/ThemeTest.vue
@@ -524,8 +524,8 @@ function contrastColors(bgHex) {
 
 	return {
 		...colors,
-		'color-elevation': isLight ? '#ffffff' : colors['neutral-20'],
-		'color-overlay': isLight ? 'rgba(0, 0, 0, 0.32)' : 'rgba(255, 255, 255, 0.32)',
+		elevation: isLight ? '#ffffff' : colors['neutral-20'],
+		overlay: isLight ? 'rgba(0, 0, 0, 0.32)' : 'rgba(255, 255, 255, 0.32)',
 	};
 }
 // Above will be supplied by website-springboard

--- a/lab/experiments/Themes/preview.vue
+++ b/lab/experiments/Themes/preview.vue
@@ -626,7 +626,7 @@ export default {
 	color: var(--maker-color-body);
 	font-weight: var(--font-weights-text, normal);
 	font-size: var(--font-base-size);
-	font-family: var(--maker-font-family-body, inherit);
+	font-family: var(--maker-font-body-font-family, inherit);
 	background-color: var(--maker-color-background);
 	border-radius: 30px;
 	box-shadow:

--- a/lab/experiments/Themes/preview.vue
+++ b/lab/experiments/Themes/preview.vue
@@ -623,10 +623,10 @@ export default {
 	max-height: calc(100% - 40px);
 	padding: 20px 10px;
 	overflow: hidden;
-	color: var(--maker-color-paragraph);
+	color: var(--maker-color-body);
 	font-weight: var(--font-weights-text, normal);
 	font-size: var(--font-base-size);
-	font-family: var(--maker-font-family-paragraph, inherit);
+	font-family: var(--maker-font-family-body, inherit);
 	background-color: var(--maker-color-background);
 	border-radius: 30px;
 	box-shadow:

--- a/lab/experiments/Themes/utils/colors.js
+++ b/lab/experiments/Themes/utils/colors.js
@@ -44,7 +44,7 @@ export const generateNeutralColors = (bgHex) => {
 
 	return {
 		...colors,
-		'color-elevation': isLight ? '#ffffff' : colors['neutral-20'],
-		'color-overlay': isLight ? 'rgba(0, 0, 0, 0.32)' : 'rgba(255, 255, 255, 0.32)',
+		elevation: isLight ? '#ffffff' : colors['neutral-20'],
+		overlay: isLight ? 'rgba(0, 0, 0, 0.32)' : 'rgba(255, 255, 255, 0.32)',
 	};
 };

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -232,9 +232,9 @@ export default {
 	height: var(--medium-height);
 	padding: 0 var(--medium-padding);
 	color: var(--text-color);
-	font-weight: var(--maker-font-weight-label, 500);
+	font-weight: var(--maker-font-label-font-weight, 500);
 	font-size: var(--medium-font-size);
-	font-family: var(--maker-font-family-label, inherit);
+	font-family: var(--maker-font-label-font-family, inherit);
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -167,7 +167,7 @@ export default {
 			 */
 			if (this.isSingleChild()) {
 				return fill({
-					color: this.color || this.theme.colors['color-elevation'] || '#000',
+					color: this.color || this.theme.colors.elevation || '#000',
 					textColor: this.textColor || this.resolvedColor,
 				});
 			}

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -282,8 +282,8 @@ export default {
 	align-items: center;
 	min-width: 0;
 	color: var(--color-contrast);
-	font-weight: var(--maker-font-weight-label, 500);
-	font-family: var(--maker-font-family-label, inherit);
+	font-weight: var(--maker-font-label-font-weight, 500);
+	font-family: var(--maker-font-label-font-family, inherit);
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;

--- a/src/components/Calendar/src/Calendar.vue
+++ b/src/components/Calendar/src/Calendar.vue
@@ -342,8 +342,8 @@ export default {
 
 .CalendarHeaderTitle {
 	color: var(--maker-color-primary, #000);
-	font-weight: var(--maker-font-weight-label, 500);
-	font-family: var(--maker-font-family-label, inherit);
+	font-weight: var(--maker-font-label-font-weight, 500);
+	font-family: var(--maker-font-label-font-family, inherit);
 }
 
 .CalendarHeaderButtonIcon {

--- a/src/components/Choice/src/Choice.vue
+++ b/src/components/Choice/src/Choice.vue
@@ -161,9 +161,9 @@ export default {
 
 	display: flex;
 	box-sizing: border-box;
-	font-weight: var(--maker-font-weight-label, 500);
+	font-weight: var(--maker-font-label-font-weight, 500);
 	font-size: var(--font-size);
-	font-family: var(--maker-font-family-label, inherit);
+	font-family: var(--maker-font-label-font-family, inherit);
 	line-height: var(--line-height);
 }
 </style>

--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -146,10 +146,10 @@ export default {
 
 .Label {
 	margin-bottom: 16px;
-	color: var(--color, var(--maker-color-title, inherit));
-	font-weight: var(--maker-font-weight-title, 500);
+	color: var(--color, var(--maker-color-heading, inherit));
+	font-weight: var(--maker-font-weight-heading, 500);
 	font-size: 14px;
-	font-family: var(--maker-font-family-title, inherit);
+	font-family: var(--maker-font-family-heading, inherit);
 	line-height: 20px;
 }
 
@@ -177,10 +177,10 @@ export default {
 }
 
 .Sublabel {
-	color: var(--color, var(--maker-color-paragraph, inherit));
-	font-weight: var(--maker-font-weight-paragraph, inherit);
+	color: var(--color, var(--maker-color-body, inherit));
+	font-weight: var(--maker-font-weight-body, inherit);
 	font-size: 14px;
-	font-family: var(--maker-font-family-paragraph, inherit);
+	font-family: var(--maker-font-family-body, inherit);
 	line-height: 24px;
 	letter-spacing: normal;
 	text-transform: none;

--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -147,9 +147,9 @@ export default {
 .Label {
 	margin-bottom: 16px;
 	color: var(--color, var(--maker-color-heading, inherit));
-	font-weight: var(--maker-font-weight-heading, 500);
+	font-weight: var(--maker-font-heading-font-weight, 500);
 	font-size: 14px;
-	font-family: var(--maker-font-family-heading, inherit);
+	font-family: var(--maker-font-heading-font-family, inherit);
 	line-height: 20px;
 }
 
@@ -178,9 +178,9 @@ export default {
 
 .Sublabel {
 	color: var(--color, var(--maker-color-body, inherit));
-	font-weight: var(--maker-font-weight-body, inherit);
+	font-weight: var(--maker-font-body-font-weight, inherit);
 	font-size: 14px;
-	font-family: var(--maker-font-family-body, inherit);
+	font-family: var(--maker-font-body-font-family, inherit);
 	line-height: 24px;
 	letter-spacing: normal;
 	text-transform: none;

--- a/src/components/Menu/README.md
+++ b/src/components/Menu/README.md
@@ -190,7 +190,7 @@ export default {
 | toggle-select-prefix | Select toggle prefix                                       |
 | toggle-select        | Select toggle text                                         |
 | toggle               | Custom toggle slot (not rendered if toggle-select is used) |
-| menu                 | Menu options                                               |
+| menu                 | —                                                          |
 
 
 ## Menu Events

--- a/src/components/PinInput/src/PinInput.vue
+++ b/src/components/PinInput/src/PinInput.vue
@@ -219,8 +219,8 @@ export default {
 	flex-wrap: nowrap;
 	align-items: center;
 	justify-content: space-between;
-	font-weight: var(--maker-font-weight-label, 500);
-	font-family: var(--maker-font-family-label, inherit);
+	font-weight: var(--maker-font-label-font-weight, 500);
+	font-family: var(--maker-font-label-font-family, inherit);
 
 	&.error {
 		padding-bottom: 8px;

--- a/src/components/SegmentedControl/src/SegmentedControl.vue
+++ b/src/components/SegmentedControl/src/SegmentedControl.vue
@@ -69,9 +69,9 @@ export default {
 	box-sizing: border-box;
 	height: 56px;
 	padding: 4px;
-	font-weight: var(--maker-font-weight-label, 500);
+	font-weight: var(--maker-font-label-font-weight, 500);
 	font-size: 14px;
-	font-family: var(--maker-font-family-label, inherit);
+	font-family: var(--maker-font-label-font-family, inherit);
 	line-height: 24px;
 	background-color: var(--maker-color-neutral-10, #f6f7f9);
 	border-radius: 4px;

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -157,8 +157,8 @@ export default {
 .Quantity {
 	margin: 0 16px;
 	color: var(--maker-color-neutral-90, inherit);
-	font-weight: var(--maker-font-weight-label, 500);
-	font-family: var(--maker-font-family-label, inherit);
+	font-weight: var(--maker-font-label-font-weight, 500);
+	font-family: var(--maker-font-label-font-family, inherit);
 	font-feature-settings: "tnum";
 	font-variant-numeric: tabular-nums;
 }

--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -122,8 +122,8 @@ export default {
 	align-items: center;
 	min-width: 0;
 	color: var(--maker-color-neutral-90);
-	font-weight: var(--maker-font-weight-label, 500);
-	font-family: var(--maker-font-family-label, inherit);
+	font-weight: var(--maker-font-label-font-weight, 500);
+	font-family: var(--maker-font-label-font-family, inherit);
 	vertical-align: middle;
 	background-color: transparent;
 	border: none;

--- a/src/components/Textarea/src/TextareaControl.vue
+++ b/src/components/Textarea/src/TextareaControl.vue
@@ -120,9 +120,9 @@ export default {
 	min-height: calc(12px * 2 + 24px * 3);
 	padding: 12px 16px;
 	color: var(--color-foreground);
-	font-weight: var(--maker-font-weight-body, inherit);
+	font-weight: var(--maker-font-body-font-weight, inherit);
 	font-size: 16px;
-	font-family: var(--maker-font-family-body, inherit);
+	font-family: var(--maker-font-body-font-family, inherit);
 	line-height: 24px;
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--color-border);

--- a/src/components/Textarea/src/TextareaControl.vue
+++ b/src/components/Textarea/src/TextareaControl.vue
@@ -120,9 +120,9 @@ export default {
 	min-height: calc(12px * 2 + 24px * 3);
 	padding: 12px 16px;
 	color: var(--color-foreground);
-	font-weight: var(--maker-font-weight-paragraph, inherit);
+	font-weight: var(--maker-font-weight-body, inherit);
 	font-size: 16px;
-	font-family: var(--maker-font-family-paragraph, inherit);
+	font-family: var(--maker-font-family-body, inherit);
 	line-height: 24px;
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--color-border);

--- a/src/components/Theme/README.md
+++ b/src/components/Theme/README.md
@@ -30,17 +30,17 @@ Any components within the theme component will inherit the tokens provided. We r
 			</label>
 			<label class="color-option">
 				<input
-					v-model="theme.colors.title"
+					v-model="theme.colors.heading"
 					type="color"
 				>
-				Title
+				Heading
 			</label>
 			<label class="color-option">
 				<input
-					v-model="theme.colors.paragraph"
+					v-model="theme.colors.body"
 					type="color"
 				>
-				Paragraph
+				Body
 			</label>
 			<m-text
 				pattern="title"
@@ -84,16 +84,16 @@ Any components within the theme component will inherit the tokens provided. We r
 				pattern="title"
 				:size="0"
 			>
-				Title
+				Heading
 			</m-text>
 			<div class="font-choice">
 				<m-select
-					v-model="theme.fonts.title.fontFamily"
+					v-model="theme.fonts.heading.fontFamily"
 					class="family-choice"
 					:options="fontOptions"
 				/>
 				<m-select
-					v-model="theme.fonts.title.fontWeight"
+					v-model="theme.fonts.heading.fontWeight"
 					:options="defaultWeights"
 				/>
 			</div>
@@ -101,16 +101,16 @@ Any components within the theme component will inherit the tokens provided. We r
 				pattern="title"
 				:size="0"
 			>
-				Paragraph
+				Body
 			</m-text>
 			<div class="font-choice">
 				<m-select
-					v-model="theme.fonts.paragraph.fontFamily"
+					v-model="theme.fonts.body.fontFamily"
 					class="family-choice"
 					:options="fontOptions"
 				/>
 				<m-select
-					v-model="theme.fonts.paragraph.fontWeight"
+					v-model="theme.fonts.body.fontWeight"
 					:options="defaultWeights"
 				/>
 			</div>
@@ -335,8 +335,8 @@ export default {
 			theme: {
 				colors: {
 					background: '#ffffff',
-					paragraph: '#000000',
-					title: '#000000',
+					body: '#000000',
+					heading: '#000000',
 					primary: '#000000',
 					'neutral-0': '#ffffff',
 					'neutral-10': '#f1f1f1',
@@ -348,13 +348,17 @@ export default {
 				fonts: {
 					baseSize: 16,
 					sizeScale: 1.15,
-					title: {
+					heading: {
 						fontFamily: '-apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif',
 						fontWeight: '600',
 					},
-					paragraph: {
+					body: {
 						fontFamily: '-apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif',
 						fontWeight: '400',
+					},
+					label: {
+						fontFamily: '-apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif',
+						fontWeight: '500',
 					},
 				},
 			},
@@ -487,6 +491,7 @@ export default {
 	},
 };
 </script>
+
 <style scoped>
 .demos {
 	text-align: center;
@@ -599,8 +604,8 @@ export default {
 			theme: {
 				colors: {
 					background: '#484543',
-					paragraph: '#ffffff',
-					title: '#e5d7cc',
+					body: '#ffffff',
+					heading: '#e5d7cc',
 					primary: '#e5d7cc',
 				},
 				profiles: [
@@ -608,8 +613,8 @@ export default {
 						id: 'profile1',
 						colors: {
 							background: '#b05d54',
-							paragraph: '#e5d7cc',
-							title: '#e5d7cc',
+							body: '#e5d7cc',
+							heading: '#e5d7cc',
 							primary: '#e5d7cc',
 						},
 					},
@@ -617,8 +622,8 @@ export default {
 						id: 'profile2',
 						colors: {
 							background: '#e5d7cc',
-							paragraph: '#000000',
-							title: '#000000',
+							body: '#000000',
+							heading: '#000000',
 							primary: '#000000',
 						},
 					},

--- a/src/components/Theme/README.md
+++ b/src/components/Theme/README.md
@@ -669,12 +669,12 @@ Variable | Purpose
 
 Variable | Purpose
 -|-
---maker-font-family-heading | heading font family
---maker-font-weight-heading | heading font weight
---maker-font-family-body | body text font family
---maker-font-weight-body | body text font weight
---maker-font-family-label | label font family
---maker-font-weight-label | label font weight
+--maker-font-heading-font-family | heading font family
+--maker-font-heading-font-weight | heading font weight
+--maker-font-body-font-family | body text font family
+--maker-font-body-font-weight | body text font weight
+--maker-font-label-font-family | label font family
+--maker-font-label-font-weight | label font weight
 
 <!-- api-tables:start -->
 ## Props

--- a/src/components/Theme/README.md
+++ b/src/components/Theme/README.md
@@ -644,6 +644,38 @@ export default {
 </style>
 ```
 
+## Reusable CSS Variables
+
+The Theme component makes these reusable CSS variables available to all DOM nodes rendered inside of it.
+
+### Colors
+
+Variable | Purpose
+-|-
+--maker-color-neutral-0 | neutral-0
+--maker-color-neutral-10 | neutral-10
+--maker-color-neutral-20 | neutral-20
+--maker-color-neutral-80 | neutral-80
+--maker-color-neutral-90 | neutral-80
+--maker-color-neutral-100 | neutral-100
+--maker-color-primary | primary color
+--maker-color-background | background color
+--maker-color-heading | heading color
+--maker-color-body | body text color
+--maker-color-elevation | elevation color
+--maker-color-overlay | overlay color
+
+### Typography
+
+Variable | Purpose
+-|-
+--maker-font-family-heading | heading font family
+--maker-font-weight-heading | heading font weight
+--maker-font-family-body | body text font family
+--maker-font-weight-body | body text font weight
+--maker-font-family-label | label font family
+--maker-font-weight-label | label font weight
+
 <!-- api-tables:start -->
 ## Props
 

--- a/src/components/Theme/src/Theme.vue
+++ b/src/components/Theme/src/Theme.vue
@@ -67,14 +67,14 @@ export default {
 				'--maker-color-neutral-100': colors['neutral-100'],
 				'--maker-color-primary': colors.primary,
 				'--maker-color-background': colors.background,
-				'--maker-color-title': colors.title,
-				'--maker-color-paragraph': colors.paragraph,
+				'--maker-color-heading': colors.heading,
+				'--maker-color-body': colors.body,
 				'--maker-color-elevation': colors.elevation,
 				'--maker-color-overlay': colors.overlay,
-				'--maker-font-family-title': fonts.title.fontFamily,
-				'--maker-font-weight-title': fonts.title.fontWeight,
-				'--maker-font-family-paragraph': fonts.paragraph.fontFamily,
-				'--maker-font-weight-paragraph': fonts.paragraph.fontWeight,
+				'--maker-font-family-heading': fonts.heading.fontFamily,
+				'--maker-font-weight-heading': fonts.heading.fontWeight,
+				'--maker-font-family-body': fonts.body.fontFamily,
+				'--maker-font-weight-body': fonts.body.fontWeight,
 				'--maker-font-family-label': fonts.label.fontFamily,
 				'--maker-font-weight-label': fonts.label.fontWeight,
 			};
@@ -89,9 +89,9 @@ export default {
 
 <style module="$s">
 .Theme {
-	color: var(--maker-color-paragraph);
-	font-weight: var(--maker-font-weight-paragraph);
-	font-family: var(--maker-font-family-paragraph);
+	color: var(--maker-color-body);
+	font-weight: var(--maker-font-weight-body);
+	font-family: var(--maker-font-family-body);
 	background-color: var(--maker-color-background);
 }
 </style>

--- a/src/components/Theme/src/Theme.vue
+++ b/src/components/Theme/src/Theme.vue
@@ -71,12 +71,12 @@ export default {
 				'--maker-color-body': colors.body,
 				'--maker-color-elevation': colors.elevation,
 				'--maker-color-overlay': colors.overlay,
-				'--maker-font-family-heading': fonts.heading.fontFamily,
-				'--maker-font-weight-heading': fonts.heading.fontWeight,
-				'--maker-font-family-body': fonts.body.fontFamily,
-				'--maker-font-weight-body': fonts.body.fontWeight,
-				'--maker-font-family-label': fonts.label.fontFamily,
-				'--maker-font-weight-label': fonts.label.fontWeight,
+				'--maker-font-heading-font-family': fonts.heading.fontFamily,
+				'--maker-font-heading-font-weight': fonts.heading.fontWeight,
+				'--maker-font-body-font-family': fonts.body.fontFamily,
+				'--maker-font-body-font-weight': fonts.body.fontWeight,
+				'--maker-font-label-font-family': fonts.label.fontFamily,
+				'--maker-font-label-font-weight': fonts.label.fontWeight,
 			};
 		},
 	},
@@ -90,8 +90,8 @@ export default {
 <style module="$s">
 .Theme {
 	color: var(--maker-color-body);
-	font-weight: var(--maker-font-weight-body);
-	font-family: var(--maker-font-family-body);
+	font-weight: var(--maker-font-body-font-weight);
+	font-family: var(--maker-font-body-font-family);
 	background-color: var(--maker-color-background);
 }
 </style>

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -10,8 +10,8 @@ export default function defaultTheme() {
 			'neutral-90': '#1b1b1b',
 			'neutral-100': '#000000',
 			background: '#ffffff',
-			title: 'inherit',
-			paragraph: 'inherit',
+			heading: 'inherit',
+			body: 'inherit',
 			elevation: '#ffffff',
 			overlay: 'rgba(0, 0, 0, 0.3)',
 			primary: '#000000',
@@ -19,11 +19,11 @@ export default function defaultTheme() {
 		fonts: {
 			baseSize: 16,
 			sizeScale: 1.17,
-			title: {
+			heading: {
 				fontFamily: 'inherit',
 				fontWeight: '500',
 			},
-			paragraph: {
+			body: {
 				fontFamily: 'inherit',
 				fontWeight: '400',
 			},
@@ -70,27 +70,27 @@ export default function defaultTheme() {
 		},
 		text: {
 			size: 0,
-			fontFamily: '@fonts.paragraph.fontFamily',
-			color: '@colors.paragraph',
+			fontFamily: '@fonts.body.fontFamily',
+			color: '@colors.body',
 			element: 'p',
-			fontWeight: '@fonts.paragraph.fontWeight',
+			fontWeight: '@fonts.body.fontWeight',
 			fontStyle: 'inherit',
 			textTransform: 'inherit',
 			textAlign: 'inherit',
 			patterns: {
 				headline: {
 					size: 7,
-					fontFamily: '@fonts.title.fontFamily',
-					fontWeight: '700',
+					fontFamily: '@fonts.heading.fontFamily',
+					fontWeight: '@fonts.heading.fontFamily',
 					element: 'h1',
-					color: '@colors.title',
+					color: '@colors.heading',
 				},
 				title: {
 					size: 3,
-					fontFamily: '@fonts.title.fontFamily',
-					fontWeight: '@fonts.title.fontWeight',
+					fontFamily: '@fonts.heading.fontFamily',
+					fontWeight: '@fonts.heading.fontWeight',
 					element: 'h2',
-					color: '@colors.title',
+					color: '@colors.heading',
 				},
 				paragraph: {}, // component default
 				label: {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
reaching team alignment, using more generic names in our global theme config for typography related stuff

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
renames `title` to `heading` and `paragraph` to `body`, also updates some docs

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
https://square.github.io/maker/styleguide/some-font-color-renames/#/Theme