### PR TITLE
ci: auto Lab deploys for PRs & releases

### DIFF
--- a/.github/workflows/deploy-styleguide-lab.yml
+++ b/.github/workflows/deploy-styleguide-lab.yml
@@ -40,5 +40,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: ${{ format("Deployed [Styleguide](https://square.github.io/maker/styleguide/{0}/#/) & [Lab](https://square.github.io/maker/lab/{0}/#/).\n<sub>Note, links may be invalidated after PR is merged or closed.</sub>", github.head_ref) }}
+          msg: ${{ format('Deployed [Styleguide](https://square.github.io/maker/styleguide/{0}/#/) & [Lab](https://square.github.io/maker/lab/{0}/#/).\n<sub>Note: links may be invalidated after PR is merged or closed.</sub>', github.head_ref) }}
           check_for_duplicate_msg: true

--- a/.github/workflows/deploy-styleguide-lab.yml
+++ b/.github/workflows/deploy-styleguide-lab.yml
@@ -40,5 +40,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: ${{ format('Deployed [Styleguide](https://square.github.io/maker/styleguide/{0}/#/) & [Lab](https://square.github.io/maker/lab/{0}/#/).\n<sub>Links may be invalidated after PR is merged or closed.</sub>', github.head_ref) }}
+          msg: ${{ format('Deployed [Styleguide](https://square.github.io/maker/styleguide/{0}/#/) & [Lab](https://square.github.io/maker/lab/{0}/#/).<br><sub>_Note&#58; links may be invalidated after PR is merged or closed._</sub>', github.head_ref) }}
           check_for_duplicate_msg: true

--- a/.github/workflows/deploy-styleguide-lab.yml
+++ b/.github/workflows/deploy-styleguide-lab.yml
@@ -40,5 +40,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: ${{ format('Deployed [Styleguide](https://square.github.io/maker/styleguide/{0}/#/) & [Lab](https://square.github.io/maker/lab/{0}/#/).\n<sub>Note: links may be invalidated after PR is merged or closed.</sub>', github.head_ref) }}
+          msg: ${{ format('Deployed [Styleguide](https://square.github.io/maker/styleguide/{0}/#/) & [Lab](https://square.github.io/maker/lab/{0}/#/).\n<sub>Links may be invalidated after PR is merged or closed.</sub>', github.head_ref) }}
           check_for_duplicate_msg: true

--- a/.github/workflows/deploy-styleguide-lab.yml
+++ b/.github/workflows/deploy-styleguide-lab.yml
@@ -40,5 +40,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: ${{ format('Deployed [Styleguide](https://square.github.io/maker/styleguide/{0}/#/) and [Lab](https://square.github.io/maker/lab/{0}/#/).<br><details><summary>Notes</summary><ol><li>Links may take a few minutes to update after PR is opened or commit is pushed.</li><li>Links may become invalidated after PR is merged or closed.</li></ol></details>', github.head_ref) }}
+          msg: ${{ format('Deployed [Styleguide](https://square.github.io/maker/styleguide/{0}/#/) and [Lab](https://square.github.io/maker/lab/{0}/#/).<br><details><summary>Disclaimers</summary><ol><li>Links may take a few minutes to update after PR is opened or commit is pushed.</li><li>Links may become invalidated after PR is merged or closed.</li></ol></details>', github.head_ref) }}
           check_for_duplicate_msg: true

--- a/.github/workflows/deploy-styleguide-lab.yml
+++ b/.github/workflows/deploy-styleguide-lab.yml
@@ -1,4 +1,4 @@
-name: Deploy Styleguide
+name: Deploy Styleguide & Lab
 
 on:
   pull_request:
@@ -8,14 +8,14 @@ on:
       - reopened
 
 jobs:
-  deploy-styleguide:
-    name: Deploy Styleguide
+  deploy-styleguide-lab:
+    name: Deploy Styleguide & Lab
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Maker Repo master branch
+      - name: Checkout Maker master branch
         uses: actions/checkout@v2
