### PR TITLE
feat: adds MTransitionCollapse utility component, for use in MAccordion later

### DIFF
--- a/src/components/TransitionResize/src/TransitionResize.vue
+++ b/src/components/TransitionResize/src/TransitionResize.vue
@@ -23,7 +23,7 @@ import {
 } from '@square/maker/utils/transitions';
 
 function resizeFn({
- element, startWidth, endWidth, startHeight, endHeight, onComplete,
+	element, startWidth, endWidth, startHeight, endHeight, onComplete,
 }) {
 	const elementStyler = styler(element);
 	const resizeWidthFn = styleFactory(startWidth, endWidth, 'width', 'px');

--- a/src/utils/TransitionCollapse/README.md
+++ b/src/utils/TransitionCollapse/README.md
@@ -1,0 +1,93 @@
+# Transition Collapse
+
+MTransitionCollapse only animates the height property of its child, so for best results wrap your default slot content in a marginless, paddingless parent with `overflow: hidden` on it.
+
+The example below illustrates that it's safe to use the transition even with dynamically generated content that may change the height of the content before, during, or after the transition.
+
+```vue
+<template>
+	<div class="container">
+		content above box
+		<m-transition-collapse>
+			<div
+				v-if="visible"
+				class="wrapper"
+			>
+				<div class="gray-box">
+					<div
+						v-for="count in repetitions"
+						:key="count"
+					>
+						content in box {{ count }}
+					</div>
+				</div>
+			</div>
+		</m-transition-collapse>
+		content below box
+	</div>
+</template>
+
+<script>
+import { MTransitionCollapse } from '@square/maker/utils/TransitionCollapse';
+
+const INCREMENT = 1;
+const DECREMENT = -1;
+const MIN_REPETITIONS = 2;
+const MAX_REPETITIONS = 12;
+
+export default {
+	components: {
+		MTransitionCollapse,
+	},
+
+	data() {
+		return {
+			visible: true,
+			repetitions: MIN_REPETITIONS,
+			increment: INCREMENT,
+		};
+	},
+
+	mounted() {
+		const transitionIntervalMs = 2000;
+		const incrementIntervalMs = 500;
+		setInterval(() => {
+			if (this.repetitions === MAX_REPETITIONS) {
+				this.increment = DECREMENT;
+			} else if (this.repetitions === MIN_REPETITIONS) {
+				this.increment = INCREMENT;
+			}
+			this.repetitions += this.increment;
+		}, incrementIntervalMs);
+		setInterval(() => {
+			this.visible = !this.visible;
+		}, transitionIntervalMs);
+	},
+};
+</script>
+
+<style scoped>
+.wrapper {
+	overflow: hidden;
+}
+.gray-box {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	box-sizing: border-box;
+    background-color: #ccc;
+	padding: 40px;
+	border: 2px solid black;
+	width: 500px;
+}
+</style>
+```
+
+<!-- api-tables:start -->
+## Slots
+
+| Slot    | Description                  |
+| ------- | ---------------------------- |
+| default | content to collapse & expand |
+<!-- api-tables:end -->

--- a/src/utils/TransitionCollapse/index.js
+++ b/src/utils/TransitionCollapse/index.js
@@ -1,0 +1,1 @@
+export { default as MTransitionCollapse } from './src/TransitionCollapse.vue';

--- a/src/utils/TransitionCollapse/src/TransitionCollapse.vue
+++ b/src/utils/TransitionCollapse/src/TransitionCollapse.vue
@@ -1,0 +1,81 @@
+<template>
+	<m-transition
+		v-bind="$attrs"
+		:enter="expandFn"
+		:leave="collapseFn"
+		v-on="$listeners"
+	>
+		<!-- @slot content to collapse & expand -->
+		<slot />
+	</m-transition>
+</template>
+
+<script>
+import { MTransition } from '@square/maker/utils/Transition';
+import styler from 'stylefire';
+import { animate } from 'popmotion';
+import {
+	animateUp, spring, styleFactory,
+} from '@square/maker/utils/transitions';
+
+function collapseFn({ element, onComplete }) {
+	const startHeight = element.scrollHeight;
+	const elementStyler = styler(element);
+	const collapseHeightFn = styleFactory(startHeight, 0, 'height', 'px');
+	// setup & render initial state
+	elementStyler.set(collapseHeightFn(animateUp.from));
+	elementStyler.render();
+	// animate transition
+	animate({
+		...animateUp,
+		...spring,
+		onUpdate(progress) {
+			elementStyler.set(collapseHeightFn(progress));
+		},
+		onComplete,
+	});
+}
+
+function expandFn({ element, onComplete: onExpandComplete }) {
+	const endHeight = element.scrollHeight;
+	const elementStyler = styler(element);
+	const expandHeightFn = styleFactory(0, endHeight, 'height', 'px');
+	// setup & render initial state
+	elementStyler.set(expandHeightFn(animateUp.from));
+	elementStyler.render();
+	// animate transition
+	animate({
+		...animateUp,
+		...spring,
+		onUpdate(progress) {
+			elementStyler.set(expandHeightFn(progress));
+		},
+		onComplete() {
+			// there's some weird Vue or Popmotion bug that causes the
+			// onComplete handler to be called a frame or 2 too early,
+			// so we perform a mini delay to make sure our onComplete
+			// code only runs after the animation has fully completed
+			const miniDelayMs = 50;
+			setTimeout(() => {
+				element.style.removeProperty('height');
+				onExpandComplete();
+			}, miniDelayMs);
+		},
+	});
+}
+
+export default {
+	components: {
+		MTransition,
+	},
+
+	inheritAttrs: false,
+
+	data() {
+		return {
+			collapseFn,
+			expandFn,
+		};
+	},
+};
+</script>

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -102,9 +102,8 @@ export function fadeInFn({ element, onComplete }) {
 	animate({
 		...animationDirection,
 		...spring,
-		// duration: 3000,
-		onUpdate(number) {
-			elementStyler.set(styleFn(number));
+		onUpdate(progress) {
+			elementStyler.set(styleFn(progress));
 		},
 		onComplete,
 	});
@@ -120,8 +119,8 @@ export function delayedFadeInFn({ element, onComplete }) {
 		animate({
 			...animationDirection,
 			...spring,
-			onUpdate(number) {
-				elementStyler.set(styleFn(number));
+			onUpdate(progress) {
+				elementStyler.set(styleFn(progress));
 			},
 			onComplete,
 		});
@@ -137,8 +136,8 @@ export function fadeOutFn({ element, onComplete }) {
 	animate({
 		...animateDown,
 		...spring,
-		onUpdate(number) {
-			elementStyler.set(styleFn(number));
+		onUpdate(progress) {
+			elementStyler.set(styleFn(progress));
 		},
 		onComplete,
 	});
@@ -153,8 +152,8 @@ export function springUpFn({ element, onComplete }) {
 	animate({
 		...animationDirection,
 		...spring,
-		onUpdate(number) {
-			elementStyler.set(styleFn(number));
+		onUpdate(progress) {
+			elementStyler.set(styleFn(progress));
 		},
 		onComplete,
 	});
@@ -169,8 +168,8 @@ export function springDownFn({ element, onComplete }) {
 	animate({
 		...animationDirection,
 		...spring,
-		onUpdate(number) {
-			elementStyler.set(styleFn(number));
+		onUpdate(progress) {
+			elementStyler.set(styleFn(progress));
 		},
 		onComplete,
 	});
@@ -185,8 +184,8 @@ export function springLeftFn({ element, onComplete }) {
 	animate({
 		...animationDirection,
 		...spring,
-		onUpdate(number) {
-			elementStyler.set(styleFn(number));
+		onUpdate(progress) {
+			elementStyler.set(styleFn(progress));
 		},
 		onComplete,
 	});
@@ -201,8 +200,8 @@ export function springRightFn({ element, onComplete }) {
 	animate({
 		...animationDirection,
 		...spring,
-		onUpdate(number) {
-			elementStyler.set(styleFn(number));
+		onUpdate(progress) {
+			elementStyler.set(styleFn(progress));
 		},
 		onComplete,
 	});
@@ -217,8 +216,8 @@ export function floatUpFn({ element, onComplete }) {
 	animate({
 		...animationDirection,
 		...spring,
-		onUpdate(number) {
-			elementStyler.set(styleFn(number));
+		onUpdate(progress) {
+			elementStyler.set(styleFn(progress));
 		},
 		onComplete,
 	});
@@ -234,8 +233,8 @@ export function delayedFloatUpFn({ element, onComplete }) {
 		animate({
 			...animationDirection,
 			...spring,
-			onUpdate(number) {
-				elementStyler.set(styleFn(number));
+			onUpdate(progress) {
+				elementStyler.set(styleFn(progress));
 			},
 			onComplete,
 		});
@@ -254,8 +253,8 @@ export function staggeredFloatUpFn({ element, onComplete }) {
 	animate({
 		...animationDirection,
 		...springSubtle,
-		onUpdate(number) {
-			elementStyler.set(styleFn(number, endValue));
+		onUpdate(progress) {
+			elementStyler.set(styleFn(progress, endValue));
 		},
 		onComplete,
 	});
@@ -270,8 +269,8 @@ export function floatDownFn({ element, onComplete }) {
 	animate({
 		...animationDirection,
 		...spring,
-		onUpdate(number) {
-			elementStyler.set(styleFn(number));
+		onUpdate(progress) {
+			elementStyler.set(styleFn(progress));
 		},
 		onComplete,
 	});
@@ -286,8 +285,8 @@ export function springUpBounceFn({ element, onComplete }) {
 	animate({
 		...animationDirection,
 		...springBounce,
-		onUpdate(number) {
-			elementStyler.set(styleFn(number));
+		onUpdate(progress) {
+			elementStyler.set(styleFn(progress));
 		},
 		onComplete,
 	});
@@ -302,8 +301,8 @@ export function springDownBounceFn({ element, onComplete }) {
 	animate({
 		...animationDirection,
 		...springBounce,
-		onUpdate(number) {
-			elementStyler.set(styleFn(number));
+		onUpdate(progress) {
+			elementStyler.set(styleFn(progress));
 		},
 		onComplete,
 	});


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
need collapse transition component in Maker for next component: Accordion

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
adds TransitionCollapse utility component

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
i'd like to move all the transition components from the `components` dir to the `utils` dir which is why I placed TransitionCollapse there in the first place