### PR TITLE
fix(select): fix styling for invalid prop

### DIFF
--- a/src/components/Select/src/SelectControl.vue
+++ b/src/components/Select/src/SelectControl.vue
@@ -230,12 +230,12 @@ export default {
 		color: var(--color-foreground);
 	}
 
-	&:not(:disabled, :invalid):hover {
+	&:not(:disabled, .invalid):hover {
 		border-color: var(--color-border-active);
 	}
 
-	&:not(:disabled, :invalid):focus,
-	&:not(:disabled, :invalid):active {
+	&:not(:disabled, .invalid):focus,
+	&:not(:disabled, .invalid):active {
 		border-color: var(--color-border-active);
 	}
 
@@ -244,7 +244,7 @@ export default {
 		opacity: 0.5;
 	}
 
-	&:invalid {
+	&.invalid {
 		border-color: var(--color-error);
 	}
 


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Select components with the `required` attribute set are automatically applying the invalid styling, even on first load if the default value is a placeholder.

<img width="334" alt="Screen Shot 2022-05-20 at 12 10 23 PM" src="https://user-images.githubusercontent.com/1486885/169569066-a11a9044-75c5-467a-a62f-49242b9907bf.png">

## Describe the changes in this PR
Applies invalid styling with our custom `invalid` prop rather than the `:invalid` selector.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
