### PR TITLE
fix(image): fix loading proper size image

### DIFF
--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -171,6 +171,12 @@ export default {
 				img.srcset = this.srcset;
 			}
 
+			// Needed to not load the full size image
+			// and match the size loaded in the UI
+			if (this.$attrs?.sizes) {
+				img.sizes = this.$attrs.sizes;
+			}
+
 			img.addEventListener('load', () => {
 				imgCache.add(this.src + this.srcset);
 				this.loaded = true;

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -20,6 +20,7 @@
 				:style="style"
 				:src="src"
 				:srcset="srcset"
+				:sizes="sizes"
 				v-bind="$attrs"
 				v-on="$listeners"
 			>
@@ -85,6 +86,10 @@ export default {
 			default: undefined,
 		},
 		srcset: {
+			type: String,
+			default: undefined,
+		},
+		sizes: {
 			type: String,
 			default: undefined,
 		},
@@ -173,8 +178,8 @@ export default {
 
 			// Needed to not load the full size image
 			// and match the size loaded in the UI
-			if (this.$attrs?.sizes) {
-				img.sizes = this.$attrs.sizes;
+			if (this.sizes) {
+				img.sizes = this.sizes;
 			}
 
 			img.addEventListener('load', () => {


### PR DESCRIPTION
## Describe the problem this PR addresses
Fixes images being loaded at full size instead of the corresponding sizes attribute passed in.

## Describe the changes in this PR
Add the sizes attribute when creating the image element for loading.

