### PR TITLE
fix(accordion): fix spacing in accordion header

### DIFF
--- a/src/components/Accordion/src/Accordion.vue
+++ b/src/components/Accordion/src/Accordion.vue
@@ -26,6 +26,7 @@
 				<!-- @slot secondary info, goes under title -->
 				<slot name="secondary">
 					<m-text
+						v-if="secondary"
 						pattern="paragraph"
 						:size="-1"
 					>
@@ -175,6 +176,7 @@ export default {
 
 <style module="$s">
 .AccordionHeader {
+	padding: 0;
 	background: none;
 	border: none;
 	cursor: pointer;


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
The Accordion header has some padding due to the browser defaults for the `button` element, as well as some spacing below the `title` slot from the text element for the `secondary` slot, even when there's no slot content.
<img width="517" alt="Screen Shot 2022-08-26 at 11 19 17 AM" src="https://user-images.githubusercontent.com/1486885/186942559-7b1688fd-4312-4f72-baaf-1d03ed2a8cc0.png">

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
This PR resets the default button padding so accordion header's contents are flush with their container and conditionally renders  the text element for secondary slot.
<img width="511" alt="Screen Shot 2022-08-26 at 11 19 49 AM" src="https://user-images.githubusercontent.com/1486885/186942901-0e822480-bb1d-4627-9766-6c3ec940cd46.png">

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
