### PR TITLE
fix(calendar): selected text color not visible in dark theme

### DIFF
--- a/src/components/Calendar/src/Calendar.vue
+++ b/src/components/Calendar/src/Calendar.vue
@@ -386,7 +386,7 @@ export default {
 
 	&.selected {
 		color: var(--maker-color-background, #fff);
-		background-color: var(--maker-color-primary, #000);
+		background-color: var(--maker-color-body, #000);
 	}
 
 	&.today {


### PR DESCRIPTION
## Describe the problem this PR addresses
Selected date is not visible in dark background
![Screen Shot 2022-07-20 at 3 53 04 PM](https://user-images.githubusercontent.com/7245055/180071407-3b6e9d0d-ea7b-42d0-9153-6ba53f913f4e.png)

## Describe the changes in this PR
![Screen Shot 2022-07-20 at 3 52 35 PM](https://user-images.githubusercontent.com/7245055/180071493-25f96d4b-9c61-421f-a920-aff8c88c7634.png)
![Screen Shot 2022-07-20 at 3 52 48 PM](https://user-images.githubusercontent.com/7245055/180071494-67dfebcf-36b0-4bad-9801-ea3fe88a8c77.png)

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
