### PR TITLE
fix(progresscircle): make default color same as progressbar

### DIFF
--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -285,8 +285,8 @@ export default function defaultTheme() {
 			color: '@colors.warning.fill',
 		},
 		progresscircle: {
-			color: '@colors.contextualPrimary.fill',
-			iconColor: '@colors.contextualPrimary.fill',
+			color: '@colors["neutral-100"]',
+			iconColor: '@colors["neutral-100"]',
 			iconName: undefined,
 		},
 		progressbar: {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
originally i set the default progresscircle color to the contextual primary fill color BUT progressbar uses neutral-100 as the default and i think that makes more sense and also for the sake of consistency i wanted both progress components to have similar defaults so i switched progresscircle's default color to neutral-100

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
changes progresscircle's default color to neutral-100 to be more consistent with progressbar

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
nope