### PR TITLE
fix(menu): fix auto focus on menu options, remove custom toggle style

### DIFF
--- a/src/components/Menu/src/Menu.vue
+++ b/src/components/Menu/src/Menu.vue
@@ -24,7 +24,6 @@
 				</select-control>
 				<div
 					v-else
-					:class="$s.CustomToggle"
 					@click="popover.toggle()"
 				>
 					<!-- @slot Custom toggle slot (not rendered if toggle-select is used) -->
@@ -149,9 +148,5 @@ export default {
 	display: flex;
 	flex-direction: column;
 	min-width: 200px;
-}
-
-.CustomToggle {
-	display: inline-block;
 }
 </style>

--- a/src/components/Menu/src/MenuOption.vue
+++ b/src/components/Menu/src/MenuOption.vue
@@ -97,7 +97,7 @@ export default {
 
 	mounted() {
 		if (this.$el?.previousElementSibling === null) {
-			this.$el.focus();
+			this.$el.focus({ preventScroll: true });
 		}
 	},
 
@@ -133,10 +133,10 @@ export default {
 				this.selectSelf();
 				break;
 			case 'ArrowUp':
-				this.$el?.previousElementSibling?.focus();
+				this.$el?.previousElementSibling?.focus({ preventScroll: true });
 				break;
 			case 'ArrowDown':
-				this.$el?.nextElementSibling?.focus();
+				this.$el?.nextElementSibling?.focus({ preventScroll: true });
 				break;
 			default:
 				break;


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
The combination of `MPopoverLayer` sitting at the end of a page and the `.focus()` event on `MMenuOption` auto-scrolling to bring the element into frame caused Menus on long pages to jump when opened. It also prevented the menu option from actually being auto-focused when the menu opens.

This also removes the `display: inline-block` style from the custom menu toggle.

![BUG](https://user-images.githubusercontent.com/1486885/173914873-6ea2904d-43bd-418e-991c-24abd4debe6a.gif)

## Describe the changes in this PR
This PR adds the `preventScroll: true` option to the `MMenuOption` focus events to prevent the page from scrolling when the menu content is mounted.

![FIX](https://user-images.githubusercontent.com/1486885/173915567-4eab115e-9dff-4525-b761-1d37719bce72.gif)

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
