### PR TITLE
feat(image): clamp border radius for thumbnail images

### DIFF
--- a/lab/experiments/ThemeTest.vue
+++ b/lab/experiments/ThemeTest.vue
@@ -511,6 +511,10 @@
 						<m-image
 							src="https://source.unsplash.com/900x600/?vacation"
 						/>
+						<m-image
+							style="width: 120px;"
+							src="https://source.unsplash.com/900x600/?vacation"
+						/>
 						<m-image-uploader
 							@image-uploader:change="setImages"
 						/>

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -13,10 +13,11 @@
 		<m-transition-fade-in>
 			<img
 				v-if="loaded"
-				:class="[
-					$s.Image,
-					$s[`shape_${resolvedShape}`],
-				]"
+				:class="{
+					[$s.Image]: true,
+					[$s[`shape_${resolvedShape}}`]]: resolvedShape,
+					[$s.thumbnail]: isThumbnail,
+				}"
 				:style="style"
 				:src="src"
 				:srcset="srcset"
@@ -56,7 +57,7 @@ function SharedIntersectionObserver() {
 }
 
 const imgCache = new Set();
-
+const THUMBNAIL_MAX_WIDTH = '150';
 let observer;
 
 /**
@@ -104,12 +105,13 @@ export default {
 	},
 
 	data() {
-		const throggleDelay = 200;
+		const throttleDelay = 200;
 
 		return {
 			loaded: imgCache.has(this.src + this.srcset),
-			throttledResizeHandler: throttle(this.getImageHeight, throggleDelay),
+			throttledResizeHandler: throttle(this.getImageDimensions, throttleDelay),
 			height: 0,
+			width: 0,
 		};
 	},
 
@@ -120,6 +122,10 @@ export default {
 			return {
 				'--image-height': `${this.height}px`,
 			};
+		},
+
+		isThumbnail() {
+			return this.width < THUMBNAIL_MAX_WIDTH;
 		},
 	},
 
@@ -141,7 +147,7 @@ export default {
 				}
 			});
 		}
-		this.getImageHeight();
+		this.getImageDimensions();
 	},
 
 	beforeDestroy() {
@@ -169,12 +175,13 @@ export default {
 			img.addEventListener('load', () => {
 				imgCache.add(this.src + this.srcset);
 				this.loaded = true;
-				this.getImageHeight();
+				this.getImageDimensions();
 			});
 		},
 
-		getImageHeight() {
+		getImageDimensions() {
 			this.height = this.$refs['image-wrapper'].offsetHeight || '0';
+			this.width = this.$refs['image-wrapper'].offsetWidth || '0';
 		},
 	},
 };
@@ -193,6 +200,10 @@ export default {
 	object-fit: cover;
 	object-position: center;
 	border-radius: var(--maker-shape-image-border-radius, 0);
+
+	&.thumbnail {
+		border-radius: var(--maker-shape-thumbnail-border-radius, 0);
+	}
 
 	&.shape_square {
 		border-radius: 0;

--- a/src/components/Theme/src/Theme.vue
+++ b/src/components/Theme/src/Theme.vue
@@ -9,6 +9,7 @@
 
 <script>
 import { mergeWith, find } from 'lodash';
+import { BASE_TEN } from '@square/maker/utils/constants';
 import key from './key';
 import defaultTheme from './default-theme';
 import { resolve, getPath } from './utils';
@@ -36,6 +37,10 @@ function resolveTheme(data, parentTheme, theme, profileId) {
 	mergeWith(data, find(data.profiles, { id: profileId }), mergeStrategy);
 	data.resolve = resolve;
 	data.getPath = getPath;
+}
+
+function clamp(value, min, max) {
+	return Math.min(Math.max(Number.parseInt(value, BASE_TEN), min), max);
 }
 
 export default {
@@ -70,6 +75,7 @@ export default {
 	computed: {
 		styles() {
 			const { colors, fonts, shapes } = this;
+			const MAX_THUMBNAIL_RADIUS = 8;
 
 			return {
 				'--maker-color-neutral-0': colors['neutral-0'],
@@ -93,6 +99,7 @@ export default {
 				'--maker-shape-default-border-radius': shapes.defaultBorderRadius,
 				'--maker-shape-button-border-radius': shapes.buttonBorderRadius,
 				'--maker-shape-image-border-radius': shapes.imageBorderRadius,
+				'--maker-shape-thumbnail-border-radius': `${clamp(shapes.imageBorderRadius, 0, MAX_THUMBNAIL_RADIUS)}px`,
 			};
 		},
 	},


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
We don't currently limit the size of MTheme's `shapes.imageBorderRadius`. For small thumbnail images, a border radius of 10px or more can be overwhelming.
 
## Describe the changes in this PR
This PR limits the image border radius to `8px` max on all smaller (150px and below) thumbnail images.

Before with `shapes.imageBorderRadius: 16px`
<img width="411" alt="Screen Shot 2022-06-07 at 3 09 00 PM" src="https://user-images.githubusercontent.com/1486885/172464933-4e5163e3-4895-4a18-a448-b27979659489.png">

After with `shapes.imageBorderRadius: 16px`, thumbnail border radius limited to `8px`
<img width="405" alt="Screen Shot 2022-06-07 at 3 09 14 PM" src="https://user-images.githubusercontent.com/1486885/172464980-b9850eac-542f-4559-beae-44e6bb64854e.png">


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
