### PR TITLE
feat(shapes): add card border-radius to theme shapes definitions

### DIFF
--- a/lab/experiments/ThemeTest.vue
+++ b/lab/experiments/ThemeTest.vue
@@ -186,6 +186,19 @@
 								</option>
 							</select>
 							<br>
+							card radius:
+							<select
+								v-model="customShape.cardBorderRadius"
+							>
+								<option
+									v-for="(value, index) in borderRadiusOptions"
+									:key="index"
+									:value="value"
+								>
+									{{ value }}
+								</option>
+							</select>
+							<br>
 							button radius:
 							<select
 								v-model="customShape.buttonBorderRadius"
@@ -825,6 +838,7 @@ export default {
 			shape: {
 				name: 'squared',
 				defaultBorderRadius: '0px',
+				cardBorderRadius: '0px',
 				buttonBorderRadius: '0px',
 				imageBorderRadius: '0px',
 			},
@@ -832,30 +846,35 @@ export default {
 				{
 					name: 'squared',
 					defaultBorderRadius: '0px',
+					cardBorderRadius: '0px',
 					buttonBorderRadius: '0px',
 					imageBorderRadius: '0px',
 				},
 				{
 					name: 'rounded',
-					defaultBorderRadius: '4px',
+					defaultBorderRadius: '8px',
+					cardBorderRadius: '4px',
 					buttonBorderRadius: '8px',
 					imageBorderRadius: '16px',
 				},
 				{
 					name: 'pill',
 					defaultBorderRadius: '4px',
+					cardBorderRadius: '8px',
 					buttonBorderRadius: '32px',
 					imageBorderRadius: '16px',
 				},
 				{
 					name: 'custom',
 					defaultBorderRadius: '0px',
+					cardBorderRadius: '0px',
 					buttonBorderRadius: '0px',
 					imageBorderRadius: '0px',
 				},
 			],
 			customShape: {
 				defaultBorderRadius: '0px',
+				cardBorderRadius: '0px',
 				buttonBorderRadius: '0px',
 				imageBorderRadius: '0px',
 			},

--- a/src/components/Card/src/Card.vue
+++ b/src/components/Card/src/Card.vue
@@ -54,7 +54,7 @@ export default {
 	padding: 16px 24px;
 	background-color: var(--maker-color-background, #fff);
 	border: 1px solid var(--maker-color-neutral-20, #eaeaea);
-	border-radius: var(--maker-shape-default-border-radius, var(--radius-rounded-default));
+	border-radius: var(--maker-shape-card-border-radius, var(--radius-rounded-default));
 
 	&.shape_squared {
 		border-radius: 0;

--- a/src/components/Theme/src/Theme.vue
+++ b/src/components/Theme/src/Theme.vue
@@ -91,6 +91,7 @@ export default {
 				'--maker-font-label-font-family': fonts.label.fontFamily,
 				'--maker-font-label-font-weight': fonts.label.fontWeight,
 				'--maker-shape-default-border-radius': shapes.defaultBorderRadius,
+				'--maker-shape-card-border-radius': shapes.cardBorderRadius,
 				'--maker-shape-button-border-radius': shapes.buttonBorderRadius,
 				'--maker-shape-image-border-radius': shapes.imageBorderRadius,
 			};

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -54,6 +54,7 @@ export default function defaultTheme() {
 		icons: defaultIcons,
 		shapes: {
 			defaultBorderRadius: '4px',
+			cardBorderRadius: '4px',
 			buttonBorderRadius: '4px',
 			imageBorderRadius: '0px',
 		},


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Design wants to Cards to have their own `theme.shapes` border-radius definition. 

## Describe the changes in this PR
Adds `theme.shapes.cardBorderRadius` definition and `--maker-shape-card-border-radius` variable.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
