### PR TITLE
feat(docs)!: need breaking commit to get to v11 since v10 is already taken

### DIFF
--- a/lab/README.md
+++ b/lab/README.md
@@ -53,6 +53,10 @@ lab/experiments/
 
 ```
 
+### Managing State
+
+Each lab app is also bootstrapped with pinia, refer to its docs on how to manage state.
+
 ### Building & Deploying
 
 ```sh


### PR DESCRIPTION
previous major release failed since v10 was already published (& removed) from npm and once a version has been published to it can't be replaced or unpublished sooo we need to hop, skip, and jump to v11