### PR TITLE
feat(image)!: update shape property for image

### DIFF
--- a/src/components/Image/README.md
+++ b/src/components/Image/README.md
@@ -6,8 +6,34 @@
 		<h4>image</h4>
 		<m-image
 			class="image"
-			src="https://source.unsplash.com/random/400x400"
+			src="https://source.unsplash.com/random/400x600"
+			:shape="shape"
 		/>
+		<m-image
+			class="image image-tall"
+			src="https://source.unsplash.com/random/400x600"
+			:shape="shape"
+		/>
+		<m-image
+			class="image image-wide"
+			src="https://source.unsplash.com/random/400x600"
+			:shape="shape"
+		/>
+		<br>
+		<label>
+			Shape
+			<select
+				v-model="shape"
+			>
+				<option
+					v-for="(value, index) in shapeOptions"
+					:key="index"
+					:value="value"
+				>
+					{{ value }}
+				</option>
+			</select>
+		</label>
 	</div>
 </template>
 
@@ -18,12 +44,37 @@ export default {
 	components: {
 		MImage,
 	},
+
+	data() {
+		return {
+			shape: 'square',
+			shapeOptions: [
+				'square',
+				'circle',
+				'arch',
+			],
+		};
+	},
 };
 </script>
 
 <style scoped>
 .image {
+	display: inline-block;
 	width: 400px;
+	height: 400px;
+	margin-right: 25px;
+}
+
+.image-tall {
+	display: inline-block;
+	width: 400px;
+	height: 500px;
+}
+
+.image-wide {
+	display: inline-block;
+	width: 600px;
 	height: 400px;
 }
 </style>
@@ -37,12 +88,12 @@ Supports all `<img>` attributes
 
 Supports attributes from [`<img>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img).
 
-| Prop     | Type      | Default | Possible values              | Description |
-| -------- | --------- | ------- | ---------------------------- | ----------- |
-| src      | `string`  | —       | —                            | —           |
-| srcset   | `string`  | —       | —                            | —           |
-| shape    | `string`  | —       | `squared`, `rounded`, `pill` | —           |
-| lazyload | `boolean` | `false` | —                            | —           |
+| Prop     | Type      | Default | Possible values            | Description |
+| -------- | --------- | ------- | -------------------------- | ----------- |
+| src      | `string`  | —       | —                          | —           |
+| srcset   | `string`  | —       | —                          | —           |
+| shape    | `string`  | —       | `square`, `circle`, `arch` | —           |
+| lazyload | `boolean` | `false` | —                          | —           |
 
 
 ## Events

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -1,5 +1,8 @@
 <template>
-	<div :class="$s.ImageWrapper">
+	<div
+		ref="image-wrapper"
+		:class="$s.ImageWrapper"
+	>
 		<m-skeleton-block
 			v-if="!loaded"
 			:class="[
@@ -14,16 +17,22 @@
 					$s.Image,
 					$s[`shape_${resolvedShape}`],
 				]"
+				:style="style"
 				:src="src"
 				:srcset="srcset"
 				v-bind="$attrs"
 				v-on="$listeners"
 			>
 		</m-transition-fade-in>
+		<pseudo-window
+			@resize="throttledResizeHandler"
+		/>
 	</div>
 </template>
 
 <script>
+import PseudoWindow from 'vue-pseudo-window';
+import { throttle } from 'lodash';
 import { MTransitionFadeIn } from '@square/maker/components/TransitionFadeIn';
 import { MSkeletonBlock } from '@square/maker/components/Skeleton';
 import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
@@ -56,6 +65,7 @@ let observer;
  */
 export default {
 	components: {
+		PseudoWindow,
 		MTransitionFadeIn,
 		MSkeletonBlock,
 	},
@@ -81,7 +91,7 @@ export default {
 		shape: {
 			type: String,
 			default: undefined,
-			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
+			validator: (shape) => ['square', 'circle', 'arch'].includes(shape),
 		},
 		lazyload: {
 			type: Boolean,
@@ -90,13 +100,23 @@ export default {
 	},
 
 	data() {
+		const throggleDelay = 200;
+
 		return {
 			loaded: imgCache.has(this.src + this.srcset),
+			throttledResizeHandler: throttle(this.getImageHeight, throggleDelay),
+			height: 0,
 		};
 	},
 
 	computed: {
 		...resolveThemeableProps('image', ['shape']),
+
+		style() {
+			return {
+				'--image-height': `${this.height}px`,
+			};
+		},
 	},
 
 	watch: {
@@ -117,6 +137,7 @@ export default {
 				}
 			});
 		}
+		this.getImageHeight();
 	},
 
 	beforeDestroy() {
@@ -142,7 +163,12 @@ export default {
 			img.addEventListener('load', () => {
 				imgCache.add(this.src + this.srcset);
 				this.loaded = true;
+				this.getImageHeight();
 			});
+		},
+
+		getImageHeight() {
+			this.height = this.$refs['image-wrapper'].offsetHeight || '0';
 		},
 	},
 };
@@ -150,9 +176,6 @@ export default {
 
 <style module="$s">
 .ImageWrapper {
-	--radius-rounded-image: 16px;
-	--radius-pill-image: 16px;
-
 	position: relative;
 	width: 100%;
 	height: 100%;
@@ -165,16 +188,17 @@ export default {
 	object-position: center;
 	border-radius: var(--maker-shape-image-border-radius, 0);
 
-	&.shape_squared {
+	&.shape_square {
 		border-radius: 0;
 	}
 
-	&.shape_rounded {
-		border-radius: var(--radius-rounded-image);
+	&.shape_circle {
+		border-radius: var(--image-height, 100%);
 	}
 
-	&.shape_pill {
-		border-radius: var(--radius-pill-image);
+	&.shape_arch {
+		border-top-left-radius: var(--image-height);
+		border-top-right-radius: var(--image-height);
 	}
 }
 </style>


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
The current and upcoming shapes conversion work needs Images to support a `shape` prop that supports either `square`, `circle` or `arch` as values.
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
Updates the local `shape` property on Image to support the following values:
- `square` - this resets the border-radius set by the theme's `shapes.imageBorderRadius` value to `0`
- `circle` - this applies a border radius equal to the image element's height (per designs)
- `arch`- this applies a border radius equal to the image element's height to the top left/right corners of the image

![Screen Shot 2022-05-25 at 3 22 19 PM](https://user-images.githubusercontent.com/1486885/170351720-6a45355f-956a-4df7-8c80-665179ad71e3.png)

![Screen Shot 2022-05-25 at 3 22 00 PM](https://user-images.githubusercontent.com/1486885/170351752-3e6a3b1d-a061-41db-bdf6-172e660d7adb.png)

![Screen Shot 2022-05-25 at 3 22 09 PM](https://user-images.githubusercontent.com/1486885/170351764-c7afd5af-5d05-4e54-8bba-78bd52d278a4.png)


<!--
  📸 Inline screenshots to better communicate the changes
-->

## Migration Guide from 11.x to 12.x
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
- MImage's `shape` prop has changed:
  - grep your codebase for `<m-image` and/or `shape="` to find all instances that may need to be migrated and then:
  - `squared` value has been renamed to `square` (and should be migrated to `square`)
  - `pill` has been removed (and can be migrated to `square` or new `circle` value)
  - `rounded` has been removed (and can be migrated to `square` or new `circle` value)
