### PR TITLE
fix(notice): colors icons using fill, required for parity with square-icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3490,9 +3490,9 @@
       "dev": true
     },
     "@square/maker-icons": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@square/maker-icons/-/maker-icons-2.1.2.tgz",
-      "integrity": "sha512-qipZEl+cbL3/cppPnsQeWeOsr/P4APmcZklanxcPI04SmYx6yM+NJsl3M2c/L8Pl4iX9WJURKZTs+9dzp8ZOxQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@square/maker-icons/-/maker-icons-3.0.0.tgz",
+      "integrity": "sha512-Dvrtwz46mokntFEaKRCQGEqIewtYL2mOvyOjGLspmcjHnZB6q2IeqaY6NPoJj9ka7dqHnFVUYVs5ATM9GSNx6w==",
       "dev": true
     },
     "@stylelint/postcss-css-in-js": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "popmotion": "^9.3.1",
     "stylefire": "^7.0.3",
     "vue": "^2.6.12",
-    "@square/maker-icons": "^2.1.2",
+    "@square/maker-icons": "^3.0.0",
     "@linusborg/vue-simple-portal": "^0.1.5",
     "@popperjs/core": "^2.10.2"
   },
@@ -56,7 +56,7 @@
     "@commitlint/config-conventional": "^11.0.0",
     "@linusborg/vue-simple-portal": "^0.1.5",
     "@popperjs/core": "^2.10.2",
-    "@square/maker-icons": "^2.1.2",
+    "@square/maker-icons": "^3.0.0",
     "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
     "@vue/babel-preset-jsx": "^1.1.2",
     "@vue/composition-api": "^1.4.9",

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -186,7 +186,7 @@ export default {
 }
 
 .Icon {
-	color: var(--color-icon);
+	fill: var(--color-icon);
 }
 
 .ActionsWrapper > *:last-child {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
need parity with square-icons, all square-icons are colored using `fill` and not `color` or `stroke`

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
the main change in this PR is bumping maker-icons from 2.1.2 to 3.0.0, and the pr for that is here: https://github.com/square/maker-icons/pull/14

tldr: we trace all icons now (like square-icons does) so that we can color all icons (including outlined ones) using `fill`

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
nope