### PR TITLE
fix(image): add a check for the image element before checking dimensions

### DIFF
--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -1,6 +1,5 @@
 <template>
 	<div
-		ref="image-wrapper"
 		:class="$s.ImageWrapper"
 	>
 		<m-skeleton-block
@@ -12,7 +11,7 @@
 		/>
 		<m-transition-fade-in>
 			<img
-				v-if="loaded"
+				v-show="loaded"
 				:class="{
 					[$s.Image]: true,
 					[$s[`shape_${resolvedShape}`]]: resolvedShape,
@@ -180,8 +179,8 @@ export default {
 		},
 
 		getImageDimensions() {
-			this.height = this.$refs['image-wrapper'].offsetHeight || '0';
-			this.width = this.$refs['image-wrapper'].offsetWidth || '0';
+			this.height = this.$el?.offsetHeight || '0';
+			this.width = this.$el?.offsetWidth || '0';
 		},
 	},
 };


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
The Image element's `getImageDimensions` method can cause an error if the image wrapper is not fully rendered.

## Describe the changes in this PR
Adds a check that image element is rendered before trying to read the `offsetWidth` and `offsetHeight`

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
