### PR TITLE
fix(textbutton): removes active state & padding, changes focus to focus-visible

### DIFF
--- a/src/components/TextButton/README.md
+++ b/src/components/TextButton/README.md
@@ -2,7 +2,7 @@
 
 TextButton was made to be used inside the `#actions` slots of other components such as [Notice](#/Notice) or [Card](#/Card).
 
-**DO NOT** use this component if you need a visually lightweight standalone button. It has no padding. It also does not have any focus, hover, or active states. Use a tertiary [Button](#/Button).
+**DO NOT** use this component if you need a visually lightweight standalone button. It has no padding. It also does not have an active state. Use a tertiary [Button](#/Button).
 
 **DO NOT** use this component if you need to navigate the user to another page, for that use [Link](#/Link).
 
@@ -19,6 +19,14 @@ TextButton was made to be used inside the `#actions` slots of other components s
 			>
 		</label><br><br>
 		<table>
+			<thead>
+				<tr>
+					<td />
+					<th>Normal</th>
+					<th>Disabled</th>
+					<th>Loading</th>
+				</tr>
+			</thead>
 			<tbody>
 				<tr>
 					<th>
@@ -31,13 +39,17 @@ TextButton was made to be used inside the `#actions` slots of other components s
 						>
 							Button
 						</m-text-button>
+					</td>
+					<td>
 						<m-text-button
 							size="large"
 							:color="color"
 							disabled
 						>
-							Disabled button
+							Disabled
 						</m-text-button>
+					</td>
+					<td>
 						<m-text-button
 							size="large"
 							:color="color"
@@ -59,13 +71,17 @@ TextButton was made to be used inside the `#actions` slots of other components s
 						>
 							Button
 						</m-text-button>
+					</td>
+					<td>
 						<m-text-button
 							size="medium"
 							:color="color"
 							disabled
 						>
-							Disabled button
+							Disabled
 						</m-text-button>
+					</td>
+					<td>
 						<m-text-button
 							size="medium"
 							:color="color"
@@ -89,19 +105,15 @@ export default {
 	},
 	data() {
 		return {
-			color: '#000',
+			color: '#000000',
 		};
 	},
 };
 </script>
 
-<style>
-body {
-	background-color: #f9f9f9;
-}
-
-th {
-	padding-right: 32px;
+<style scoped>
+th, td {
+	padding: 8px;
 }
 </style>
 ```

--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -136,7 +136,7 @@ export default {
 	border-radius: var(--maker-shape-default-border-radius, 4px);
 	outline-color: currentColor;
 	cursor: pointer;
-	transition: box-shadow 0.2s ease-in;
+	transition: box-shadow 0.2s ease-in, opacity 0.2s ease-in;
 	user-select: none;
 	touch-action: manipulation;
 	fill: currentColor;
@@ -153,8 +153,11 @@ export default {
 		font-size: 16px;
 	}
 
-	&:active,
-	&:focus {
+	&:hover:not(:disabled) {
+		opacity: 0.8;
+	}
+
+	&:focus-visible {
 		box-shadow: 0 0 0 1px currentColor;
 	}
 

--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -127,6 +127,7 @@ export default {
 	display: inline-flex;
 	align-items: center;
 	min-width: 0;
+	padding: 0;
 	color: var(--color, var(--maker-color-neutral-90));
 	font-weight: var(--maker-font-label-font-weight, 500);
 	font-family: var(--maker-font-label-font-family, inherit);


### PR DESCRIPTION
## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
textbutton was never designed to have an :active state and it should have never been added in the first place, same goes for the over-eager :focus state, and padding inherited from browser native styles

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
removes the :active state, removes the browser native padding, and changes the :focus style to :focus-visible, also adds small :hover state (simple subtle opacity change)

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
also slightly improves the textbutton styleguide docs: https://square.github.io/maker/styleguide/fix-textbutton/#/TextButton