### PR TITLE
fix(text-button): use button color for loading, and keep opacity at 1

### DIFF
--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -353,6 +353,7 @@ export default {
 	&.loading {
 		/* don't inherit color in loading state on hover/active */
 		color: transparent !important;
+		opacity: 1;
 	}
 }
 

--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -162,6 +162,10 @@ export default {
 		& > * {
 			opacity: 0.5;
 		}
+
+		& > .Loading {
+			opacity: 1;
+		}
 	}
 
 	&.loading {
@@ -179,7 +183,7 @@ export default {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	color: var(--maker-color-neutral-90);
+	color: var(--color, var(--maker-color-neutral-90));
 	background-color: transparent;
 }
 

--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -164,6 +164,7 @@ export default {
 		}
 	}
 
+	/* stylelint-disable-next-line no-descending-specificity */
 	& > .Loading {
 		opacity: 1;
 	}

--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -162,10 +162,10 @@ export default {
 		& > * {
 			opacity: 0.5;
 		}
+	}
 
-		& > .Loading {
-			opacity: 1;
-		}
+	& > .Loading {
+		opacity: 1;
 	}
 
 	&.loading {

--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -120,6 +120,8 @@ export default {
 </script>
 
 <style module="$s">
+/* stylelint-disable no-descending-specificity */
+
 .TextButton {
 	position: relative;
 	display: inline-flex;
@@ -164,7 +166,6 @@ export default {
 		}
 	}
 
-	/* stylelint-disable-next-line no-descending-specificity */
 	& > .Loading {
 		opacity: 1;
 	}


### PR DESCRIPTION
## Describe the problem this PR addresses
Updates the loading component to use the same color as the text-button and fix the opacity to be 1.

## Describe the changes in this PR
Text button:
![image](https://user-images.githubusercontent.com/18740390/177851631-f4175e40-6d0d-49dd-837e-1505e568fbb9.png)

Loading state before fix:
![image](https://user-images.githubusercontent.com/18740390/177851940-0f99aae2-1a9d-4a01-bc2e-382755f5c83a.png)

Loading state after fix:
![image](https://user-images.githubusercontent.com/18740390/177851849-257fc39c-3566-4731-8cde-772e266bb5b1.png)
