### PR TITLE
Theme shape

### DIFF
--- a/lab/experiments/ThemeTest.vue
+++ b/lab/experiments/ThemeTest.vue
@@ -70,24 +70,68 @@
 								<span :style="{ backgroundColor : 'var(--neutral-100)' }" /> Neutral 100
 							</div>
 						</div>
+						<br>
 						<m-divider />
+						<br>
 						<m-heading
 							:size="0"
 						>
-							Shape
+							Default Shape
 						</m-heading>
 						<select
 							v-model="shape"
 						>
-							<template v-for="(value, index) in shapes">
+							<option
+								v-for="(value, index) in shapes"
+								:key="index"
+								:value="value"
+							>
+								{{ value }}
+							</option>
+						</select>
+						<template
+							v-if="shape === 'custom'"
+						>
+							<br>
+							default radius:
+							<select
+								v-model="customShape.defaultBorderRadius"
+							>
 								<option
+									v-for="(value, index) in borderRadiusOptions"
 									:key="index"
 									:value="value"
 								>
 									{{ value }}
 								</option>
-							</template>
-						</select>
+							</select>
+							<br>
+							button radius:
+							<select
+								v-model="customShape.buttonBorderRadius"
+							>
+								<option
+									v-for="(value, index) in borderRadiusOptions"
+									:key="index"
+									:value="value"
+								>
+									{{ value }}
+								</option>
+							</select>
+							<br>
+							image radius:
+							<select
+								v-model="customShape.imageBorderRadius"
+							>
+								<option
+									v-for="(value, index) in borderRadiusOptions"
+									:key="index"
+									:value="value"
+								>
+									{{ value }}
+								</option>
+							</select>
+						</template>
 					</div>
 				</div>
 				<div
@@ -131,17 +175,19 @@
 								</m-choice-option>
 							</m-choice>
 						</div>
-						<m-heading
-							:size="-1"
-						>
-							Enter delivery address
-						</m-heading>
-						<m-text :size="-1">
-							<check-circle :class="$s.Icon" /> Pickup until 10:00 pm
-						</m-text>
-						<m-text :size="-1">
-							<check-circle :class="$s.Icon" /> Estimated prep time: 15 minutes
-						</m-text>
+						<m-card>
+							<m-heading
+								:size="-1"
+							>
+								Enter delivery address
+							</m-heading>
+							<m-text :size="-1">
+								<check-circle :class="$s.Icon" /> Pickup until 10:00 pm
+							</m-text>
+							<m-text :size="-1">
+								<check-circle :class="$s.Icon" /> Estimated prep time: 15 minutes
+							</m-text>
+						</m-card>
 						<m-notice
 							type="info"
 							variant="block"
@@ -282,17 +328,15 @@
 					:class="$s.Preview"
 				>
 					<div>
-						<m-heading
-							:size="0"
-						>
-							Schedule order
-						</m-heading>
-						<m-text :size="-1">
-							<check-circle :class="$s.Icon" /> No minimum
-						</m-text>
-						<m-text :size="-1">
-							<check-circle :class="$s.Icon" /> No fees
-						</m-text>
+						<m-text-button>
+							<info :class="$s.Icon" />  Learn more
+						</m-text-button>
+						<m-image
+							src="https://source.unsplash.com/900x600/?vacation"
+						/>
+						<m-image-uploader
+							@image-uploader:change="setImages"
+						/>
 					</div>
 					<m-divider />
 					<div>
@@ -310,15 +354,6 @@
 							:min-date="minDate"
 							:max-date="maxDate"
 							:disabled-dates="disabledDates"
-						/>
-					</div>
-					<m-divider />
-					<div>
-						<m-text-button>
-							<info :class="$s.Icon" />  Learn more
-						</m-text-button>
-						<m-image-uploader
-							@image-uploader:change="setImages"
 						/>
 					</div>
 				</div>
@@ -348,6 +383,8 @@ import { MTextButton } from '@square/maker/components/TextButton';
 import { MCalendar } from '@square/maker/components/Calendar';
 import { MImageUploader } from '@square/maker/components/ImageUploader';
 import { MSegmentedControl, MSegment } from '@square/maker/components/SegmentedControl';
+import { MCard } from '@square/maker/components/Card';
+import { MImage } from '@square/maker/components/Image';
 import { MModalLayer } from '@square/maker/components/Modal';
 
 import CheckCircle from '@square/maker-icons/CheckCircle';
@@ -439,6 +476,8 @@ export default {
 		MImageUploader,
 		MSegmentedControl,
 		MSegment,
+		MCard,
+		MImage,
 		MTextButton,
 		MModalLayer,
 	},
@@ -497,6 +536,22 @@ export default {
 				'squared',
 				'rounded',
 				'pill',
+				'custom',
+			],
+			customShape: {
+				defaultBorderRadius: '0px',
+				buttonBorderRadius: '0px',
+				imageBorderRadius: '0px',
+			},
+			borderRadiusOptions: [
+				'0px',
+				'4px',
+				'8px',
+				'12px',
+				'16px',
+				'20px',
+				'24px',
+				'32px',
 			],
 		};
 	},
@@ -519,7 +574,8 @@ export default {
 					bgColor: this.backgroundColor,
 				},
 				shapes: {
-					default: this.shape,
+					...(this.shape === 'custom' ? { squared: this.customShape } : {}),
+					global: this.shape === 'custom' ? 'squared' : this.shape,
 				},
 			};
 		},

--- a/lab/experiments/ThemeTest.vue
+++ b/lab/experiments/ThemeTest.vue
@@ -70,6 +70,24 @@
 								<span :style="{ backgroundColor : 'var(--neutral-100)' }" /> Neutral 100
 							</div>
 						</div>
