### PR TITLE
wip: themeable notice icons

### DIFF
--- a/lab/experiments/ThemeTest.vue
+++ b/lab/experiments/ThemeTest.vue
@@ -152,7 +152,6 @@
 						</div>
 						<br>
 						<m-divider />
-						<br>
 						<m-text
 							pattern="title"
 							:size="0"
@@ -213,6 +212,24 @@
 								</option>
 							</select>
 						</template>
+						<br>
+						<m-divider />
+						<m-text
+							pattern="title"
+							:size="0"
+						>
+							Icon Style
+						</m-text>
+						<select
+							v-model="iconStyle"
+						>
+							<option value="filled">
+								filled
+							</option>
+							<option value="outline">
+								outline
+							</option>
+						</select>
 					</div>
 				</div>
 				<div
@@ -578,6 +595,12 @@ import { MPinInput } from '@square/maker/components/PinInput';
 import { MToggle } from '@square/maker/components/Toggle';
 import { MPill } from '@square/maker/components/Pill';
 
+import AlertTriangleFilled from '@square/maker-icons/AlertTriangleFilled';
+import AlertCircleFilled from '@square/maker-icons/AlertCircleFilled';
+import CheckCircleFilled from '@square/maker-icons/CheckCircleFilled';
+import InfoFilled from '@square/maker-icons/InfoFilled';
+import AlertTriangle from '@square/maker-icons/AlertTriangle';
+import AlertCircle from '@square/maker-icons/AlertCircle';
 import CheckCircle from '@square/maker-icons/CheckCircle';
 import Info from '@square/maker-icons/Info';
 
@@ -686,6 +709,19 @@ function contrastColors(bgHex) {
 }
 // Above will be supplied by website-springboard
 
+const filledIcons = {
+	critical: AlertCircleFilled,
+	warning: AlertTriangleFilled,
+	success: CheckCircleFilled,
+	info: InfoFilled,
+};
+const outlineIcons = {
+	critical: AlertCircle,
+	warning: AlertTriangle,
+	success: CheckCircle,
+	info: Info,
+};
+
 export default {
 	components: {
 		MTheme,
@@ -702,8 +738,6 @@ export default {
 		MCheckbox,
 		MRadio,
 		MButton,
-		CheckCircle,
-		Info,
 		MCalendar,
 		MImageUploader,
 		MSegmentedControl,
@@ -715,6 +749,8 @@ export default {
 		MPinInput,
 		MToggle,
 		MPill,
+		CheckCircle,
+		Info,
 	},
 
 	mixins: [
@@ -834,6 +870,7 @@ export default {
 				'32px',
 			],
 			pillPatterns: Object.keys(defaultTheme().pill.patterns),
+			iconStyle: 'filled',
 		};
 	},
 
@@ -841,7 +878,8 @@ export default {
 		theme() {
 			const colors = contrastColors(this.backgroundColor);
 			const baseTen = 10;
-			return {
+			const icons = this.iconStyle === 'filled' ? filledIcons : outlineIcons;
+			const theme = {
 				colors: {
 					...colors,
 					primary: this.primaryColor,
@@ -865,6 +903,7 @@ export default {
 						fontWeight: this.textPatterns.label.fontWeight,
 					},
 				},
+				icons,
 				modal: {
 					bgColor: this.backgroundColor,
 				},
@@ -877,6 +916,10 @@ export default {
 					},
 				},
 			};
+
+			// console.log({ theme });
+
+			return theme;
 		},
 
 		contrastColor() {

--- a/lab/experiments/ThemeTest.vue
+++ b/lab/experiments/ThemeTest.vue
@@ -870,7 +870,7 @@ export default {
 				'32px',
 			],
 			pillPatterns: Object.keys(defaultTheme().pill.patterns),
-			iconStyle: 'filled',
+			iconStyle: 'outline',
 		};
 	},
 
@@ -903,7 +903,9 @@ export default {
 						fontWeight: this.textPatterns.label.fontWeight,
 					},
 				},
-				icons,
+				icons: {
+					...icons,
+				},
 				modal: {
 					bgColor: this.backgroundColor,
 				},

--- a/package-lock.json
+++ b/package-lock.json
@@ -3490,9 +3490,9 @@
       "dev": true
     },
     "@square/maker-icons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@square/maker-icons/-/maker-icons-2.0.0.tgz",