-      - name: Checkout nested Maker Repo deploys branch in .dist directory
+      - name: Checkout Maker deploys branch in .dist directory
         uses: actions/checkout@v2
         with:
           repository: square/maker
@@ -28,17 +28,17 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
-      - name: Build & deploy
+      - name: Build & deploy Styleguide & Lab
         run: |
           cd .dist
           git config user.name github-actions
           git config user.email github-actions@github.com
           cd ..
-          npm run styleguide-deploy
-      - name: Comment Styleguide Deploy link on PR
+          npm run deploy-all
+      - name: Comment Styleguide & Lab links on PR
         uses: pretzelhammer/comment-on-pr@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: ${{ format('Styleguide deployed to https://square.github.io/maker/styleguide/{0}/#/', github.head_ref) }}
+          msg: ${{ format('Deployed [Styleguide](https://square.github.io/maker/styleguide/{0}/#/). Deployed [Lab](https://square.github.io/maker/lab/{0}/#/).', github.head_ref) }}
           check_for_duplicate_msg: true

--- a/.github/workflows/deploy-styleguide-lab.yml
+++ b/.github/workflows/deploy-styleguide-lab.yml
@@ -40,5 +40,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: ${{ format('Deployed [Styleguide](https://square.github.io/maker/styleguide/{0}/#/). Deployed [Lab](https://square.github.io/maker/lab/{0}/#/).', github.head_ref) }}
+          msg: ${{ format("Deployed [Styleguide](https://square.github.io/maker/styleguide/{0}/#/) & [Lab](https://square.github.io/maker/lab/{0}/#/).\n<sub>Note, links may be invalidated after PR is merged or closed.</sub>", github.head_ref) }}
           check_for_duplicate_msg: true

--- a/.github/workflows/deploy-styleguide-lab.yml
+++ b/.github/workflows/deploy-styleguide-lab.yml
@@ -40,5 +40,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: ${{ format('Deployed [Styleguide](https://square.github.io/maker/styleguide/{0}/#/) & [Lab](https://square.github.io/maker/lab/{0}/#/).<br><sub>_Note&#58; links may be invalidated after PR is merged or closed._</sub>', github.head_ref) }}
+          msg: ${{ format('Deployed [Styleguide](https://square.github.io/maker/styleguide/{0}/#/) and [Lab](https://square.github.io/maker/lab/{0}/#/).<br><details><summary>Notes</summary><ol><li>Links may take a few minutes to update after PR is opened or commit is pushed.</li><li>Links may become invalidated after PR is merged or closed.</li></ol></details>', github.head_ref) }}
           check_for_duplicate_msg: true

--- a/.github/workflows/deploy-styleguide.yml
+++ b/.github/workflows/deploy-styleguide.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - synchronize
+      - reopened
 
 jobs:
   deploy-styleguide:
@@ -35,7 +36,7 @@ jobs:
           cd ..
           npm run styleguide-deploy
       - name: Comment Styleguide Deploy link on PR
-        uses: unsplash/comment-on-pr@master
+        uses: pretzelhammer/comment-on-pr@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout
+      - name: Checkout Maker master branch
         uses: actions/checkout@v2
       - name: Setup Node.js
         uses: actions/setup-node@v2
@@ -24,16 +24,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release@17
-      - name: Checkout nested Maker Repo deploys branch in .dist directory
+      - name: Checkout Maker deploys branch in .dist directory
         uses: actions/checkout@v2
         with:
           repository: square/maker
           ref: deploys
           path: .dist
-      - name: Build & deploy styleguide
+      - name: Build & deploy Styleguide & Lab
         run: |
           cd .dist
           git config user.name github-actions
           git config user.email github-actions@github.com
           cd ..
-          npm run styleguide-deploy
+          npm run deploy-all

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -94,13 +94,13 @@ const BUILT_INDEX = `
 			<h2>Styleguides</h2>
 			<div class="subcategories">
 				<div class="subcategory">
-					<h3>Versioned Releases</h3>
+					<h3>Releases</h3>
 					<ul>
 						${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isVersion), true)}
 					</ul>
 				</div>
 				<div class="subcategory">
-					<h3>WIP Branches</h3>
+					<h3>WIPs</h3>
 					<ul>
 						${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isntVersion))}
 					</ul>
@@ -112,13 +112,13 @@ const BUILT_INDEX = `
 			<h2>Labs</h2>
 			<div class="subcategories">
 				<div class="subcategory">