+						<m-divider />
+						<m-heading
+							:size="0"
+						>
+							Shape
+						</m-heading>
+						<select
+							v-model="shape"
+						>
+							<template v-for="(value, index) in shapes">
+								<option
+									:key="index"
+									:value="value"
+								>
+									{{ value }}
+								</option>
+							</template>
+						</select>
 					</div>
 				</div>
 				<div
@@ -474,6 +492,12 @@ export default {
 			selected: 'medium',
 			images: [],
 			item: storeData.items[0],
+			shape: 'rounded',
+			shapes: [
+				'squared',
+				'rounded',
+				'pill',
+			],
 		};
 	},
 
@@ -494,8 +518,8 @@ export default {
 				modal: {
 					bgColor: this.backgroundColor,
 				},
-				actionbarbutton: {
-					shape: 'rounded',
+				shapes: {
+					default: this.shape,
 				},
 			};
 		},

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -171,10 +171,14 @@ export default {
 					textColor: this.textColor || this.resolvedColor,
 				});
 			}
-			return fill({
-				color: this.resolvedColor,
-				textColor: this.resolvedTextColor,
-			});
+			return {
+				...fill({
+					color: this.resolvedColor,
+					textColor: this.resolvedTextColor,
+				}),
+				'--border-radius-small': this.theme.shapes.radii.small,
+				'--border-radius-large': this.theme.shapes.radii.large,
+			};
 		},
 
 		isDisabled() {
@@ -238,7 +242,6 @@ export default {
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;
-	border-radius: 32px;
 	outline: none;
 	box-shadow:
 		var(--outline-border, 0 0),
@@ -295,11 +298,11 @@ export default {
 	}
 
 	&.shape_rounded {
-		border-radius: 8px;
+		border-radius: var(--border-radius-small, 8px);
 	}
 
 	&.shape_pill {
-		border-radius: 32px;
+		border-radius: var(--border-radius-large, 32px);
 	}
 
 	&:disabled {

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -3,7 +3,6 @@
 		:class="[
 			$s.Button,
 			$s[`align_${resolvedAlign}`],
-			$s[`shape_${resolvedShape}`],
 			{
 				[$s.fullWidth]: resolvedFullWidth,
 				[$s.iconButton]: isSingleChild() && !resolvedFullWidth,
@@ -160,24 +159,25 @@ export default {
 	computed: {
 		...resolveThemeableProps('actionbarbutton', ['color', 'shape', 'textColor', 'align', 'fullWidth']),
 		style() {
+			let colors = fill({
+				color: this.resolvedColor,
+				textColor: this.resolvedTextColor,
+			});
+
 			/**
 			 * Return different default theme colors for icon buttons
 			 * This can be removed if the action bar icon button ever
 			 * becomes its own component or if we add theming for variants
 			 */
 			if (this.isSingleChild()) {
-				return fill({
+				colors = fill({
 					color: this.color || this.theme.colors['color-elevation'] || '#000',
 					textColor: this.textColor || this.resolvedColor,
 				});
 			}
 			return {
-				...fill({
-					color: this.resolvedColor,
-					textColor: this.resolvedTextColor,
-				}),
-				'--border-radius-small': this.theme.shapes.radii.small,
-				'--border-radius-large': this.theme.shapes.radii.large,
+				...colors,
+				'--border-radius': this.theme.shapes[this.resolvedShape]?.buttonBorderRadius,
 			};
 		},
 
@@ -242,6 +242,7 @@ export default {
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;
+	border-radius: var(--border-radius, --maker-shape-default-border-radius, 8px);
 	outline: none;
 	box-shadow:
 		var(--outline-border, 0 0),
@@ -293,18 +294,6 @@ export default {
 		justify-content: space-between;
 	}
 
-	&.shape_squared {
-		border-radius: 0;
-	}
-
-	&.shape_rounded {
-		border-radius: var(--border-radius-small, 8px);
-	}
-
-	&.shape_pill {
-		border-radius: var(--border-radius-large, 32px);
-	}
-
 	&:disabled {
 		cursor: initial;
 
@@ -345,7 +334,7 @@ export default {
 	justify-content: center;
 	color: var(--text-color);
 	background-color: inherit;
-	border-radius: 32px;
+	border-radius: 50%;
 }
 
 .MainText {

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -3,7 +3,6 @@
 		:class="[
 			$s.Button,
 			$s[`size_${resolvedSize}`],
-			$s[`shape_${resolvedShape}`],
 			$s[`align_${resolvedAlign}`],
 			{
 				[$s.fullWidth]: resolvedFullWidth,
@@ -235,8 +234,7 @@ export default {
 					color: this.resolvedColor,
 					textColor: this.resolvedTextColor,
 				}),
-				'--border-radius-small': this.theme.shapes.radii.small,
-				'--border-radius-large': this.theme.shapes.radii.large,
+				'--border-radius': this.theme.shapes[this.resolvedShape]?.buttonBorderRadius,
 			};
 		},
 		isDisabled() {
@@ -273,6 +271,7 @@ export default {
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;
+	border-radius: var(--maker-shape-button-border-radius);
 	outline: none;
 	box-shadow:
 		var(--outline-border, 0 0),
@@ -285,18 +284,6 @@ export default {
 	user-select: none;
 	touch-action: manipulation;
 	fill: currentColor;
-
-	&.shape_squared {
-		border-radius: 0;
-	}
-
-	&.shape_rounded {
-		border-radius: var(--border-radius-small, 8px);
-	}
-
-	&.shape_pill {
-		border-radius: var(--border-radius-large, 32px);
-	}
 
 	&.iconButton {
 		min-width: max-content;

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -230,10 +230,14 @@ export default {
 	computed: {
 		...resolveThemeableProps('button', ['color', 'size', 'textColor', 'variant', 'shape', 'align', 'fullWidth']),
 		style() {
-			return VARIANTS[this.resolvedVariant]({
-				color: this.resolvedColor,
-				textColor: this.resolvedTextColor,
-			});
+			return {
+				...VARIANTS[this.resolvedVariant]({
+					color: this.resolvedColor,
+					textColor: this.resolvedTextColor,
+				}),
+				'--border-radius-small': this.theme.shapes.radii.small,
+				'--border-radius-large': this.theme.shapes.radii.large,
+			};
 		},
 		isDisabled() {
 			return this.disabled || this.loading;
@@ -269,7 +273,6 @@ export default {
 	vertical-align: middle;
 	background-color: var(--color-main);
 	border: none;
-	border-radius: 8px;
 	outline: none;
 	box-shadow:
 		var(--outline-border, 0 0),
@@ -283,12 +286,16 @@ export default {
 	touch-action: manipulation;
 	fill: currentColor;
 
-	&.shape_pill {
-		border-radius: 32px;
-	}
-
 	&.shape_squared {
 		border-radius: 0;
+	}
+
+	&.shape_rounded {
+		border-radius: var(--border-radius-small, 8px);
+	}
+
+	&.shape_pill {
+		border-radius: var(--border-radius-large, 32px);
 	}
 
 	&.iconButton {

--- a/src/components/Calendar/src/Calendar.vue
+++ b/src/components/Calendar/src/Calendar.vue
@@ -330,7 +330,7 @@ export default {
 	font-family: inherit;
 	line-height: var(--line-height);
 	background-color: var(--color-background, #fff);
-	border-radius: 4px;
+	border-radius: var(--maker-shape-default-border-radius, 4px);
 }
 
 .CalendarHeader {
@@ -383,7 +383,7 @@ export default {
 	font-size: inherit;
 	background-color: inherit;
 	border: none;
-	border-radius: 8px;
+	border-radius: var(--maker-shape-button-border-radius, 8px);
 	outline: none;
 	cursor: pointer;
 	transition: background-color 0.2s ease-in;

--- a/src/components/Card/src/Card.vue
+++ b/src/components/Card/src/Card.vue
@@ -36,7 +36,7 @@ export default {
 		shape: {
 			type: String,
 			default: undefined,
-			validator: (shape) => ['squared', 'rounded'].includes(shape),
+			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
 		},
 	},
 

--- a/src/components/Card/src/Card.vue
+++ b/src/components/Card/src/Card.vue
@@ -2,7 +2,9 @@
 	<div
 		:class="[
 			$s.Card,
+			$s[`shape_${resolvedShape}`],
 		]"
+		:style="style"
 		v-bind="$attrs"
 		v-on="$listeners"
 	>
@@ -12,13 +14,41 @@
 </template>
 
 <script>
+import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
 
 /**
  * @inheritAttrs div
  * @inheritListeners div
  */
 export default {
+	inject: {
+		theme: {
+			default: defaultTheme(),
+			from: MThemeKey,
+		},
+	},
+
 	inheritAttrs: false,
+
+	props: {
+		/**
+		 * card shape
+		 */
+		shape: {
+			type: String,
+			default: undefined,
+			validator: (shape) => ['squared', 'rounded'].includes(shape),
+		},
+	},
+
+	computed: {
+		...resolveThemeableProps('card', ['shape']),
+		style() {
+			return {
+				'--border-radius-small': this.theme.shapes.radii.small,
+			};
+		},
+	},
 };
 </script>
 
@@ -27,6 +57,14 @@ export default {
 	padding: 16px 24px;
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--neutral-20, #eaeaea);
-	border-radius: 8px;
+
+	&.shape_rounded,
+	&.shape_pill {
+		border-radius: var(--border-radius-small, 8px);
+	}
+
+	&.shape_squared {
+		border-radius: 0;
+	}
 }
 </style>

--- a/src/components/Card/src/Card.vue
+++ b/src/components/Card/src/Card.vue
@@ -2,7 +2,6 @@
 	<div
 		:class="[
 			$s.Card,
-			$s[`shape_${resolvedShape}`],
 		]"
 		:style="style"
 		v-bind="$attrs"
@@ -43,9 +42,10 @@ export default {
 
 	computed: {
 		...resolveThemeableProps('card', ['shape']),
+
 		style() {
 			return {
-				'--border-radius-small': this.theme.shapes.radii.small,
+				'--border-radius': this.theme.shapes[this.resolvedShape]?.defaultBorderRadius,
 			};
 		},
 	},
@@ -57,14 +57,6 @@ export default {
 	padding: 16px 24px;
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--neutral-20, #eaeaea);
-
-	&.shape_rounded,
-	&.shape_pill {
-		border-radius: var(--border-radius-small, 8px);
-	}
-
-	&.shape_squared {
-		border-radius: 0;
-	}
+	border-radius: var(--border-radius, --maker-shape-default-border-radius);
 }
 </style>

--- a/src/components/Choice/src/ChoiceOption.vue
+++ b/src/components/Choice/src/ChoiceOption.vue
@@ -57,7 +57,6 @@ export default {
 	--selected-disabled-text-color
 */
 .Button {
-	--border-radius: 8px;
 	--button-padding: 12px 24px;
 
 	flex-shrink: 0;
@@ -70,7 +69,7 @@ export default {
 	text-align: left;
 	background-color: var(--neutral-10, #f2f2f2);
 	border: none;
-	border-radius: var(--border-radius);
+	border-radius: var(--maker-border-radius, 8px);
 	outline: none;
 	box-shadow: var(--focus-border, 0 0);
 	cursor: pointer;

--- a/src/components/Choice/src/ChoiceOption.vue
+++ b/src/components/Choice/src/ChoiceOption.vue
@@ -69,7 +69,7 @@ export default {
 	text-align: left;
 	background-color: var(--neutral-10, #f2f2f2);
 	border: none;
-	border-radius: var(--maker-border-radius, 8px);
+	border-radius: var(--maker-shape-default-border-radius, 8px);
 	outline: none;
 	box-shadow: var(--focus-border, 0 0);
 	cursor: pointer;

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -1,5 +1,8 @@
 <template>
-	<div :class="$s.ImageWrapper">
+	<div
+		:class="$s.ImageWrapper"
+		:style="style"
+	>
 		<template v-if="isIntersecting">
 			<m-transition-fade-in>
 				<m-skeleton-block
@@ -7,7 +10,10 @@
 				/>
 				<img
 					v-else
-					:class="$s.Image"
+					:class="[
+						$s.Image,
+						$s[`shape_${resolvedShape}`],
+					]"
 					:src="src"
 					:srcset="srcset"
 					v-bind="$attrs"
@@ -21,6 +27,7 @@
 <script>
 import { MTransitionFadeIn } from '@square/maker/components/TransitionFadeIn';
 import { MSkeletonBlock } from '@square/maker/components/Skeleton';
+import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
 
 function SharedIntersectionObserver() {
 	const callbacks = new WeakMap();
@@ -54,6 +61,13 @@ export default {
 		MSkeletonBlock,
 	},
 
+	inject: {
+		theme: {
+			default: defaultTheme(),
+			from: MThemeKey,
+		},
+	},
+
 	inheritAttrs: false,
 
 	props: {
@@ -65,6 +79,11 @@ export default {
 			type: String,
 			default: undefined,
 		},
+		shape: {
+			type: String,
+			default: undefined,
+			validator: (shape) => ['squared', 'rounded'].includes(shape),
+		},
 	},
 
 	data() {
@@ -72,6 +91,15 @@ export default {
 			isIntersecting: true,
 			loaded: imgCache.has(this.src + this.srcset),
 		};
+	},
+
+	computed: {
+		...resolveThemeableProps('image', ['shape']),
+		style() {
+			return {
+				'--border-radius-medium': this.theme.shapes.radii.medium,
+			};
+		},
 	},
 
 	watch: {
@@ -135,5 +163,13 @@ export default {
 	height: 100%;
 	object-fit: cover;
 	object-position: center;
+
+	&.shape_rounded {
+		border-radius: var(--border-radius-medium, 16px);
+	}
+
+	&.shape_squared {
+		border-radius: 0;
+	}
 }
 </style>

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -1,7 +1,6 @@
 <template>
 	<div
 		:class="$s.ImageWrapper"
-		:style="style"
 	>
 		<template v-if="isIntersecting">
 			<m-transition-fade-in>
@@ -12,8 +11,8 @@
 					v-else
 					:class="[
 						$s.Image,
-						$s[`shape_${resolvedShape}`],
 					]"
+					:style="style"
 					:src="src"
 					:srcset="srcset"
 					v-bind="$attrs"
@@ -97,7 +96,7 @@ export default {
 		...resolveThemeableProps('image', ['shape']),
 		style() {
 			return {
-				'--border-radius-medium': this.theme.shapes.radii.medium,
+				'--border-radius': this.theme.shapes[this.resolvedShape]?.imageBorderRadius,
 			};
 		},
 	},
@@ -163,13 +162,6 @@ export default {
 	height: 100%;
 	object-fit: cover;
 	object-position: center;
-
-	&.shape_rounded {
-		border-radius: var(--border-radius-medium, 16px);
-	}
-
-	&.shape_squared {
-		border-radius: 0;
-	}
+	border-radius: var(--border-radius, 0);
 }
 </style>

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -81,7 +81,7 @@ export default {
 		shape: {
 			type: String,
 			default: undefined,
-			validator: (shape) => ['squared', 'rounded'].includes(shape),
+			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
 		},
 	},
 

--- a/src/components/ImageUploader/src/ImagePicker.vue
+++ b/src/components/ImageUploader/src/ImagePicker.vue
@@ -189,7 +189,7 @@ export default {
 	height: 96px;
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--neutral-20, rgba(0, 0, 0, 0.15));
-	border-radius: var(--maker-border-radius, 8px);
+	border-radius: var(--maker-shape-default-border-radius, 8px);
 	cursor: pointer;
 	transition: background-color 150ms linear;
 }

--- a/src/components/ImageUploader/src/ImagePicker.vue
+++ b/src/components/ImageUploader/src/ImagePicker.vue
@@ -189,7 +189,7 @@ export default {
 	height: 96px;
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--neutral-20, rgba(0, 0, 0, 0.15));
-	border-radius: 8px;
+	border-radius: var(--maker-border-radius, 8px);
 	cursor: pointer;
 	transition: background-color 150ms linear;
 }

--- a/src/components/ImageUploader/src/ImageSelection.vue
+++ b/src/components/ImageUploader/src/ImageSelection.vue
@@ -119,7 +119,7 @@ export default {
 	background-position: center;
 	background-size: cover;
 	border: 1px solid var(--neutral-20, rgba(0, 0, 0, 0.15));
-	border-radius: 8px;
+	border-radius: var(--maker-border-radius, 8px);
 	transition: background-image linear 150ms;
 
 	--color-error: rgba(206, 50, 23, 1);

--- a/src/components/ImageUploader/src/ImageSelection.vue
+++ b/src/components/ImageUploader/src/ImageSelection.vue
@@ -119,7 +119,7 @@ export default {
 	background-position: center;
 	background-size: cover;
 	border: 1px solid var(--neutral-20, rgba(0, 0, 0, 0.15));
-	border-radius: var(--maker-border-radius, 8px);
+	border-radius: var(--maker-shape-default-border-radius, 8px);
 	transition: background-image linear 150ms;
 
 	--color-error: rgba(206, 50, 23, 1);

--- a/src/components/Input/src/InputControl.vue
+++ b/src/components/Input/src/InputControl.vue
@@ -154,7 +154,6 @@ export default {
 	--color-foreground: var(--neutral-90, rgba(107, 107, 107, 0.9));
 	--color-border-active: var(--neutral-80, #222);
 	--color-error: rgba(206, 50, 23, 1);
-	--border-radius: 8px;
 
 	display: flex;
 	align-items: center;
@@ -168,7 +167,7 @@ export default {
 	font-family: var(--font-family);
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--color-border);
-	border-radius: var(--border-radius);
+	border-radius: var(--maker-border-radius, 8px);
 	transition: border-color 0.2s ease;
 
 	&:not(.disabled, .invalid):hover,

--- a/src/components/Input/src/InputControl.vue
+++ b/src/components/Input/src/InputControl.vue
@@ -167,7 +167,7 @@ export default {
 	font-family: var(--font-family);
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--color-border);
-	border-radius: var(--maker-border-radius, 8px);
+	border-radius: var(--maker-shape-default-border-radius, 8px);
 	transition: border-color 0.2s ease;
 
 	&:not(.disabled, .invalid):hover,

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -126,7 +126,7 @@ export default {
 	font-size: 14px;
 	font-family: inherit;
 	line-height: 24px;
-	border-radius: 8px;
+	border-radius: var(--maker-border-radius, 8px);
 }
 
 .IconContentWrapper {

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -126,7 +126,7 @@ export default {
 	font-size: 14px;
 	font-family: inherit;
 	line-height: 24px;
-	border-radius: var(--maker-border-radius, 8px);
+	border-radius: var(--maker-shape-default-border-radius, 8px);
 }
 
 .IconContentWrapper {

--- a/src/components/PinInput/src/PinInput.vue
+++ b/src/components/PinInput/src/PinInput.vue
@@ -238,7 +238,7 @@ export default {
 	text-align: center;
 	background: #fff;
 	border: 1px solid #d3d3d3;
-	border-radius: 8px;
+	border-radius: var(--maker-border-radius, 8px);
 	outline: none;
 	caret-color: black;
 	cursor: pointer;

--- a/src/components/PinInput/src/PinInput.vue
+++ b/src/components/PinInput/src/PinInput.vue
@@ -238,7 +238,7 @@ export default {
 	text-align: center;
 	background: #fff;
 	border: 1px solid #d3d3d3;
-	border-radius: var(--maker-border-radius, 8px);
+	border-radius: var(--maker-shape-default-border-radius, 8px);
 	outline: none;
 	caret-color: black;
 	cursor: pointer;

--- a/src/components/Popover/src/PopoverContent.vue
+++ b/src/components/Popover/src/PopoverContent.vue
@@ -81,7 +81,7 @@ export default {
 	color: var(--popover-color, var(--color-text, black));
 	background-color: var(--popover-bg-color, var(--color-background, white));
 	border: 1px solid var(--neutral-10);
-	border-radius: 8px;
+	border-radius: var(--maker-border-radius, 8px);
 	box-shadow: 0 0 18px 6px rgba(0, 0, 0, 0.2);
 }
 </style>

--- a/src/components/Popover/src/PopoverContent.vue
+++ b/src/components/Popover/src/PopoverContent.vue
@@ -81,7 +81,7 @@ export default {
 	color: var(--popover-color, var(--color-text, black));
 	background-color: var(--popover-bg-color, var(--color-background, white));
 	border: 1px solid var(--neutral-10);
-	border-radius: var(--maker-border-radius, 8px);
+	border-radius: var(--maker-shape-default-border-radius, 8px);
 	box-shadow: 0 0 18px 6px rgba(0, 0, 0, 0.2);
 }
 </style>

--- a/src/components/ProgressBar/src/ProgressBar.vue
+++ b/src/components/ProgressBar/src/ProgressBar.vue
@@ -3,7 +3,6 @@
 		:class="[
 			$s.ProgressBarContainer,
 			$s[`size_${size}`],
-			$s[`shape_${shape}`],
 		]"
 	>
 		<div
@@ -65,14 +64,14 @@ export default {
 	width: 100%;
 	overflow: hidden;
 	background-color: #f5f4f4;
-	border-radius: var(--maker-border-radius, 0);
+	border-radius: var(--maker-default-border-radius, 0);
 }
 
 .ProgressBar {
 	width: var(--fill-percent, 0);
 	height: 100%;
 	background-color: var(--bar-color);
-	border-radius: var(--maker-border-radius, 0);
+	border-radius: var(--maker-default-border-radius, 0);
 	transition: width 100ms linear;
 }
 

--- a/src/components/ProgressBar/src/ProgressBar.vue
+++ b/src/components/ProgressBar/src/ProgressBar.vue
@@ -32,14 +32,6 @@ export default {
 			validator: (size) => ['xsmall', 'small', 'medium', 'large'].includes(size),
 		},
 		/**
-		 * Shape of the progress bar
-		 */
-		shape: {
-			type: String,
-			default: 'rounded',
-			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
-		},
-		/**
 		 * Color of the progress bar (not background)
 		 */
 		color: {
@@ -73,12 +65,14 @@ export default {
 	width: 100%;
 	overflow: hidden;
 	background-color: #f5f4f4;
+	border-radius: var(--maker-border-radius, 0);
 }
 
 .ProgressBar {
 	width: var(--fill-percent, 0);
 	height: 100%;
 	background-color: var(--bar-color);
+	border-radius: var(--maker-border-radius, 0);
 	transition: width 100ms linear;
 }
 
@@ -96,17 +90,5 @@ export default {
 
 .ProgressBarContainer.size_large {
 	height: 16px;
-}
-
-.ProgressBarContainer.shape_squared,
-.ProgressBarContainer.shape_squared .ProgressBar {
-	border-radius: 0;
-}
-
-.ProgressBarContainer.shape_rounded,
-.ProgressBarContainer.shape_rounded .ProgressBar,
-.ProgressBarContainer.shape_pill,
-.ProgressBarContainer.shape_pill .ProgressBar {
-	border-radius: 16px;
 }
 </style>

--- a/src/components/SegmentedControl/src/Segment.vue
+++ b/src/components/SegmentedControl/src/Segment.vue
@@ -2,6 +2,7 @@
 	<button
 		:class="[
 			$s.Button,
+			$s[`shape_${controlState.shapeInner}`],
 			$s[`size_${controlState.sizeInner}`],
 			{ [$s.selected]: isSelected },
 		]"
@@ -50,6 +51,18 @@ export default {
 	border-radius: var(--maker-shape-button-border-radius, 8px);
 	outline: none;
 	cursor: pointer;
+}
+
+.shape_pill {
+	border-radius: 32px;
+}
+
+.shape_rounded {
+	border-radius: 4px;
+}
+
+.shape_squared {
+	border-radius: 0;
 }
 
 .selected {

--- a/src/components/SegmentedControl/src/Segment.vue
+++ b/src/components/SegmentedControl/src/Segment.vue
@@ -2,7 +2,6 @@
 	<button
 		:class="[
 			$s.Button,
-			$s[`shape_${controlState.shapeInner}`],
 			$s[`size_${controlState.sizeInner}`],
 			{ [$s.selected]: isSelected },
 		]"
@@ -48,17 +47,9 @@ export default {
 	line-height: inherit;
 	background-color: transparent;
 	border: none;
-	border-radius: 4px;
+	border-radius: var(--maker-border-radius-button, 8px);
 	outline: none;
 	cursor: pointer;
-}
-
-.shape_pill {
-	border-radius: 32px;
-}
-
-.shape_squared {
-	border-radius: 0;
 }
 
 .selected {

--- a/src/components/SegmentedControl/src/Segment.vue
+++ b/src/components/SegmentedControl/src/Segment.vue
@@ -47,7 +47,7 @@ export default {
 	line-height: inherit;
 	background-color: transparent;
 	border: none;
-	border-radius: var(--maker-border-radius-button, 8px);
+	border-radius: var(--maker-shape-button-border-radius, 8px);
 	outline: none;
 	cursor: pointer;
 }

--- a/src/components/SegmentedControl/src/SegmentedControl.vue
+++ b/src/components/SegmentedControl/src/SegmentedControl.vue
@@ -2,7 +2,6 @@
 	<div
 		:class="[
 			$s.Container,
-			$s[`shape_${shapeInner}`],
 			$s[`size_${sizeInner}`],
 		]"
 	>
@@ -32,14 +31,6 @@ export default {
 			required: true,
 		},
 		/**
-		 * Shape of Control & Segments
-		 */
-		shape: {
-			type: String,
-			default: 'rounded',
-			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
-		},
-		/**
 		 * Size of Control & Segments
 		 */
 		size: {
@@ -51,7 +42,6 @@ export default {
 	data() {
 		return {
 			currentValue: this.selected,
-			shapeInner: this.shape,
 			sizeInner: this.size,
 		};
 	},
@@ -72,15 +62,7 @@ export default {
 	font-size: 14px;
 	line-height: 24px;
 	background-color: var(--neutral-10, #f6f7f9);
-	border-radius: 4px;
-}
-
-.shape_pill {
-	border-radius: 32px;
-}
-
-.shape_squared {
-	border-radius: 0;
+	border-radius: var(--maker-border-radius-button, 8px);
 }
 
 .size_small {

--- a/src/components/SegmentedControl/src/SegmentedControl.vue
+++ b/src/components/SegmentedControl/src/SegmentedControl.vue
@@ -62,7 +62,7 @@ export default {
 	font-size: 14px;
 	line-height: 24px;
 	background-color: var(--neutral-10, #f6f7f9);
-	border-radius: var(--maker-border-radius-button, 8px);
+	border-radius: var(--maker-shape-button-border-radius, 8px);
 }
 
 .size_small {

--- a/src/components/SegmentedControl/src/SegmentedControl.vue
+++ b/src/components/SegmentedControl/src/SegmentedControl.vue
@@ -3,6 +3,7 @@
 		:class="[
 			$s.Container,
 			$s[`size_${sizeInner}`],
+			$s[`shape_${shape}`],
 		]"
 	>
 		<slot />
@@ -31,6 +32,14 @@ export default {
 			required: true,
 		},
 		/**
+		 * Shape of Control & Segments
+		 */
+		shape: {
+			type: String,
+			default: undefined,
+			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
+		},
+		/**
 		 * Size of Control & Segments
 		 */
 		size: {
@@ -43,6 +52,7 @@ export default {
 		return {
 			currentValue: this.selected,
 			sizeInner: this.size,
+			shapeInner: this.shape,
 		};
 	},
 	watch: {
@@ -63,6 +73,18 @@ export default {
 	line-height: 24px;
 	background-color: var(--neutral-10, #f6f7f9);
 	border-radius: var(--maker-shape-button-border-radius, 8px);
+}
+
+.shape_pill {
+	border-radius: 32px;
+}
+
+.shape_rounded {
+	border-radius: 4px;
+}
+
+.shape_squared {
+	border-radius: 0;
 }
 
 .size_small {

--- a/src/components/Select/src/SelectControl.vue
+++ b/src/components/Select/src/SelectControl.vue
@@ -180,7 +180,6 @@ export default {
 	--color-foreground: var(--neutral-90, rgba(2, 1, 1, 0.9));
 	--color-border-active: var(--neutral-80, #222);
 	--color-error: rgba(206, 50, 23, 1);
-	--border-radius: 8px;
 
 	position: relative;
 	box-sizing: border-box;
@@ -188,7 +187,7 @@ export default {
 	font-size: 16px;
 	font-family: inherit;
 	font-family: var(--font-family);
-	border-radius: var(--border-radius);
+	border-radius: var(--maker-border-radius, 8px);
 }
 
 .Prefix {

--- a/src/components/Select/src/SelectControl.vue
+++ b/src/components/Select/src/SelectControl.vue
@@ -187,7 +187,7 @@ export default {
 	font-size: 16px;
 	font-family: inherit;
 	font-family: var(--font-family);
-	border-radius: var(--maker-border-radius, 8px);
+	border-radius: var(--maker-shape-default-border-radius, 8px);
 }
 
 .Prefix {

--- a/src/components/Skeleton/src/SkeletonText.vue
+++ b/src/components/Skeleton/src/SkeletonText.vue
@@ -76,7 +76,7 @@ export default {
 		top: 50%;
 		width: 100%;
 		height: 75%;
-		border-radius: 8px;
+		border-radius: var(--maker-shape-default-border-radius, 8px);
 		transform: translateY(-50%);
 		animation: pulsing 0.5s ease-in-out infinite alternate;
 		content: "";

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -7,7 +7,6 @@
 			size="small"
 			:color="resolvedColor"
 			:text-color="resolvedTextColor"
-			:shape="resolvedShape"
 			:disabled="value === minVal"
 			@click="decrement"
 		>
@@ -21,7 +20,6 @@
 			size="small"
 			:color="resolvedColor"
 			:text-color="resolvedTextColor"
-			:shape="resolvedShape"
 			:disabled="value === maxVal"
 			@click="increment"
 		>
@@ -96,18 +94,10 @@ export default {
 			default: undefined,
 			validator: (color) => chroma.valid(color),
 		},
-		/**
-		 * stepper button shape
-		 */
-		shape: {
-			type: String,
-			default: undefined,
-			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
-		},
 	},
 
 	computed: {
-		...resolveThemeableProps('stepper', ['color', 'textColor', 'shape']),
+		...resolveThemeableProps('stepper', ['color', 'textColor']),
 
 		maxVal() {
 			return Number.parseInt(this.max, 10);

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -7,6 +7,7 @@
 			size="small"
 			:color="resolvedColor"
 			:text-color="resolvedTextColor"
+			:shape="resolvedShape"
 			:disabled="value === minVal"
 			@click="decrement"
 		>
@@ -19,6 +20,7 @@
 			variant="primary"
 			size="small"
 			:color="resolvedColor"
+			:shape="resolvedShape"
 			:text-color="resolvedTextColor"
 			:disabled="value === maxVal"
 			@click="increment"
@@ -94,10 +96,18 @@ export default {
 			default: undefined,
 			validator: (color) => chroma.valid(color),
 		},
+		/**
+		 * stepper button shape
+		 */
+		shape: {
+			type: String,
+			default: undefined,
+			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
+		},
 	},
 
 	computed: {
-		...resolveThemeableProps('stepper', ['color', 'textColor']),
+		...resolveThemeableProps('stepper', ['color', 'textColor', 'shape']),
 
 		maxVal() {
 			return Number.parseInt(this.max, 10);

--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -127,7 +127,7 @@ export default {
 	vertical-align: middle;
 	background-color: transparent;
 	border: none;
-	border-radius: 4px;
+	border-radius: var(--maker-shape-default-border-radius, 4px);
 	outline-color: currentColor;
 	cursor: pointer;
 	transition: box-shadow 0.2s ease-in;

--- a/src/components/Textarea/src/TextareaControl.vue
+++ b/src/components/Textarea/src/TextareaControl.vue
@@ -125,7 +125,7 @@ export default {
 	line-height: 24px;
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--color-border);
-	border-radius: var(--maker-border-radius, 8px);
+	border-radius: var(--maker-shape-default-border-radius, 8px);
 	outline: none;
 	transition:
 		border 0.2s ease,

--- a/src/components/Textarea/src/TextareaControl.vue
+++ b/src/components/Textarea/src/TextareaControl.vue
@@ -111,7 +111,6 @@ export default {
 	--color-foreground: var(--neutral-90, rgba(0, 0, 0, 0.9));
 	--color-border-active: var(--neutral-80, #222);
 	--color-error: rgba(206, 50, 23, 1);
-	--border-radius: 8px;
 
 	box-sizing: border-box;
 	width: 100%;
@@ -126,7 +125,7 @@ export default {
 	line-height: 24px;
 	background-color: var(--color-background, #fff);
 	border: 1px solid var(--color-border);
-	border-radius: var(--border-radius);
+	border-radius: var(--maker-border-radius, 8px);
 	outline: none;
 	transition:
 		border 0.2s ease,

--- a/src/components/Theme/src/Theme.vue
+++ b/src/components/Theme/src/Theme.vue
@@ -57,13 +57,7 @@ export default {
 	computed: {
 		styles() {
 			const { colors, shapes } = this;
-			const { radii } = shapes;
-			radii.default = shapes.default === 'squared' ? 0 : radii.small;
-			radii.button = {
-				squared: 0,
-				rounded: radii.small,
-				pill: radii.large,
-			}[shapes.default];
+			const shape = shapes[shapes.global];
 
 			return {
 				'--neutral-0': colors['neutral-0'],
@@ -77,8 +71,8 @@ export default {
 				'--color-text': colors.text,
 				'--color-elevation': colors['color-elevation'],
 				'--color-overlay': colors['color-overlay'],
-				'--maker-border-radius': radii.default,
-				'--maker-border-radius-button': radii.button,
+				'--maker-shape-default-border-radius': shape.defaultBorderRadius,
+				'--maker-shape-button-border-radius': shape.buttonBorderRadius,
 			};
 		},
 	},

--- a/src/components/Theme/src/Theme.vue
+++ b/src/components/Theme/src/Theme.vue
@@ -56,7 +56,14 @@ export default {
 	},
 	computed: {
 		styles() {
-			const { colors } = this;
+			const { colors, shapes } = this;
+			const { radii } = shapes;
+			radii.default = shapes.default === 'squared' ? 0 : radii.small;
+			radii.button = {
+				squared: 0,
+				rounded: radii.small,
+				pill: radii.large,
+			}[shapes.default];
 
 			return {
 				'--neutral-0': colors['neutral-0'],
@@ -70,6 +77,8 @@ export default {
 				'--color-text': colors.text,
 				'--color-elevation': colors['color-elevation'],
 				'--color-overlay': colors['color-overlay'],
+				'--maker-border-radius': radii.default,
+				'--maker-border-radius-button': radii.button,
 			};
 		},
 	},

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -20,6 +20,14 @@ export default function defaultTheme() {
 			baseSize: 16,
 			sizeScale: 1.17,
 		},
+		shapes: {
+			default: 'rounded',
+			radii: {
+				small: '8px',
+				medium: '16px',
+				large: '32px',
+			},
+		},
 		profiles: [
 			{
 				id: 'defaultProfile',
@@ -28,7 +36,7 @@ export default function defaultTheme() {
 		button: {
 			size: 'medium',
 			variant: 'primary',
-			shape: 'rounded',
+			shape: '@shapes.default',
 			color: '@colors.primary',
 			textColor: undefined,
 			fullWidth: false,
@@ -40,10 +48,16 @@ export default function defaultTheme() {
 		},
 		actionbarbutton: {
 			color: '@colors.primary',
-			shape: 'pill',
+			shape: '@shapes.default',
 			textColor: undefined,
 			fullWidth: false,
 			align: 'center',
+		},
+		image: {
+			shape: 'squared',
+		},
+		card: {
+			shape: '@shapes.default',
 		},
 		text: {
 			fontFamily: 'inherit',
@@ -63,7 +77,6 @@ export default function defaultTheme() {
 		stepper: {
 			color: '@colors["neutral-10"]',
 			textColor: '@colors["neutral-90"]',
-			shape: 'pill',
 		},
 		notice: {
 			color: undefined,

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -21,12 +21,22 @@ export default function defaultTheme() {
 			sizeScale: 1.17,
 		},
 		shapes: {
-			default: 'rounded',
-			radii: {
-				small: '8px',
-				medium: '16px',
-				large: '32px',
+			squared: {
+				defaultBorderRadius: '0px',
+				buttonBorderRadius: '0px',
+				imageBorderRadius: '0px',
 			},
+			rounded: {
+				defaultBorderRadius: '4px',
+				buttonBorderRadius: '8px',
+				imageBorderRadius: '16px',
+			},
+			pill: {
+				defaultBorderRadius: '4px',
+				buttonBorderRadius: '100px',
+				imageBorderRadius: '16px',
+			},
+			global: 'rounded',
 		},
 		profiles: [
 			{
@@ -36,7 +46,7 @@ export default function defaultTheme() {
 		button: {
 			size: 'medium',
 			variant: 'primary',
-			shape: '@shapes.default',
+			shape: '@shapes.global',
 			color: '@colors.primary',
 			textColor: undefined,
 			fullWidth: false,
@@ -48,16 +58,16 @@ export default function defaultTheme() {
 		},
 		actionbarbutton: {
 			color: '@colors.primary',
-			shape: '@shapes.default',
+			shape: '@shapes.global',
 			textColor: undefined,
 			fullWidth: false,
 			align: 'center',
 		},
 		image: {
-			shape: 'squared',
+			shape: '@shapes.global',
 		},
 		card: {
-			shape: '@shapes.default',
+			shape: '@shapes.global',
 		},
 		text: {
 			fontFamily: 'inherit',


### PR DESCRIPTION
Adds theming support for shape across multiple maker components.

1. Defines a `shapes` prop on default theme where global shape presets and their border radius values are defined:

```
		shapes: {
			squared: {
				defaultBorderRadius: '0px',
				buttonBorderRadius: '0px',
				imageBorderRadius: '0px',
			},
			rounded: {
				defaultBorderRadius: '4px',
				buttonBorderRadius: '8px',
				imageBorderRadius: '16px',
			},
			pill: {
				defaultBorderRadius: '4px',
				buttonBorderRadius: '100px',
				imageBorderRadius: '16px',
			},
			global: 'rounded',
		},
		...
		button: {
			shape: '@shapes.global',
		},
		card: {
			shape: '@shapes.global',
		},
```
2. Adds global maker border radius variables to Theme to be used by components that don't have a local `shape` prop override and for use to apply shape similarly to our color variables:
- `--maker-shape-default-border-radius`
- `--maker-shape-default-border-radius`
3. Update component styles to reflect new shape updates.
4. Update ThemeTest lab to demo shape presets as well as custom border radius values