-      "integrity": "sha512-pel3XO5E4mMVsoRVrCA+ERTZdYvJrtxvhCqc8LpPoXG2HeO9kRceczLBjUcHXoDzFUfz/JoAJ4N/7sbZH/xtAQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@square/maker-icons/-/maker-icons-2.1.1.tgz",
+      "integrity": "sha512-gjY48hcSJUKAddbC6cpMFMVVxTonHWiahCLTb8ih6GBzLBMRvH9bzx5TtAamcRFyGDFI6E5Okhs3rR5DrODnDw==",
       "dev": true
     },
     "@stylelint/postcss-css-in-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3490,9 +3490,9 @@
       "dev": true
     },
     "@square/maker-icons": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@square/maker-icons/-/maker-icons-2.1.1.tgz",
-      "integrity": "sha512-gjY48hcSJUKAddbC6cpMFMVVxTonHWiahCLTb8ih6GBzLBMRvH9bzx5TtAamcRFyGDFI6E5Okhs3rR5DrODnDw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@square/maker-icons/-/maker-icons-2.1.2.tgz",
+      "integrity": "sha512-qipZEl+cbL3/cppPnsQeWeOsr/P4APmcZklanxcPI04SmYx6yM+NJsl3M2c/L8Pl4iX9WJURKZTs+9dzp8ZOxQ==",
       "dev": true
     },
     "@stylelint/postcss-css-in-js": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "popmotion": "^9.3.1",
     "stylefire": "^7.0.3",
     "vue": "^2.6.12",
-    "@square/maker-icons": "^2.1.1",
+    "@square/maker-icons": "^2.1.2",
     "@linusborg/vue-simple-portal": "^0.1.5",
     "@popperjs/core": "^2.10.2"
   },
@@ -56,7 +56,7 @@
     "@commitlint/config-conventional": "^11.0.0",
     "@linusborg/vue-simple-portal": "^0.1.5",
     "@popperjs/core": "^2.10.2",
-    "@square/maker-icons": "^2.1.1",
+    "@square/maker-icons": "^2.1.2",
     "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
     "@vue/babel-preset-jsx": "^1.1.2",
     "@vue/composition-api": "^1.4.9",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "popmotion": "^9.3.1",
     "stylefire": "^7.0.3",
     "vue": "^2.6.12",
-    "@square/maker-icons": "^2.0.0",
+    "@square/maker-icons": "^2.1.1",
     "@linusborg/vue-simple-portal": "^0.1.5",
     "@popperjs/core": "^2.10.2"
   },
@@ -56,7 +56,7 @@
     "@commitlint/config-conventional": "^11.0.0",
     "@linusborg/vue-simple-portal": "^0.1.5",
     "@popperjs/core": "^2.10.2",
-    "@square/maker-icons": "^2.0.0",
+    "@square/maker-icons": "^2.1.1",
     "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
     "@vue/babel-preset-jsx": "^1.1.2",
     "@vue/composition-api": "^1.4.9",

--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -1,0 +1,55 @@
+# Icon
+
+Use Icon to render icons defined in the Theme. Only built-in icons are: critical, warning, success, and info which are used within [Notice](#/Notice).
+
+```vue
+<template>
+	<ul class="icon-list">
+		<li
+			v-for="name in ['critical', 'warning', 'success', 'info']"
+			:key="name"
+		>
+			<m-icon :name="name" /> {{ name }}
+		</li>
+	</ul>
+</template>
+
+<script>
+import { MIcon } from '@square/maker/components/Icon';
+
+export default {
+	components: {
+		MIcon,
+	},
+};
+</script>
+
+<style scoped>
+.icon-list {
+	margin: 0 !important;
+	padding: 0 !important;
+	list-style: none;
+}
+
+.icon-list li {
+	display: flex;
+	gap: 4px;
+	align-items: center;
+}
+</style>
+```
+
+<!-- api-tables:start -->
+## Props
+
+Supports attributes from [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/svg).
+
+| Prop  | Type     | Default | Possible values | Description                    |
+| ----- | -------- | ------- | --------------- | ------------------------------ |
+| name* | `string` | —       | —               | name of icon, defined in theme |
+
+
+## Events
+
+Supports events from [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/svg).
+<!-- api-tables:end -->

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -1,0 +1,1 @@
+export { default as MIcon } from './src/Icon.vue';

--- a/src/components/Icon/src/Icon.vue
+++ b/src/components/Icon/src/Icon.vue
@@ -1,11 +1,14 @@
 <template>
-	<component
-		:is="iconComponent"
-		:key="iconComponent.__file"
-		:class="$s.Icon"
-		v-bind="$attrs"
-		v-on="$listeners"
-	/>
+	<span>
+		<component
+			:is="iconComponent"
+			:key="iconComponent.__file"
+			:class="$s.Icon"
+			v-bind="$attrs"
+			v-on="$listeners"
+		/>
+		{{ iconComponent.__file }}
+	</span>
 </template>
 
 <script>

--- a/src/components/Icon/src/Icon.vue
+++ b/src/components/Icon/src/Icon.vue
@@ -1,8 +1,8 @@
 <template>
 	<component
 		:is="iconComponent"
+		:key="iconComponent.__file"
 		:class="$s.Icon"
-		inline
 		v-bind="$attrs"
 		v-on="$listeners"
 	/>
@@ -36,11 +36,29 @@ export default {
 		},
 	},
 
