### PR TITLE
fix(progressbar): bg color on dark site backgrounds

### DIFF
--- a/lab/experiments/ThemeTest.vue
+++ b/lab/experiments/ThemeTest.vue
@@ -521,6 +521,18 @@
 							suffix text
 						</m-link>.
 					</div>
+					<m-divider />
+					<div>
+						<m-progress-bar
+							:progress="50"
+						/>
+						<m-progress-circle
+							:progress="50"
+						/>
+						<m-star-rating
+							:rating="3.5"
+						/>
+					</div>
 				</div>
 				<div
 					:class="$s.Preview"
@@ -633,6 +645,9 @@ import { WCAG_CONTRAST_TEXT, getContrast } from '@square/maker/utils/get-contras
 import makerColors from '@square/maker/utils/maker-colors';
 import { MLink } from '@square/maker/components/Link';
 import { MIcon } from '@square/maker/components/Icon';
+import { MProgressBar } from '@square/maker/components/ProgressBar';
+import { MProgressCircle } from '@square/maker/components/ProgressCircle';
+import { MStarRating } from '@square/maker/components/StarRating';
 
 import AlertTriangleFilled from '@square/maker-icons/AlertTriangleFilled';
 import AlertCircleFilled from '@square/maker-icons/AlertCircleFilled';
@@ -696,6 +711,9 @@ export default {
 		Info,
 		MLink,
 		MIcon,
+		MProgressBar,
+		MProgressCircle,
+		MStarRating,
 	},
 
 	mixins: [

--- a/src/components/ProgressBar/src/ProgressBar.vue
+++ b/src/components/ProgressBar/src/ProgressBar.vue
@@ -102,7 +102,7 @@ export default {
 .ProgressBarContainer {
 	width: 100%;
 	overflow: hidden;
-	background-color: #f5f4f4;
+	background-color: var(--maker-color-neutral-10, #f1f1f1);
 	border-radius: var(--maker-default-border-radius, 16px);
 
 	&.shape_squared {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
the original plan for this PR was just to add a few more components to the ThemeTest lab but while doing that I ran into a small MProgressBar bug where its background container color wasn't responsive to the theme background color, and so along with updating the ThemeTest lab i also fixed that bug in this PR

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
fixes ProgressBar container background color contrast bug against dark backgrounds

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
https://square.github.io/maker/lab/more-components-in-themetest/#/ThemeTest