### PR TITLE
feat(image): add image:loaded event

### DIFF
--- a/src/components/Image/README.md
+++ b/src/components/Image/README.md
@@ -8,7 +8,7 @@
 			class="image"
 			src="https://source.unsplash.com/random/400x600"
 			:shape="shape"
-			@image:loaded="imageLoaded"
+			@image:visible="imageVisible"
 		/>
 		<m-image
 			class="image image-tall"
@@ -61,7 +61,7 @@ export default {
 	},
 
 	methods: {
-		imageLoaded() {
+		imageVisible() {
 			this.fadedInComplete = 'Fade in completed';
 		},
 	},
@@ -113,5 +113,5 @@ Supports events from [`<img>`](https://developer.mozilla.org/en-US/docs/Web/HTML
 
 | Event        | Type | Description                                        |
 | ------------ | ---- | -------------------------------------------------- |
-| image:loaded | -    | Image is loaded and fade in transition is complete |
+| image:visible | -    | Image is loaded and fade in transition is complete |
 <!-- api-tables:end -->

--- a/src/components/Image/README.md
+++ b/src/components/Image/README.md
@@ -8,6 +8,7 @@
 			class="image"
 			src="https://source.unsplash.com/random/400x600"
 			:shape="shape"
+			@image:loaded="imageLoaded"
 		/>
 		<m-image
 			class="image image-tall"
@@ -19,6 +20,8 @@
 			src="https://source.unsplash.com/random/400x600"
 			:shape="shape"
 		/>
+		<br>
+		{{ fadedInComplete }}
 		<br>
 		<label>
 			Shape
@@ -53,7 +56,14 @@ export default {
 				'circle',
 				'arch',
 			],
+			fadedInComplete: 'Fade in not completed',
 		};
+	},
+
+	methods: {
+		imageLoaded() {
+			this.fadedInComplete = 'Fade in completed';
+		},
 	},
 };
 </script>
@@ -100,4 +110,8 @@ Supports attributes from [`<img>`](https://developer.mozilla.org/en-US/docs/Web/
 ## Events
 
 Supports events from [`<img>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img).
+
+| Event        | Type | Description                                        |
+| ------------ | ---- | -------------------------------------------------- |
+| image:loaded | -    | Image is loaded and fade in transition is complete |
 <!-- api-tables:end -->

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -195,7 +195,7 @@ export default {
 		},
 
 		afterEnter() {
-			this.$emit('image:loaded');
+			this.$emit('image:visible');
 		},
 	},
 };

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -9,7 +9,7 @@
 				$s[`shape_${resolvedShape}`],
 			]"
 		/>
-		<m-transition-fade-in>
+		<m-transition-fade-in @after-enter="afterEnter">
 			<img
 				v-show="loaded"
 				:class="{
@@ -192,6 +192,10 @@ export default {
 		getImageDimensions() {
 			this.height = this.$el?.offsetHeight || '0';
 			this.width = this.$el?.offsetWidth || '0';
+		},
+
+		afterEnter() {
+			this.$emit('image:loaded');
 		},
 	},
 };


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

Currently, there is no way of knowing when the `<img>` element in an `MImage` component is not only loaded but has completed it's fade-in transition.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->

This PR adds a `image:loaded` event that is emitted when the image src is loaded and the `@after-enter` hook on the image transition is called.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