+	data() {
+		return {
+			rerender: 0,
+		};
+	},
+
 	computed: {
 		iconComponent() {
 			const component = this.theme.icons[this.name];
+			console.log({ __file: component.__file, rerender: this.rerender });
 			assert.error(component, `'${this.name}' icon not defined in theme`);
 			return component;
+		},
+	},
+
+	watch: {
+		'theme.icons': {
+			handler(newVal, oldVal) {
+				this.rerender += 1;
+				// console.log(JSON.stringify({ newVal, oldVal, rerender: this.rerender }, null, 4));
+			},
+			deep: true,
+			immediate: true,
 		},
 	},
 };

--- a/src/components/Icon/src/Icon.vue
+++ b/src/components/Icon/src/Icon.vue
@@ -1,0 +1,54 @@
+<template>
+	<component
+		:is="iconComponent"
+		:class="$s.Icon"
+		inline
+		v-bind="$attrs"
+		v-on="$listeners"
+	/>
+</template>
+
+<script>
+import assert from '@square/maker/utils/assert';
+import { MThemeKey, defaultTheme } from '@square/maker/components/Theme';
+
+/**
+ * @inheritAttrs svg
+ * @inheritListeners svg
+ */
+export default {
+	inject: {
+		theme: {
+			default: defaultTheme(),
+			from: MThemeKey,
+		},
+	},
+
+	inheritAttrs: false,
+
+	props: {
+		/**
+		 * name of icon, defined in theme
+		 */
+		name: {
+			type: String,
+			required: true,
+		},
+	},
+
+	computed: {
+		iconComponent() {
+			const component = this.theme.icons[this.name];
+			assert.error(component, `'${this.name}' icon not defined in theme`);
+			return component;
+		},
+	},
+};
+</script>
+
+<style module="$s">
+.Icon {
+	width: 16px;
+	height: 16px;
+}
+</style>

--- a/src/components/Notice/README.md
+++ b/src/components/Notice/README.md
@@ -117,6 +117,7 @@ Supports attributes from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/
 | pattern    | `string` | —          | —                                     | pattern defined at theme level     |
 | type       | `string` | —          | `error`, `success`, `warning`, `info` | type of notice                     |
 | variant    | `string` | `'inline'` | `inline`, `block`                     | notice variant                     |
