### PR TITLE
feat: makes progressbar themeable

### DIFF
--- a/src/components/ProgressBar/README.md
+++ b/src/components/ProgressBar/README.md
@@ -1,8 +1,22 @@
 # Progress Bar
 
+Use Progress Bar to display progress.
+
+## Examples
+
 ```vue
 <template>
 	<div :class="$s.Container">
+		<m-text
+			pattern="title"
+			:size="2"
+		>
+			default progressbar
+		</m-text>
+		<m-progress-bar
+			:progress="progress"
+		/>
+
 		<div :class="$s.Section">
 			<label>
 				Color picker
@@ -71,14 +85,10 @@ export default {
 
 	data() {
 		return {
-			color: '#000',
+			color: '#000000',
 			progress: 50,
 		};
 	},
-
-	computed: {},
-
-	methods: {},
 };
 </script>
 
@@ -102,10 +112,18 @@ export default {
 <!-- api-tables:start -->
 ## Props
 
-| Prop     | Type     | Default    | Possible values                      | Description                                |
-| -------- | -------- | ---------- | ------------------------------------ | ------------------------------------------ |
-| size     | `string` | `'medium'` | `xsmall`, `small`, `medium`, `large` | Size (height) of the progress bar          |
-| shape    | `string` | —          | `squared`, `rounded`, `pill`         | Shape of the progress bar                  |
-| color    | `string` | `'#000'`   | —                                    | Color of the progress bar (not background) |
-| progress | `number` | `0`        | —                                    | Progress/width of the bar (0-100)          |
+Supports attributes from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div).
+
+| Prop     | Type     | Default | Possible values                      | Description                                |
+| -------- | -------- | ------- | ------------------------------------ | ------------------------------------------ |
+| pattern  | `string` | —       | —                                    | pattern defined at theme level             |
+| size     | `string` | —       | `xsmall`, `small`, `medium`, `large` | Size (height) of the progress bar          |
+| shape    | `string` | —       | `squared`, `rounded`, `pill`         | Shape of the progress bar                  |
+| color    | `string` | —       | —                                    | Color of the progress bar (not background) |
+| progress | `number` | `0`     | —                                    | Progress (width) of the bar (0 - 100)      |
+
+
+## Events
+
+Supports events from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div).
 <!-- api-tables:end -->

--- a/src/components/ProgressBar/src/ProgressBar.vue
+++ b/src/components/ProgressBar/src/ProgressBar.vue
@@ -2,14 +2,16 @@
 	<div
 		:class="[
 			$s.ProgressBarContainer,
-			$s[`size_${size}`],
-			$s[`shape_${shape}`],
+			$s[`size_${resolvedSize}`],
+			$s[`shape_${resolvedShape}`],
 		]"
+		v-bind="$attrs"
+		v-on="$listeners"
 	>
 		<div
 			:class="[
 				$s.ProgressBar,
-				$s[`shape_${shape}`],
+				$s[`shape_${resolvedShape}`],
 			]"
 			:style="barStyles"
 		/>
@@ -17,21 +19,40 @@
 </template>
 
 <script>
-import { colord } from 'colord';
+import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
+import cssValidator from '@square/maker/utils/css-validator';
 
 const MIN_PROGRESS = 0;
 const MAX_PROGRESS = 100;
 
+/**
+ * @inheritAttrs div
+ * @inheritListeners div
+ */
 export default {
-	name: 'ProgressBar',
+	inject: {
+		theme: {
+			default: defaultTheme(),
+			from: MThemeKey,
+		},
+	},
+
+	inheritAttrs: false,
 
 	props: {
+		/**
+		 * pattern defined at theme level
+		 */
+		pattern: {
+			type: String,
+			default: undefined,
+		},
 		/**
 		 * Size (height) of the progress bar
 		 */
 		size: {
 			type: String,
-			default: 'medium',
+			default: undefined,
 			validator: (size) => ['xsmall', 'small', 'medium', 'large'].includes(size),
 		},
 		/**
@@ -43,15 +64,15 @@ export default {
 			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
 		},
 		/**
-		 * Color of the progress bar (not background)
+		 * Color of the progress bar
 		 */
 		color: {
 			type: String,
-			default: '#000',
-			validator: (color) => colord(color).isValid(),
+			default: undefined,
+			validator: cssValidator('color'),
 		},
 		/**
-		 * Progress/width of the bar (0-100)
+		 * Progress (width) of the bar (0 - 100)
 		 */
 		progress: {
 			type: Number,
@@ -61,9 +82,15 @@ export default {
 	},
 
 	computed: {
+		...resolveThemeableProps('progressbar', [
+			'pattern',
+			'color',
+			'size',
+			'shape',
+		]),
 		barStyles() {
 			return {
-				'--bar-color': this.color,
+				'--bar-color': this.resolvedColor,
 				'--fill-percent': `${this.progress}%`,
 			};
 		},

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -286,6 +286,11 @@ export default function defaultTheme() {
 			iconColor: '@colors.contextualPrimary.fill',
 			iconName: undefined,
 		},
+		progressbar: {
+			color: '@colors["neutral-100"]',
+			size: 'medium',
+			shape: undefined,
+		},
 		modal: {
 			color: undefined,
 			bgColor: undefined,


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
progressbar wasn't themeable or context-aware (would become invisible on black backgrounds because the default color of the progressbar is black)

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
progressbar is now themeable and context-aware (progressbar flips to white on background backgrounds since its default color is now set to @colors["neutral-100"]

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
https://square.github.io/maker/styleguide/themeable-progressbar/#/ProgressBar