### PR TITLE
feat(starrating): is now context aware

### DIFF
--- a/src/components/StarRating/README.md
+++ b/src/components/StarRating/README.md
@@ -1,177 +1,177 @@
 # StarRating
 
+Use Star Rating to display an item's rating in stars.
+
+## Examples
+
+You can pass a number between 0.0 and 5.0 to the `rating` prop and Star Rating will render it rounded to the nearest number of half-stars:
+
 ```vue
 <template>
-	<div :class="$s.StarDemos">
-		<label>
-			Color picker
+	<div>
+		<div>
+			Rating ({{ rating }} stars):
+			<br>
 			<input
-				v-model="color"
-				type="color"
+				v-model="rating"
+				type="range"
+				min="0"
+				max="5"
+				step="0.1"
 			>
-		</label>
-		<div>
-			<m-text
-				pattern="title"
-				:class="$s.StarDemoHeader"
-				:size="1"
-			>
-				Star States
-			</m-text>
-
-			<div>
-				<div
-					v-for="fill in ['full', 'half', 'empty']"
-					:key="fill"
-					:class="$s.StarState"
-				>
-					{{ fill }}
-					<m-star
-						:fill="fill"
-						:color="color"
-					/>
-				</div>
-			</div>
 		</div>
 
-		<div>
-			<m-text
-				pattern="title"
-				:class="$s.StarDemoHeader"
-				:size="1"
-			>
-				Star Rating
-			</m-text>
-
-			<div>
-				Rating ({{ avgRating }} Stars):
-				<br>
-				<input
-					v-model="avgRating"
-					type="range"
-					min="0"
-					max="5"
-					step="0.1"
-				>
-			</div>
-
-			<div
-				v-for="size in ['small', 'medium', 'large']"
-				:key="size"
-			>
-				{{ size }}
-				<m-star-rating
-					:rating="avgRating"
-					:size="size"
-					:color="color"
-				/>
-			</div>
-		</div>
-
-		<div>
-			<m-text
-				pattern="title"
-				:class="$s.StarDemoHeader"
-				:size="1"
-			>
-				Editable Star Rating
-			</m-text>
-
-			<div>
-				Rating: ({{ formRating }} Stars)
-			</div>
-
-			<div
-				v-for="size in ['small', 'medium', 'large']"
-				:key="size"
-			>
-				{{ size }}
-				<m-star-rating
-					:rating="formRating"
-					:size="size"
-					:is-editable="true"
-					:color="color"
-					@star-click="setFormRating"
-				/>
-			</div>
+		<div
+			v-for="size in ['small', 'medium', 'large']"
+			:key="size"
+		>
+			{{ size }}
+			<m-star-rating
+				:rating="rating"
+				:size="size"
+				:color="color"
+			/>
 		</div>
 	</div>
 </template>
 
 <script>
-import { MStar, MStarRating } from '@square/maker/components/StarRating';
-import { MText } from '@square/maker/components/Text';
+import { MStarRating } from '@square/maker/components/StarRating';
 
 export default {
 	components: {
-		MStar,
 		MStarRating,
-		MText,
 	},
 	data() {
 		return {
-			avgRating: 2.5,
-			formRating: 0,
-			color: '#FFBF00',
+			rating: 2.5,
 		};
 	},
+};
+</script>
+```
 