+| icon-name  | `string` | —          | —                                     | name of icon, defined in theme     |
 | icon-color | `string` | —          | —                                     | icon color                         |
 | color      | `string` | —          | —                                     | text color for inline notices      |
 | bg-color   | `string` | —          | —                                     | background color for block notices |

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -186,7 +186,7 @@ export default {
 }
 
 .Icon {
-	stroke: var(--color-icon);
+	color: var(--color-icon);
 }
 
 .ActionsWrapper > *:last-child {

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -11,10 +11,9 @@
 	>
 		<div :class="$s.IconContentWrapper">
 			<div :class="$s.IconAligner">
-				<component
-					:is="iconComponent"
+				<m-icon
+					:name="finalIconName"
 					:class="$s.Icon"
-					inline
 				/>
 			</div>
 			<div>
@@ -33,12 +32,9 @@
 </template>
 
 <script>
-import AlertTriangle from '@square/maker-icons/AlertTriangle';
-import AlertCircle from '@square/maker-icons/AlertCircle';
-import CheckCircle from '@square/maker-icons/CheckCircle';
-import Info from '@square/maker-icons/Info';
 import assert from '@square/maker/utils/assert';
 import cssValidator from '@square/maker/utils/css-validator';
+import { MIcon } from '@square/maker/components/Icon';
 import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
 
 /**
@@ -47,10 +43,7 @@ import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/co
  */
 export default {
 	components: {
-		AlertTriangle,
-		AlertCircle,
-		CheckCircle,
-		Info,
+		MIcon,
 	},
 
 	inject: {
@@ -87,6 +80,13 @@ export default {
 			validator: (variant) => ['inline', 'block'].includes(variant),
 		},
 		/**
+		 * name of icon, defined in theme
+		 */
+		iconName: {
+			type: String,
+			default: undefined,
+		},
+		/**
 		 * icon color
 		 */
 		iconColor: {
@@ -116,21 +116,25 @@ export default {
 		...resolveThemeableProps('notice', [
 			'pattern',
 			'type',
+			'iconName',
 			'iconColor',
 			'color',
 			'bgColor',
 		]),
-		iconComponent() {
+		finalIconName() {
+			if (this.resolvedIconName) {
+				return this.resolvedIconName;
+			}
 			if (this.resolvedType === 'error') {
-				return AlertCircle;
+				return 'critical';
 			}
 			if (this.resolvedType === 'success') {
-				return CheckCircle;
+				return 'success';
 			}
 			if (this.resolvedType === 'warning') {
-				return AlertTriangle;
+				return 'warning';
 			}
-			return Info;
+			return 'info';
 		},
 		showActions() {
 			return this.$slots.actions && this.variant === 'block';
@@ -182,8 +186,6 @@ export default {
 }
 
 .Icon {
-	width: 16px;
-	height: 16px;
 	stroke: var(--color-icon);
 }
 

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -1,7 +1,7 @@
-import AlertTriangle from '@square/maker-icons/AlertTriangle';
-import AlertCircle from '@square/maker-icons/AlertCircle';
-import CheckCircle from '@square/maker-icons/CheckCircle';
-import Info from '@square/maker-icons/Info';
+import AlertTriangleFilled from '@square/maker-icons/AlertTriangleFilled';
+import AlertCircleFilled from '@square/maker-icons/AlertCircleFilled';
+import CheckCircleFilled from '@square/maker-icons/CheckCircleFilled';
+import InfoFilled from '@square/maker-icons/InfoFilled';
 import { resolve, getPath } from './utils';
 
 export default function defaultTheme() {
@@ -55,10 +55,10 @@ export default function defaultTheme() {
 			},
 		},
 		icons: {
-			critical: AlertCircle,
-			warning: AlertTriangle,
-			success: CheckCircle,
-			info: Info,
+			critical: AlertCircleFilled,
+			warning: AlertTriangleFilled,
+			success: CheckCircleFilled,
+			info: InfoFilled,
 		},
 		shapes: {
 			defaultBorderRadius: '4px',

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -1,3 +1,7 @@
+import AlertTriangle from '@square/maker-icons/AlertTriangle';
+import AlertCircle from '@square/maker-icons/AlertCircle';
+import CheckCircle from '@square/maker-icons/CheckCircle';
+import Info from '@square/maker-icons/Info';
 import { resolve, getPath } from './utils';
 
 export default function defaultTheme() {
@@ -49,6 +53,12 @@ export default function defaultTheme() {
 				fontFamily: 'inherit',
 				fontWeight: '500',
 			},
+		},
+		icons: {
+			critical: AlertCircle,
+			warning: AlertTriangle,
+			success: CheckCircle,
+			info: Info,
 		},
 		shapes: {
 			defaultBorderRadius: '4px',
@@ -154,23 +164,28 @@ export default function defaultTheme() {
 			patterns: {
 				error: {
 					type: 'error',
+					iconName: 'critical',
 					iconColor: '@colors.critical.fill',
 					color: '@colors.critical.text',
 					bgColor: '@colors.critical.subtle',
 				},
 				success: {
 					type: 'success',
+					iconName: 'success',
 					iconColor: '@colors.success.fill',
 					color: '@colors.success.text',
 					bgColor: '@colors.success.subtle',
 				},
 				warning: {
 					type: 'warning',
+					iconName: 'warning',
 					iconColor: '@colors.warning.fill',
 					color: '@colors.warning.text',
 					bgColor: '@colors.warning.subtle',
 				},
 				info: {
+					type: 'info',
+					iconName: 'info',
 					iconColor: '@colors["neutral-80"]',
 					color: '@colors["neutral-90"]',
 					bgColor: '@colors["neutral-10"]',


### PR DESCRIPTION
my icon components are not re-rendering and i don't understand what's going on

[lab env](https://square.github.io/maker/lab/themeable-notice-icons/#/ThemeTest) (can change icon style from the sidebar, and the changes should be reflected in the notice component icons)

https://user-images.githubusercontent.com/7769424/170489985-e1f048ac-42e9-46d6-bfae-5377aadc37c3.mov

i tried to reproduce it in a [simplified jsfiddle](https://jsfiddle.net/fykpbeL3/4/) but of course it works there 🤦 

https://user-images.githubusercontent.com/7769424/170490371-064eb9dd-7876-451d-ad78-7050c7dd9e44.mov



