### PR TITLE
fix(image): add original shape option for images

### DIFF
--- a/src/components/Image/README.md
+++ b/src/components/Image/README.md
@@ -88,12 +88,12 @@ Supports all `<img>` attributes
 
 Supports attributes from [`<img>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img).
 
-| Prop     | Type      | Default | Possible values            | Description |
-| -------- | --------- | ------- | -------------------------- | ----------- |
-| src      | `string`  | —       | —                          | —           |
-| srcset   | `string`  | —       | —                          | —           |
-| shape    | `string`  | —       | `square`, `circle`, `arch` | —           |
-| lazyload | `boolean` | `false` | —                          | —           |
+| Prop     | Type      | Default | Possible values                        | Description                                                               |
+| -------- | --------- | ------- | -------------------------------------- | ------------------------------------------------------------------------- |
+| src      | `string`  | —       | —                                      | —                                                                         |
+| srcset   | `string`  | —       | —                                      | —                                                                         |
+| shape    | `string`  | —       | `original`, `square`, `circle`, `arch` | Original applies theme's border radius, square applies border radius of 0 |
+| lazyload | `boolean` | `false` | —                                      | —                                                                         |
 
 
 ## Events

--- a/src/components/Image/README.md
+++ b/src/components/Image/README.md
@@ -6,8 +6,34 @@
 		<h4>image</h4>
 		<m-image
 			class="image"
-			src="https://source.unsplash.com/random/400x400"
+			src="https://source.unsplash.com/random/400x600"
+			:shape="shape"
 		/>
+		<m-image
+			class="image image-tall"
+			src="https://source.unsplash.com/random/400x600"
+			:shape="shape"
+		/>
+		<m-image
+			class="image image-wide"
+			src="https://source.unsplash.com/random/400x600"
+			:shape="shape"
+		/>
+		<br>
+		<label>
+			Shape
+			<select
+				v-model="shape"
+			>
+				<option
+					v-for="(value, index) in shapeOptions"
+					:key="index"
+					:value="value"
+				>
+					{{ value }}
+				</option>
+			</select>
+		</label>
 	</div>
 </template>
 
@@ -18,12 +44,37 @@ export default {
 	components: {
 		MImage,
 	},
+
+	data() {
+		return {
+			shape: 'square',
+			shapeOptions: [
+				'square',
+				'circle',
+				'arch',
+			],
+		};
+	},
 };
 </script>
 
 <style scoped>
 .image {
+	display: inline-block;
 	width: 400px;
+	height: 400px;
+	margin-right: 25px;
+}
+
+.image-tall {
+	display: inline-block;
+	width: 400px;
+	height: 500px;
+}
+
+.image-wide {
+	display: inline-block;
+	width: 600px;
 	height: 400px;
 }
 </style>
@@ -37,12 +88,12 @@ Supports all `<img>` attributes
 
 Supports attributes from [`<img>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img).
 
