### PR TITLE
feat(stepper): allow manual number entry for stepper

### DIFF
--- a/src/components/PinInput/src/PinInputControl.vue
+++ b/src/components/PinInput/src/PinInputControl.vue
@@ -33,6 +33,8 @@
 </template>
 
 <script>
+import { BASE_TEN } from '@square/maker/utils/constants';
+
 const DEFAULT_INPUT_SIZE = 6;
 
 export default {
@@ -121,7 +123,6 @@ export default {
 				return;
 			}
 			// Only allow integers in input
-			const BASE_TEN = 10;
 			const inputValue = Number.isInteger(Number.parseInt(input, BASE_TEN)) ? input : '';
 
 			// One-time-code autofill is treated as an input, not a paste
@@ -144,7 +145,6 @@ export default {
 		},
 
 		attemptSplitPinIntoInputs(value, inputIndex) {
-			const BASE_TEN = 10;
 			if (inputIndex === 0
 				&& value?.length === this.pinLength
 				&& Number.isInteger(Number.parseInt(value, BASE_TEN))

--- a/src/components/Stepper/README.md
+++ b/src/components/Stepper/README.md
@@ -7,7 +7,7 @@
 	>
 		<m-stepper
 			v-model="number"
-			min="0"
+			min="-10"
 			max="10"
 		/>
 		v-model: {{ number }}
@@ -46,7 +46,7 @@ export default {
 
 ## Events
 
-| Event          | Type     | Description           |
-| -------------- | -------- | --------------------- |
-| stepper:update | `number` | updated stepper value |
+| Event          | Type | Description |
+| -------------- | ---- | ----------- |
+| stepper:update | -    | —           |
 <!-- api-tables:end -->

--- a/src/components/Stepper/README.md
+++ b/src/components/Stepper/README.md
@@ -7,7 +7,7 @@
 	>
 		<m-stepper
 			v-model="number"
-			min="-10"
+			min="0"
 			max="10"
 		/>
 		v-model: {{ number }}

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -152,10 +152,6 @@ export default {
 				return;
 			}
 			const incrementBy = 1;
-			/**
-			 * updated stepper value
-			 * @property {number}
-			 */
 			this.emitUpdate(this.value + incrementBy);
 		},
 		decrement() {
@@ -163,10 +159,6 @@ export default {
 				return;
 			}
 			const decrementBy = 1;
-			/**
-			 * updated stepper value
-			 * @property {number}
-			 */
 			this.emitUpdate(this.value - decrementBy);
 		},
 
@@ -183,17 +175,33 @@ export default {
 			event?.preventDefault?.();
 			event?.stopPropagation?.();
 
-			const newValue = Number(this.manualValue);
+			const newValue = Number.parseInt(this.manualValue, 10);
 			this.isSettingManualValue = false;
 
 			if (Number.isNaN(newValue) || newValue === null || newValue === undefined) {
 				return;
 			}
 
-			this.emitUpdate(newValue);
+			this.emitUpdate(this.validateManualValueInRange(newValue));
+		},
+
+		validateManualValueInRange(newValue) {
+			if (!Number.isNaN(this.minVal) && newValue < this.minVal) {
+				return this.minVal;
+			}
+
+			if (!Number.isNaN(this.maxVal) && newValue > this.maxVal) {
+				return this.maxVal;
+			}
+
+			return newValue;
 		},
 
 		emitUpdate(newValue) {
+			/**
+			 * updated stepper value
+			 * @property {number}
+			 */
 			this.$emit('stepper:update', newValue);
 		},
 	},

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -30,7 +30,10 @@
 				@keyup.enter="commitManualValue"
 			>
 			<span
-				:class="$s.QuantityReadonly"
+				:class="[
+					$s.QuantityReadonly,
+					{ [$s.isManualInput]: isSettingManualValue }
+				]"
 				@click="triggerManualInput"
 			>
 				<!-- This allows us to auto-resize the input as users type -->
@@ -225,6 +228,10 @@ export default {
 .QuantityReadonly {
 	padding: 0 12px;
 	cursor: pointer;
+
+	&.isManualInput {
+		color: transparent;
+	}
 }
 
 .QuantityReadonly,
@@ -246,11 +253,14 @@ export default {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	width: 100%;
+	height: 100%;
 	padding: 0;
 	color: var(--neutral-90, inherit);
 	text-align: center;
 	background: transparent;
 	border: 0;
+	-moz-appearance: textfield;
 
 	&::-webkit-inner-spin-button,
 	&::-webkit-outer-spin-button {

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -26,8 +26,7 @@
 				type="number"
 				inputmode="numeric"
 				align="center"
-				@blur="commitManualValue"
-				@keyup.enter="commitManualValue"
+				@change="commitManualValue"
 			>
 			<span
 				:class="[
@@ -60,6 +59,7 @@ import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/co
 import { MButton } from '@square/maker/components/Button';
 import Plus from '@square/maker-icons/Plus';
 import Minus from '@square/maker-icons/Minus';
+import { BASE_TEN } from '@square/maker/utils/constants';
 
 export default {
 	components: {
@@ -141,11 +141,11 @@ export default {
 		...resolveThemeableProps('stepper', ['color', 'textColor', 'shape']),
 
 		maxVal() {
-			return Number.parseInt(this.max, 10);
+			return Number.parseInt(this.max, BASE_TEN);
 		},
 
 		minVal() {
-			return Number.parseInt(this.min, 10);
+			return Number.parseInt(this.min, BASE_TEN);
 		},
 	},
 
@@ -178,7 +178,8 @@ export default {
 			event?.preventDefault?.();
 			event?.stopPropagation?.();
 
-			const newValue = Number.parseInt(this.manualValue, 10);
+			// eslint-disable-next-line no-magic-numbers
+			const newValue = Math.round(Number.parseFloat(this.manualValue, BASE_TEN));
 			this.isSettingManualValue = false;
 
 			if (Number.isNaN(newValue) || newValue === null || newValue === undefined) {

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -17,7 +17,7 @@
 			:class="$s.Quantity"
 		>
 			<input
-				v-show="isSettingManualValue"
+				v-if="isSettingManualValue"
 				ref="manualInput"
 				v-model="manualValue"
 				:class="$s.QuantityManualInput"

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -175,8 +175,8 @@ export default {
 		},
 
 		commitManualValue(event) {
-			event?.preventDefault?.();
-			event?.stopPropagation?.();
+			event.preventDefault();
+			event.stopPropagation();
 
 			// eslint-disable-next-line no-magic-numbers
 			const newValue = Math.round(Number.parseFloat(this.manualValue, BASE_TEN));

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,1 @@
+export const BASE_TEN = 10;


### PR DESCRIPTION
## Describe the problem this PR addresses
Setting a stepper input to a much higher or lower number requires tapping the `+`/`-` buttons many times to get to the correct value.

Closes #317

## Describe the changes in this PR
This PR adds the ability to manually type in a value for a stepper in order to side step having to tap the increment/decrement buttons many times.
Clicking/tapping the inner number will create an input that will autofocus and (for mobile) pop open the numeric keyboard.
Manual inputs are validated to be an actual number and be within the min/max range (if defined).
The updated value will not be emitted until the user blurs/hits enter.

https://user-images.githubusercontent.com/3402466/167197148-ad631c88-7ff0-4418-ab46-7a3a991bfeac.mov