### PR TITLE
refactor(pininput): uses blockformcontrollayout internally now

### DIFF
--- a/src/components/PinInput/README.md
+++ b/src/components/PinInput/README.md
@@ -305,9 +305,10 @@ export default {
 
 ## Slots
 
-| Slot  | Description      |
-| ----- | ---------------- |
-| error | Input error slot |
+| Slot    | Description             |
+| ------- | ----------------------- |
+| default | —                       |
+| error   | slot for error messages |
 
 
 ## Events

--- a/src/components/PinInput/index.js
+++ b/src/components/PinInput/index.js
@@ -1,1 +1,1 @@
-export { default as MPinInput } from './src/PinInput.vue';
+export { default as MPinInput } from './src/PinInputFormItem.vue';

--- a/src/components/PinInput/src/PinInputControl.vue
+++ b/src/components/PinInput/src/PinInputControl.vue
@@ -1,38 +1,34 @@
 <template>
-	<div>
-		<div
+	<div
+		:class="{
+			[$s.PinInputContainer]: true,
+			[$s.shake]: isShaking,
+			[$s.disabled]: disabled,
+			[$s.error]: Boolean($slots.error),
+		}"
+	>
+		<input
+			v-for="(val, i) in pin"
+			:key="i"
+			:ref="getPinCellRef(i)"
+			:value="val"
+			:autocomplete="i === 0 ? 'one-time-code' : 'off'"
+			:disabled="disabled"
+			:maxlength="i === 0 ? pinLength : 1"
 			:class="{
-				[$s.PinInputContainer]: true,
-				[$s.shake]: isShaking,
-				[$s.disabled]: disabled,
-				[$s.error]: Boolean($slots.error),
+				[$s.PinInputCell]: true,
+				[$s.filled]: variant === 'fill',
+				[$s.error]: invalid,
 			}"
+			type="text"
+			inputmode="numeric"
+			pattern="[0-9]*"
+			required
+			@input="onInputPin($event, i)"
+			@paste="onPastePin($event, i)"
+			@focus="onFocusPin($event, i)"
+			@keydown.delete="onDelete($event, i)"
 		>
-			<input
-				v-for="(val, i) in pin"
-				:key="i"
-				:ref="getPinCellRef(i)"
-				:value="val"
-				:autocomplete="i === 0 ? 'one-time-code' : 'off'"
-				:disabled="disabled"
-				:maxlength="i === 0 ? pinLength : 1"
-				:class="{
-					[$s.PinInputCell]: true,
-					[$s.filled]: variant === 'fill',
-					[$s.error]: invalid,
-				}"
-				type="text"
-				inputmode="numeric"
-				pattern="[0-9]*"
-				required
-				@input="onInputPin($event, i)"
-				@paste="onPastePin($event, i)"
-				@focus="onFocusPin($event, i)"
-				@keydown.delete="onDelete($event, i)"
-			>
-		</div>
-		<!-- @slot Input error slot -->
-		<slot name="error" />
 	</div>
 </template>
 

--- a/src/components/PinInput/src/PinInputFormItem.vue
+++ b/src/components/PinInput/src/PinInputFormItem.vue
@@ -1,0 +1,55 @@
+<template>
+	<m-block-form-control-layout>
+		<template #control>
+			<pin-input-control
+				ref="pinInputControl"
+				:invalid="isInvalid"
+				v-bind="$attrs"
+				v-on="$listeners"
+			>
+				<template
+					v-for="(_, slot) of $slots"
+					#[slot]
+				>
+					<slot
+						:name="slot"
+					/>
+				</template>
+			</pin-input-control>
+		</template>
+		<template #error>
+			<!-- @slot slot for error messages -->
+			<slot name="error" />
+		</template>
+	</m-block-form-control-layout>
+</template>
+
+<script>
+import { MBlockFormControlLayout } from '@square/maker/utils/BlockFormControlLayout';
+import PinInputControl from './PinInputControl.vue';
+
+/**
+ * @inheritAttrs ./PinInputControl.vue
+ * @inheritListeners ./PinInputControl.vue
+ */
+export default {
+	components: {
+		MBlockFormControlLayout,
+		PinInputControl,
+	},
+
+	inheritAttrs: false,
+
+	computed: {
+		isInvalid() {
+			return this.$attrs.invalid === '' || this.$attrs.invalid || !!this.$slots.error;
+		},
+	},
+
+	methods: {
+		shakeAndClearInputs() {
+			this.$refs.pinInputControl.shakeAndClearInputs();
+		},
+	},
+};
+</script>


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
makes pininput code more standard compared to the other block form items in maker

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
refactors pininput to use blockformcontrollayout internally

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
nope