### PR TITLE
fix(icon): can color icon with color css now

### DIFF
--- a/src/components/Icon/src/Icon.vue
+++ b/src/components/Icon/src/Icon.vue
@@ -49,5 +49,6 @@ export default {
 .Icon {
 	width: 16px;
 	height: 16px;
+	fill: currentColor;
 }
 </style>

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -186,7 +186,7 @@ export default {
 }
 
 .Icon {
-	fill: var(--color-icon);
+	color: var(--color-icon);
 }
 
 .ActionsWrapper > *:last-child {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
i found a slightly better fix that builds on top of this pr: https://github.com/square/maker/pull/353 😆 

now icons can be colored with `color` css and that's more intuitive than using `fill`, and it still works with maker-icons and square-icons which use `fill`.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
adds `fill: currentColor` to the `.Icon` css class in the icon component

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
nope