-	methods: {
-		setFormRating(rating) {
-			this.formRating = rating;
+Star Rating can be made interactive and editable by adding the `is-editable` prop and then listening to state changes via `@star-click` event:
+
+```vue
+<template>
+	<div>
+		<div>
+			Rating: ({{ rating }} Stars)
+		</div>
+
+		<div
+			v-for="size in ['small', 'medium', 'large']"
+			:key="size"
+		>
+			{{ size }}
+			<m-star-rating
+				:rating="rating"
+				:size="size"
+				is-editable
+				@star-click="rating = $event"
+			/>
+		</div>
+	</div>
+</template>
+
+<script>
+import { MStarRating } from '@square/maker/components/StarRating';
+
+export default {
+	components: {
+		MStarRating,
+	},
+	data() {
+		return {
+			rating: 0,
+		};
+	},
+};
+</script>
+```
+
+Although Star Rating has a `color` prop, it's better to leave it omitted and let Maker's theming system the best color for the rating given contrast requirements against the background.
+
+
+```vue
+<template>
+	<m-theme :theme="theme">
+		<label>
+			background color
+			<input
+				v-model="bgColor"
+				type="color"
+			>
+		</label>
+		<m-star-rating
+			v-for="rating in [1, 2, 3, 4, 5]"
+			:key="rating"
+			:rating="rating"
+		/>
+	</m-theme>
+</template>
+
+<script>
+import { MTheme } from '@square/maker/components/Theme';
+import makerColors from '@square/maker/utils/maker-colors';
+import { MStarRating } from '@square/maker/components/StarRating';
+
+export default {
+	components: {
+		MTheme,
+		MStarRating,
+	},
+	data() {
+		return {
+			bgColor: '#ffffff',
+		};
+	},
+	computed: {
+		theme() {
+			return {
+				colors: {
+					background: this.bgColor,
+					...makerColors(this.bgColor),
+				},
+			};
 		},
 	},
 };
 </script>
-
-<style module="$s">
-.StarDemos {
-	display: flex;
-	flex-direction: column;
-	gap: 32px;
-}
-
-.StarDemoHeader {
-	margin-bottom: 8px;
-}
-
-.StarState {
-	display: inline-flex;
-	align-items: center;
-	margin-right: 8px;
-}
-</style>
 ```
 
 <!-- api-tables:start -->
 ## Star Props
 
+Supports attributes from [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/svg).
+
 | Prop  | Type     | Default     | Possible values         | Description                           |
 | ----- | -------- | ----------- | ----------------------- | ------------------------------------- |
 | fill  | `string` | `'full'`    | `full`, `half`, `empty` | Determines the fill style of the star |
-| color | `string` | `'#FFBF00'` | —                       | Color of the star                     |
+| color | `string` | `'#ffbf00'` | —                       | Color of the star                     |
 
 
 ## Star Events
 
-| Event      | Type | Description |
-| ---------- | ---- | ----------- |
-| mouseenter | -    | —           |
-| mouseleave | -    | —           |
-| click      | -    | —           |
+Supports events from [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/svg).
 
 
 ## StarRating Props
 
-| Prop        | Type      | Default     | Possible values            | Description                                                                |
-| ----------- | --------- | ----------- | -------------------------- | -------------------------------------------------------------------------- |
-| rating      | `number`  | `0`         | —                          | Rating value from 0-5, determines fill state of stars                      |
-| size        | `string`  | `'medium'`  | `small`, `medium`, `large` | Size of rating component                                                   |
-| color       | `string`  | `'#FFBF00'` | —                          | Color of the star                                                          |
-| is-editable | `boolean` | `false`     | —                          | Determines whether to bubble up click/hover events and show pointer cursor |
+Supports attributes from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div).
+
+| Prop        | Type      | Default    | Possible values            | Description                                                                |
+| ----------- | --------- | ---------- | -------------------------- | -------------------------------------------------------------------------- |
+| rating      | `number`  | `0`        | —                          | Rating value from 0-5, determines fill state of stars                      |
+| size        | `string`  | `'medium'` | `small`, `medium`, `large` | Size of rating component                                                   |
+| color       | `string`  | —          | —                          | Color of the star                                                          |
+| is-editable | `boolean` | `false`    | —                          | Determines whether to bubble up click/hover events and show pointer cursor |
 
 
 ## StarRating Events
+
+Supports events from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div).
 
 | Event        | Type | Description |
 | ------------ | ---- | ----------- |

--- a/src/components/StarRating/src/Star.vue
+++ b/src/components/StarRating/src/Star.vue
@@ -5,9 +5,8 @@
 		viewBox="0 0 16 16"
 		fill="none"
 		xmlns="http://www.w3.org/2000/svg"
-		@mouseenter="$emit('mouseenter')"
-		@mouseleave="$emit('mouseleave')"
-		@click="$emit('click')"
+		v-bind="$attrs"
+		v-on="$listeners"
 	>
 		<path
 			v-if="fill === 'full'"
@@ -17,7 +16,6 @@
 			stroke-linecap="round"
 			stroke-linejoin="round"
 		/>
-
 		<path
 			v-if="fill === 'empty'"
 			d="M8.00001 1.5L10.0433 5.00814C10.1846 5.25074 10.4214 5.42277 10.6958 5.48219L14.6636 6.34141L11.9586 9.36878C11.7716 9.57814 11.6811 9.85649 11.7094 10.1358L12.1184 14.175L8.40325 12.5379C8.14634 12.4246 7.85367 12.4246 7.59676 12.5379L3.88166 14.175L4.29062 10.1358C4.3189 9.85649 4.22846 9.57814 4.0414 9.36878L1.33637 6.34141L5.30423 5.48219C5.57862 5.42277 5.8154 5.25074 5.9567 5.00814L8.00001 1.5Z"
