### PR TITLE
fix(choice): use primary button color for selected choice color

### DIFF
--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -145,7 +145,7 @@ export default function defaultTheme() {
 			},
 		},
 		choice: {
-			selectedColor: undefined,
+			selectedColor: '@button.color',
 		},
 		stepper: {
 			color: '@colors["neutral-10"]',


### PR DESCRIPTION
Closes #391

## Describe the problem this PR addresses
Currently, the selected choice colour (if not explicitly set) defaults to use the neutral-10 colour. Instead we should be defaulting to use the same colour as the primary buttons.

## Describe the changes in this PR
Defaults `choice.selectedColor` to be `@colors.button`.

### Current Version
![image](https://user-images.githubusercontent.com/3402466/179755055-110ca2ae-6a14-472d-a72f-9d2d7439623d.png)

### Fixed Version
![image](https://user-images.githubusercontent.com/3402466/179754384-312d9311-97e0-44df-9484-ce2141beb3b1.png)