-					<h3>Versioned Releases</h3>
+					<h3>Releases</h3>
 					<ul>
 						${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isVersion), true)}
 					</ul>
 				</div>
 				<div class="subcategory">
-					<h3>WIP Branches</h3>
+					<h3>WIPs</h3>
 					<ul>
 						${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isntVersion))}
 					</ul>

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -26,7 +26,7 @@ ensureDirectory(LAB_DIST);
 ensureDirectory(STYLEGUIDE_DIST);
 
 const STYLEGUIDE_DEPLOYS = getDirectories(STYLEGUIDE_DIST).filter((d) => d !== '0.0.0-semantic-release');
-const LAB_DEPLOYS = getDirectories(LAB_DIST);
+const LAB_DEPLOYS = getDirectories(LAB_DIST).filter((d) => d !== '0.0.0-semantic-release');
 const additionalVersions = ['latest-preview', 'latest'];
 
 function isVersion(deployName) {
@@ -35,8 +35,8 @@ function isVersion(deployName) {
 function isntVersion(deployName) {
 	return !isVersion(deployName);
 }
-function sort(items, isNumericVersions) {
-	if (isNumericVersions) {
+function sort(items, isSemverItems) {
+	if (isSemverItems) {
 		items = items.filter((item) => semverValid(item));
 		semverSort(items);
 
@@ -50,8 +50,8 @@ function sort(items, isNumericVersions) {
 	return items.sort();
 }
 
-function toDeployLinks(prefix, suffix, items, isNumericVersions) {
-	items = sort(items, isNumericVersions);
+function toDeployLinks(prefix, suffix, items, isSemverItems) {
+	items = sort(items, isSemverItems);
 	return items.map((item) => `<li><a href="${prefix}${item}${suffix}">${item}</a></li>`).join('\n');
 }
 
@@ -64,9 +64,15 @@ const BUILT_INDEX = `
 <html lang="en">
 <head>
 	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<style>
+		body {
+			font-family: sans-serif;
+		}
+	</style>
 </head>
 <body>
-	<h2>Styleguide Deploys</h2>
+	<h2>Styleguides</h2>
 	<h3>Versioned Releases</h3>
 	<ul>
 		${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isVersion), true)}
@@ -75,9 +81,14 @@ const BUILT_INDEX = `
 	<ul>
 		${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isntVersion))}
 	</ul>
-	<h2>Lab Deploys</h2>
+	<h2>Labs</h2>
+	<h3>Versioned Releases</h3>
 	<ul>
-		${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS)}
+		${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isVersion), true)}
+	</ul>
+	<h3>WIP Branches</h3>
+	<ul>
+		${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isntVersion))}
 	</ul>
 </body>
 </html>

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -69,27 +69,63 @@ const BUILT_INDEX = `
 		body {
 			font-family: sans-serif;
 		}
+		h1, h2, h3, h4, h5, h6 {
+			margin: 0 0 0.5em 0;
+			white-space: nowrap;
+		}
+		.categories, .subcategories {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 16px;
+		}
+		.categories {
+			gap: 32px;
+		}
+		ul {
+			margin: 0;
+			padding: 0;
+			list-style-type: none;
+		}
 	</style>
 </head>
 <body>
-	<h2>Styleguides</h2>
-	<h3>Versioned Releases</h3>
-	<ul>
-		${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isVersion), true)}
-	</ul>
-	<h3>WIP Branches</h3>
-	<ul>
-		${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isntVersion))}
-	</ul>
-	<h2>Labs</h2>
-	<h3>Versioned Releases</h3>
-	<ul>
-		${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isVersion), true)}
-	</ul>
-	<h3>WIP Branches</h3>
-	<ul>
-		${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isntVersion))}
-	</ul>
+	<div class="categories">
+		<div class="category">
+			<h2>Styleguides</h2>
+			<div class="subcategories">
+				<div class="subcategory">
+					<h3>Versioned Releases</h3>
+					<ul>
+						${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isVersion), true)}
+					</ul>
+				</div>
+				<div class="subcategory">
+					<h3>WIP Branches</h3>
+					<ul>
+						${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isntVersion))}
+					</ul>
+				</div>
+			</div>
+		</div>
+
+		<div class="category">
+			<h2>Labs</h2>
+			<div class="subcategories">
+				<div class="subcategory">
+					<h3>Versioned Releases</h3>
+					<ul>
+						${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isVersion), true)}
+					</ul>
+				</div>
+				<div class="subcategory">
+					<h3>WIP Branches</h3>
+					<ul>
+						${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isntVersion))}
+					</ul>
+				</div>
+			</div>
+		</div>
+	</div>
 </body>
 </html>
 `;