-| Prop     | Type      | Default | Possible values              | Description |
-| -------- | --------- | ------- | ---------------------------- | ----------- |
-| src      | `string`  | —       | —                            | —           |
-| srcset   | `string`  | —       | —                            | —           |
-| shape    | `string`  | —       | `squared`, `rounded`, `pill` | —           |
-| lazyload | `boolean` | `false` | —                            | —           |
+| Prop     | Type      | Default | Possible values            | Description |
+| -------- | --------- | ------- | -------------------------- | ----------- |
+| src      | `string`  | —       | —                          | —           |
+| srcset   | `string`  | —       | —                          | —           |
+| shape    | `string`  | —       | `square`, `circle`, `arch` | —           |
+| lazyload | `boolean` | `false` | —                          | —           |
 
 
 ## Events

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -91,7 +91,7 @@ export default {
 		shape: {
 			type: String,
 			default: undefined,
-			validator: (shape) => ['square', 'circle', 'arch'].includes(shape),
+			validator: (shape) => ['original', 'square', 'circle', 'arch'].includes(shape),
 		},
 		lazyload: {
 			type: Boolean,

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -88,6 +88,10 @@ export default {
 			type: String,
 			default: undefined,
 		},
+		/**
+		 * Original applies theme's border radius, square applies border radius of 0
+		 * @values original, square, circle, arch
+		 */
 		shape: {
 			type: String,
 			default: undefined,

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -141,7 +141,9 @@ export default {
 	},
 
 	beforeDestroy() {
-		observer.unwatch(this.$el);
+		if (observer) {
+			observer.unwatch(this.$el);
+		}
 	},
 
 	methods: {

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -1,5 +1,8 @@
 <template>
-	<div :class="$s.ImageWrapper">
+	<div
+		ref="image-wrapper"
+		:class="$s.ImageWrapper"
+	>
 		<m-skeleton-block
 			v-if="!loaded"
 			:class="[
@@ -14,16 +17,22 @@
 					$s.Image,
 					$s[`shape_${resolvedShape}`],
 				]"
+				:style="style"
 				:src="src"
 				:srcset="srcset"
 				v-bind="$attrs"
 				v-on="$listeners"
 			>
 		</m-transition-fade-in>
+		<pseudo-window
+			@resize="throttledResizeHandler"
+		/>
 	</div>
 </template>
 
 <script>
+import PseudoWindow from 'vue-pseudo-window';
+import { throttle } from 'lodash';
 import { MTransitionFadeIn } from '@square/maker/components/TransitionFadeIn';
 import { MSkeletonBlock } from '@square/maker/components/Skeleton';
 import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
@@ -56,6 +65,7 @@ let observer;
  */
 export default {
 	components: {
+		PseudoWindow,
 		MTransitionFadeIn,
 		MSkeletonBlock,
 	},
@@ -81,7 +91,7 @@ export default {
 		shape: {
 			type: String,
 			default: undefined,
-			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
+			validator: (shape) => ['square', 'circle', 'arch'].includes(shape),
 		},
 		lazyload: {
 			type: Boolean,
@@ -90,13 +100,23 @@ export default {
 	},
 
 	data() {
+		const throggleDelay = 200;
+
 		return {
 			loaded: imgCache.has(this.src + this.srcset),
+			throttledResizeHandler: throttle(this.getImageHeight, throggleDelay),
+			height: 0,
 		};
 	},
 
 	computed: {
 		...resolveThemeableProps('image', ['shape']),
+
+		style() {
+			return {
+				'--image-height': `${this.height}px`,
+			};
+		},
 	},
 
 	watch: {
@@ -117,6 +137,7 @@ export default {
 				}
 			});
 		}
+		this.getImageHeight();
 	},
 
 	beforeDestroy() {
@@ -142,7 +163,12 @@ export default {
 			img.addEventListener('load', () => {
 				imgCache.add(this.src + this.srcset);
 				this.loaded = true;
+				this.getImageHeight();
 			});
+		},
+
+		getImageHeight() {
+			this.height = this.$refs['image-wrapper'].offsetHeight || '0';
 		},
 	},
 };
@@ -150,9 +176,6 @@ export default {
 
 <style module="$s">
 .ImageWrapper {
-	--radius-rounded-image: 16px;
-	--radius-pill-image: 16px;
-
 	position: relative;
 	width: 100%;
 	height: 100%;
@@ -165,16 +188,17 @@ export default {
 	object-position: center;
 	border-radius: var(--maker-shape-image-border-radius, 0);
 
-	&.shape_squared {
+	&.shape_square {
 		border-radius: 0;
 	}
 
-	&.shape_rounded {
-		border-radius: var(--radius-rounded-image);
+	&.shape_circle {
+		border-radius: var(--image-height, 100%);
 	}
 
-	&.shape_pill {
-		border-radius: var(--radius-pill-image);
+	&.shape_arch {
+		border-top-left-radius: var(--image-height);
+		border-top-right-radius: var(--image-height);
 	}
 }
 </style>


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Adds an `original` image shape option to reset an image within a theme.
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
