### PR TITLE
fix(input): fix webkit autofill styles

### DIFF
--- a/src/components/Input/src/InputControl.vue
+++ b/src/components/Input/src/InputControl.vue
@@ -10,16 +10,6 @@
 		]"
 		@click="focus"
 	>
-		<span
-			v-if="$slots.prefix"
-			:class="[
-				$s.Affix,
-				$s.Prefix,
-			]"
-		>
-			<!-- @slot Input prefix -->
-			<slot name="prefix" />
-		</span>
 		<input
 			ref="input"
 			:class="[
@@ -31,6 +21,21 @@
 			v-on="$listeners"
 			@input="$emit('input:update', $event.target.value)"
 		>
+		<!--
+			Both affix slots need to come after the input, so we can target
+			them with the sibling selector (~) to apply webkit autofill styles
+			which are not otherwise targetable.
+		-->
+		<span
+			v-if="$slots.prefix"
+			:class="[
+				$s.Affix,
+				$s.Prefix,
+			]"
+		>
+			<!-- @slot Input prefix -->
+			<slot name="prefix" />
+		</span>
 		<span
 			v-if="$slots.suffix"
 			:class="[
@@ -139,6 +144,7 @@ export default {
 }
 
 .Affix {
+	z-index: 1;
 	display: flex;
 	align-items: center;
 	box-sizing: inherit;
@@ -150,10 +156,12 @@ export default {
 	fill: currentColor;
 
 	&.Prefix {
+		order: 1;
 		padding-right: 8px;
 	}
 
 	&.Suffix {
+		order: 3;
 		padding-left: 8px;
 	}
 }
@@ -170,6 +178,7 @@ export default {
 	width: 100%;
 	height: 48px;
 	padding: 0 16px;
+	overflow: hidden;
 	color: var(--color-foreground);
 	font-size: 16px;
 	background-color: var(--color-background, #fff);
@@ -194,6 +203,7 @@ export default {
 
 .Input {
 	flex-grow: 1;
+	order: 2;
 	box-sizing: inherit;
 	color: inherit;
 	font-weight: inherit;
@@ -217,6 +227,18 @@ export default {
 
 	&.align_right {
 		text-align: right;
+	}
+
+	&:-webkit-autofill,
+	&:-webkit-autofill:hover,
+	&:-webkit-autofill:focus,
+	&:-webkit-autofill:active {
+		box-shadow: 0 0 0 48px var(--color-foreground) inset, 0 0 0 9999px var(--color-foreground);
+		-webkit-text-fill-color: var(--color-background);
+	}
+
+	&:-webkit-autofill ~ .Affix {
+		color: var(--color-background);
 	}
 }
 </style>

--- a/src/components/Select/src/SelectControl.vue
+++ b/src/components/Select/src/SelectControl.vue
@@ -5,13 +5,6 @@
 			$s[`variant_${variant}`],
 		]"
 	>
-		<span
-			v-if="$slots.prefix"
-			:class="$s.Prefix"
-		>
-			<!-- @slot Select prefix -->
-			<slot name="prefix" />
-		</span>
 		<button
 			v-if="$slots.default"
 			:class="[
@@ -60,6 +53,18 @@
 			</option>
 		</select>
 		<chevron-down-icon :class="$s.Icon" />
+		<!--
+			Prefix slot needs to come after the select, so we can target
+			them with the sibling selector (~) to apply webkit autofill styles
+			which are not otherwise targetable.
+		-->
+		<span
+			v-if="$slots.prefix"
+			:class="$s.Prefix"
+		>
+			<!-- @slot Select prefix -->
+			<slot name="prefix" />
+		</span>
 	</div>
 </template>
 
@@ -198,6 +203,17 @@ export default {
 	pointer-events: none;
 }
 
+.Icon {
+	position: absolute;
+	top: 50%;
+	right: 16px;
+	width: 16px;
+	height: 16px;
+	color: var(--color-foreground);
+	transform: translateY(-50%);
+	pointer-events: none;
+}
+
 .Select,
 .SelectButton {
 	display: flex;
@@ -251,16 +267,18 @@ export default {
 	&::-ms-expand {
 		display: none;
 	}
-}
 
-.Icon {
-	position: absolute;
-	top: 50%;
-	right: 16px;
-	width: 16px;
-	height: 16px;
-	color: var(--color-foreground);
-	transform: translateY(-50%);
-	pointer-events: none;
+	&:-webkit-autofill,
+	&:-webkit-autofill:hover,
+	&:-webkit-autofill:focus,
+	&:-webkit-autofill:active {
+		box-shadow: 0 0 0 48px var(--color-foreground) inset, 0 0 0 9999px var(--color-foreground);
+		-webkit-text-fill-color: var(--color-background);
+	}
+
+	&:-webkit-autofill ~ .Icon,
+	&:-webkit-autofill ~ .Prefix {
+		color: var(--color-background);
+	}
 }
 </style>

--- a/src/components/Textarea/src/TextareaControl.vue
+++ b/src/components/Textarea/src/TextareaControl.vue
@@ -147,6 +147,14 @@ export default {
 		border-color: var(--color-error);
 	}
 
+	&:-webkit-autofill,
+	&:-webkit-autofill:hover,
+	&:-webkit-autofill:focus,
+	&:-webkit-autofill:active {
+		box-shadow: 0 0 0 9999px var(--color-foreground) inset, 0 0 0 9999px var(--color-foreground);
+		-webkit-text-fill-color: var(--color-background);
+	}
+
 	&:hover:not(:disabled, :invalid) {
 		border-color: var(--color-border-active);
 	}


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Autofill styles currently look strange and inset on Input components.
<img width="369" alt="Screen Shot 2022-07-01 at 2 41 09 PM" src="https://user-images.githubusercontent.com/1486885/177625720-451f5d96-9f63-4186-8b3c-11e5c473bd67.png">
<img width="361" alt="Screen Shot 2022-07-01 at 2 40 42 PM" src="https://user-images.githubusercontent.com/1486885/177625725-77f20f5a-ca93-4e12-b760-e72d8e420030.png">

## Describe the changes in this PR
This PR fixes the autofill styles and applies Maker colors.
<img width="363" alt="Screen Shot 2022-07-01 at 2 31 22 PM" src="https://user-images.githubusercontent.com/1486885/177625829-544207c5-6930-4e4b-9cd7-75486f7c70ac.png">
<img width="373" alt="Screen Shot 2022-07-01 at 2 32 20 PM" src="https://user-images.githubusercontent.com/1486885/177625840-57839dce-c0ac-4d82-94a6-33c899cd6d87.png">

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