--- a/build/sync-to-latest/index.js
+++ b/build/sync-to-latest/index.js
@@ -2,7 +2,9 @@ const path = require('path');
 const fse = require('fs-extra');
 const semver = require('semver');
 const {
-	getCurrentBranch, isStableRelease, isPreviewRelease,
+	getCurrentBranch,
+	isStableRelease,
+	isPreviewRelease,
 } = require('../utils');
 
 const branchName = getCurrentBranch();
@@ -16,51 +18,72 @@ if (!isStable && !isPreview) {
 	process.exit(noErrorStatus);
 }
 
-function getDirectories(baseDirectory) {
+function getSubDirectories(baseDirectory) {
 	return fse.readdirSync(baseDirectory, { withFileTypes: true })
 		.filter((entry) => entry.isDirectory())
 		.map((directory) => directory.name);
 }
 
+function getSemverDeploys(semverDirectory) {
+	return getSubDirectories(semverDirectory)
+		.filter((deploy) => semver.valid(deploy));
+}
+
+// sorts in desc order, from latest to oldest
+function sortSemverDescInPlace(semverArray) {
+	semverArray.sort((semverA, semverB) => {
+		const lessThan = -1;
+		const greaterThan = 1;
+		if (semver.gt(semverA, semverB)) {
+			return lessThan;
+		}
+		return greaterThan;
+	});
+}
+
+function getLatestFromSorted(sortedSemverArray) {
+	return sortedSemverArray.find(
+		(semverItem) => !semver.prerelease(semverItem),
+	);
+}
+
+function getLatestPreviewFromSorted(sortedSemverArray) {
+	return sortedSemverArray.find(
+		(semverItem) => !!semver.prerelease(semverItem),
+	);
+}
+
 const DIST = path.resolve(process.cwd(), '.dist');
 const STYLEGUIDE_DIST = path.resolve(DIST, 'styleguide');
-const STYLEGUIDE_SEMVER_DEPLOYS = getDirectories(STYLEGUIDE_DIST).filter(
-	(deploy) => semver.valid(deploy),
-);
+const LAB_DIST = path.resolve(DIST, 'lab');
 
-// sorted in descending order, from latest to oldest
-STYLEGUIDE_SEMVER_DEPLOYS.sort((semverA, semverB) => {
-	const lessThan = -1;
-	const greaterThan = 1;
-	if (semver.gt(semverA, semverB)) {
-		return lessThan;
-	}
-	return greaterThan;
-});
+const STYLEGUIDE_SEMVER_DEPLOYS = getSemverDeploys(STYLEGUIDE_DIST);
+const LAB_SEMVER_DEPLOYS = getSemverDeploys(LAB_DIST);
+
+sortSemverDescInPlace(STYLEGUIDE_SEMVER_DEPLOYS);
+sortSemverDescInPlace(LAB_SEMVER_DEPLOYS);
+
+function syncDistDirectories(distDirectory, distSourceDirectory, distDestinationDirectory) {
+	const sourceDirectory = path.resolve('./', '.dist', distDirectory, distSourceDirectory);
+	const destinationDirectory = path.resolve('./', '.dist', distDirectory, distDestinationDirectory);
+	fse.removeSync(destinationDirectory);
+	fse.copySync(sourceDirectory, destinationDirectory);
+}
 
 const noDeploys = 0;
-if (STYLEGUIDE_SEMVER_DEPLOYS.length === noDeploys) {
-	// nothing to sync
-	const noErrorStatus = 0;
-	process.exit(noErrorStatus);
+function syncSemverToLatest(semverArray, distDirectory) {
+	if (semverArray.length > noDeploys) {
+		const latestDeploy = getLatestFromSorted(semverArray);
+		if (latestDeploy) {
+			syncDistDirectories(distDirectory, latestDeploy, 'latest');
+		}
+
+		const latestPreviewDeploy = getLatestPreviewFromSorted(semverArray);
+		if (latestPreviewDeploy) {
+			syncDistDirectories(distDirectory, latestPreviewDeploy, 'latest-preview');
+		}
+	}
 }
 
-const latestDeploy = STYLEGUIDE_SEMVER_DEPLOYS.find(
-	(deploySemver) => !semver.prerelease(deploySemver),
-);
-if (latestDeploy) {
-	const latestDeployPath = path.resolve('./', '.dist/styleguide', latestDeploy);
-	const latestPath = path.resolve('./', '.dist/styleguide', 'latest');
-	fse.removeSync(latestPath);
-	fse.copySync(latestDeployPath, latestPath);
-}
-
-const latestPreviewDeploy = STYLEGUIDE_SEMVER_DEPLOYS.find(
-	(deploySemver) => !!semver.prerelease(deploySemver),
-);
-if (latestPreviewDeploy) {
-	const latestPreviewDeployPath = path.resolve('./', '.dist/styleguide', latestPreviewDeploy);
-	const latestPreviewPath = path.resolve('./', '.dist/styleguide', 'latest-preview');
-	fse.removeSync(latestPreviewPath);
-	fse.copySync(latestPreviewDeployPath, latestPreviewPath);
-}
+syncSemverToLatest(STYLEGUIDE_SEMVER_DEPLOYS, 'styleguide');
+syncSemverToLatest(LAB_SEMVER_DEPLOYS, 'lab');

--- a/build/utils.js
+++ b/build/utils.js
@@ -23,8 +23,23 @@ function getCurrentBranch() {
 	return branchName;
 }
 
+const BACKPORT_BRANCH_REGEX = /\d+\.x/;
+const SEMANTIC_BRANCHES = new Set([
+	'master',
+	'next',
+	'next-major',
+	'beta',
+	'alpha',
+]);
+const PREVIEW_BRANCHES = new Set([
+	'next',
+	'next-major',
+	'beta',
+	'alpha',
+]);
+
 function isSemanticReleaseBranch(branchName) {
-	return ['master', 'next', 'next-major', 'beta', 'alpha'].includes(branchName);
+	return SEMANTIC_BRANCHES.has(branchName) || BACKPORT_BRANCH_REGEX.test(branchName);
 }
 
 function isStableRelease(branchName) {
@@ -32,7 +47,7 @@ function isStableRelease(branchName) {
 }
 
 function isPreviewRelease(branchName) {
-	return ['next', 'next-major', 'beta', 'alpha'].includes(branchName);
+	return PREVIEW_BRANCHES.has(branchName);
 }
 
 function getLibraryVersion() {

--- a/build/utils.js
+++ b/build/utils.js
@@ -31,6 +31,9 @@ const SEMANTIC_BRANCHES = new Set([
 	'beta',
 	'alpha',
 ]);
+const STABLE_BRANCHES = new Set([
+	'master',
+]);
 const PREVIEW_BRANCHES = new Set([
 	'next',
 	'next-major',
@@ -43,7 +46,7 @@ function isSemanticReleaseBranch(branchName) {
 }
 
 function isStableRelease(branchName) {
-	return branchName === 'master';
+	return STABLE_BRANCHES.has(branchName) || BACKPORT_BRANCH_REGEX.test(branchName);
 }
 
 function isPreviewRelease(branchName) {

--- a/lab/webpack-lab-config.js
+++ b/lab/webpack-lab-config.js
@@ -5,15 +5,20 @@ const StylelintPlugin = require('stylelint-webpack-plugin');
 const ESLintPlugin = require('eslint-webpack-plugin');
 const { JustSsrPlugin, clientOnly } = require('vue-just-ssr');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const branch = require('git-branch');
-const { merge } = require('../build/utils');
+const {
+	merge,
+	getCurrentBranch,
+	isSemanticReleaseBranch,
+	getLibraryVersion,
+} = require('../build/utils');
 const webpackBaseConfig = require('../build/webpack-base-config');
 
 const entry = path.resolve('./lab/App.vue');
 require.resolve(entry);
 
 const isProduction = process.env.NODE_ENV === 'production';
-const branchName = branch.sync();
+const branchName = getCurrentBranch();
+const deployName = isSemanticReleaseBranch(branchName) ? getLibraryVersion() : branchName;
 
 const labDirectory = path.resolve('./lab/experiments/');
 
@@ -73,7 +78,7 @@ const config = merge({}, webpackBaseConfig, {
 	},
 
 	output: {
-		path: path.resolve(`.dist/lab/${branchName}`),
+		path: path.resolve(`.dist/lab/${deployName}`),
 	},
 
 	resolve: {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "npm run generate-api-tables && just-ssr --webpack-config build/webpack-development-config --open",
     "lab": "just-ssr --webpack-config lab/webpack-lab-config --open --port 8081",
     "lab-build": "NODE_ENV=production webpack --config lab/webpack-lab-config",
-    "lab-deploy": "npm run pull-deploys && npm run lab-build && npm run generate-deploy-index && npm run push-deploys",
+    "lab-deploy": "npm run pull-deploys && npm run lab-build && npm run sync-to-latest && npm run generate-deploy-index && npm run push-deploys",
     "generate-api-tables": "node ./build/generate-readme-api-tables",
     "styleguide": "npm run generate-api-tables && just-ssr --webpack-config styleguide/webpack-styleguide-config --open",
     "styleguide-build": "npm run generate-api-tables && NODE_ENV=production webpack --config styleguide/webpack-styleguide-config",

--- a/styleguide/webpack-styleguide-config.js
+++ b/styleguide/webpack-styleguide-config.js
@@ -9,7 +9,7 @@ const webpackBaseConfig = require('../build/webpack-base-config');
 const { getCurrentBranch, isSemanticReleaseBranch, getLibraryVersion } = require('../build/utils');
 
 const branchName = getCurrentBranch();
-const deploy = isSemanticReleaseBranch(branchName) ? getLibraryVersion() : branchName;
+const deployName = isSemanticReleaseBranch(branchName) ? getLibraryVersion() : branchName;
 
 const entry = path.resolve('./styleguide/App.vue');
 require.resolve(entry);
@@ -40,7 +40,7 @@ const config = merge({}, webpackBaseConfig, {
 	},
 
 	output: {
-		path: path.resolve(`.dist/styleguide/${deploy}`),
+		path: path.resolve(`.dist/styleguide/${deployName}`),
 	},
 
 	resolve: {


### PR DESCRIPTION
## Describe the problem this PR addresses
- no auto lab deploys for PRs or releases
- same comment with link to styleguide and lab deploy is re-commented every time a commit is pushed to an open PR
- deploy index is totally unstyled

## Describe the changes in this PR
- adds auto lab deploys for all PRs and releases
- comment with links should only be commented once
- adds some style to deploy index

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
we can [change this line](https://github.com/square/maker/pull/330/files#diff-dfea2822e411012ccce10fd935556cbbdf9659c52be2de78ef8f83ac3b127155R39) from `pretzelhammer/comment-on-pr` back to `unsplash/comment-on-pr` once this issue is closed https://github.com/unsplash/comment-on-pr/issues/55 and/or this PR is merged https://github.com/unsplash/comment-on-pr/pull/56