@@ -25,7 +23,6 @@
 			stroke-linecap="round"
 			stroke-linejoin="round"
 		/>
-
 		<template v-if="fill === 'half'">
 			<path
 				d="M8 1.5L10.0433 5.00814C10.1846 5.25074 10.4214 5.42277 10.6958 5.48219L14.6636 6.34141L11.9586 9.36878C11.7716 9.57814 11.6811 9.85648 11.7094 10.1358L12.1184 14.175L8.40325 12.5379C8.14634 12.4246 7.85367 12.4246 7.59676 12.5379L3.88166 14.175L4.29062 10.1358C4.3189 9.85649 4.22846 9.57814 4.0414 9.36878L1.33637 6.34141L5.30423 5.48219C5.57862 5.42277 5.8154 5.25074 5.9567 5.00814L8 1.5Z"
@@ -42,10 +39,14 @@
 </template>
 
 <script>
-import { colord } from 'colord';
+import cssValidator from '@square/maker/utils/css-validator';
 
+/**
+ * @inheritAttrs svg
+ * @inheritListeners svg
+ */
 export default {
-	name: 'Star',
+	inheritAttrs: false,
 
 	props: {
 		/**
@@ -61,8 +62,8 @@ export default {
 		 */
 		color: {
 			type: String,
-			default: '#FFBF00',
-			validator: (color) => colord(color).isValid(),
+			default: '#ffbf00',
+			validator: cssValidator('color'),
 		},
 	},
 };

--- a/src/components/StarRating/src/StarRating.vue
+++ b/src/components/StarRating/src/StarRating.vue
@@ -1,10 +1,14 @@
 <template>
-	<div :style="starComputedStyles">
-		<star
+	<div
+		:style="starComputedStyles"
+		v-bind="$attrs"
+		v-on="$listeners"
+	>
+		<m-star
 			v-for="star in MAX_RATING"
 			:key="star"
 			:fill="fillForStarRating(star)"
-			:color="color"
+			:color="resolvedColor"
 			:class="$s.Star"
 			@mouseenter="hoverStar(star)"
 			@mouseleave="unhoverStar(star)"
@@ -14,8 +18,9 @@
 </template>
 
 <script>
-import { colord } from 'colord';
-import Star from './Star.vue';
+import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
+import cssValidator from '@square/maker/utils/css-validator';
+import { MStar } from '@square/maker/components/StarRating';
 
 const MIN_RATING = 0;
 const MAX_RATING = 5;
@@ -36,12 +41,23 @@ const STAR_STYLES = {
 	},
 };
 
+/**
+ * @inheritAttrs div
+ * @inheritListeners div
+ */
 export default {
-	name: 'StarRating',
-
 	components: {
-		Star,
+		MStar,
 	},
+
+	inject: {
+		theme: {
+			default: defaultTheme(),
+			from: MThemeKey,
+		},
+	},
+
+	inheritAttrs: false,
 
 	props: {
 		/**
@@ -52,7 +68,6 @@ export default {
 			default: 0,
 			validator: (rating) => rating >= MIN_RATING && rating <= MAX_RATING,
 		},
-
 		/**
 		 * Size of rating component
 		 */
@@ -66,10 +81,9 @@ export default {
 		 */
 		color: {
 			type: String,
-			default: '#FFBF00',
-			validator: (color) => colord(color).isValid(),
+			default: undefined,
+			validator: cssValidator('color'),
 		},
-
 		/**
 		 * Determines whether to bubble up click/hover events and show pointer cursor
 		 */
@@ -87,6 +101,10 @@ export default {
 	},
 
 	computed: {
+		...resolveThemeableProps('starrating', [
+			'color',
+		]),
+
 		displayedRating() {
 			return this.hoveredRating || this.rating;
 		},

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -281,6 +281,9 @@ export default function defaultTheme() {
 				info: {}, // component default
 			},
 		},
+		starrating: {
+			color: '@colors.warning.fill',
+		},
 		progresscircle: {
 			color: '@colors.contextualPrimary.fill',
 			iconColor: '@colors.contextualPrimary.fill',


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
star rating was not context aware

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
star rating is now context aware, it's default color was `#ffbf00` which is the same as `@colors.warning.fill`, so i changed it to `@colors.warning.fill` so the default behavior against a white background is the same but the star rating will now change colors to improve contrast against certain backgrounds (before it just always stayed `#ffbf00` and just became unreadable or invisible)

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
nope