### PR TITLE
docs: adds utils to styleguide

### DIFF
--- a/styleguide/COMPONENTS.md
+++ b/styleguide/COMPONENTS.md
@@ -1,0 +1,3 @@
+# Maker Components
+
+Browse component documentation by clicking on the links in the side navigation. All of the components can be used standalone. If you would like to theme components for a whole app you need to wrap them using the [Theme](#/Theme) component.

--- a/styleguide/INDEX.md
+++ b/styleguide/INDEX.md
@@ -1,0 +1,25 @@
+# Square Maker
+
+A mobile-first themeable Vue.js 2.x component library. Browse documentation for available components and utilities by clicking on the links in the side navigation.
+
+## 🚀 Install
+
+```sh
+# install maker
+npm i @square/maker
+```
+
+```sh
+# install peer dependencies
+npx i-peers -a
+```
+
+## Other versions
+
+You can browse every version of the styleguide that has ever been deployed by visiting the [Maker Deploys 🚀](https://square.github.io/maker/) page. You can find docs for older versions, pre-release versions, and WIP features & fixes on this page.
+
+## Other links
+
+- [Github repository](https://github.com/square/maker)
+- [Public Coda document](https://coda.io/d/Maker-Design-System_dU6uDHCPXDC/Welcome_suwju)
+- [Contributing docs](https://github.com/square/maker/blob/master/.github/CONTRIBUTING.md)

--- a/styleguide/SideNav.vue
+++ b/styleguide/SideNav.vue
@@ -1,17 +1,34 @@
 <template>
 	<div>
 		<nav class="nav">
-			<template
-				v-for="navLink in navLinks"
+			<router-link
+				to="/components"
+				class="header-link link"
 			>
-				<router-link
-					:key="navLink.path.name"
-					:to="navLink.path"
-					class="link"
-				>
-					{{ navLink.label }}
-				</router-link>
-			</template>
+				components
+			</router-link>
+			<router-link
+				v-for="componentLink in componentsLinks"
+				:key="componentLink.path.name"
+				:to="componentLink.path"
+				class="link"
+			>
+				{{ componentLink.label }}
+			</router-link>
+			<router-link
+				to="/utils"
+				class="header-link link"
+			>
+				utils
+			</router-link>
+			<router-link
+				v-for="utilLink in utilsLinks"
+				:key="utilLink.path.name"
+				:to="utilLink.path"
+				class="link"
+			>
+				{{ utilLink.label }}
+			</router-link>
 		</nav>
 	</div>
 </template>
@@ -28,22 +45,39 @@ export default {
 					path: {
 						name: route.name,
 					},
+					category: route.category,
 				}));
+		},
+		componentsLinks() {
+			return this.navLinks
+				.filter((link) => link.category === 'components');
+		},
+		utilsLinks() {
+			return this.navLinks
+				.filter((link) => link.category === 'utils');
 		},
 	},
 };
 </script>
 
 <style scoped>
-.nav a {
+.nav .link {
 	display: block;
 	color: #5f666c;
-	font-size: 14px;
+	font-size: 16px;
 	line-height: 1.75;
 	text-decoration: none;
 }
 
-.nav a:hover {
+.nav .link:hover {
 	color: #006aff;
+}
+
+.nav .header-link {
+	font-weight: 600;
+	font-size: 14px;
+	line-height: 2.5;
+	letter-spacing: 1px;
+	text-transform: uppercase;
 }
 </style>

--- a/styleguide/UTILS.md
+++ b/styleguide/UTILS.md
@@ -1,0 +1,3 @@
+# Maker Utils
+
+Browse util documentation by clicking on the links in the side navigation. The utils are used internally within Maker to help implement components, but they're also exported publically if you'd like to use them to implement your own custom components.

--- a/styleguide/create-router.js
+++ b/styleguide/create-router.js
@@ -1,30 +1,45 @@
-/* global COMPONENT_ROUTES */
+/* global COMPONENTS_ROUTES, UTILS_ROUTES */
 import Vue from 'vue';
 import Router from 'vue-router';
 import Meta from 'vue-meta';
 import VuePortal from '@linusborg/vue-simple-portal';
-import Readme from '../README.md';
+import IndexPage from './INDEX.md';
+import ComponentsPage from './COMPONENTS.md';
+import UtilsPage from './UTILS.md';
 
 Vue.use(Router);
 Vue.use(Meta);
 Vue.use(VuePortal);
 
 // eslint-disable-next-line no-unused-vars
-const importComponentDocument = (componentName) => () => import(`@square/maker/components/${componentName}/README.md`);
+const importComponentsDocument = (componentName) => () => import(`@square/maker/components/${componentName}/README.md`);
+// eslint-disable-next-line no-unused-vars
+const importUtilsDocument = (componentName) => () => import(`@square/maker/utils/${componentName}/README.md`);
 
 function createRouter() {
 	return new Router({
 		mode: 'hash',
 		routes: [
 			{
-				name: 'home',
+				name: 'index',
 				path: '/',
-				component: Readme,
+				component: IndexPage,
 			},
-			// this "constant" is generated
+			{
+				name: 'components',
+				path: '/components',
+				component: ComponentsPage,
+			},
+			{
+				name: 'utils',
+				path: '/utils',
+				component: UtilsPage,
+			},
+			// these "constants" are generated
 			// at build time and replaced with
 			// the actual routes as part of the build
-			...COMPONENT_ROUTES,
+			...COMPONENTS_ROUTES,
+			...UTILS_ROUTES,
 		],
 	});
 }


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
components in the `utils` directory were not being documented in the styleguide

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
components in the `utils` directory will now be documented in the styleguide

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
check out the new styuleguide side nav: https://square.github.io/maker/styleguide/styleguide-utils/#/

after this gets merged i wanna move all the Transition components and the TouchCapture component from the `components` directory to the `utils` directory