### PR TITLE
ci: fail loudly when deploys push fails

### DIFF
--- a/build/deploys/push.js
+++ b/build/deploys/push.js
@@ -1,6 +1,10 @@
+/* eslint-disable no-console */
+
 const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
 const ensureDeployDirectory = require('./ensure');
+
+const EXIT_ERROR_CODE = 1;
 
 (async function pushDeploys() {
 	const deployDirectory = await ensureDeployDirectory();
@@ -18,10 +22,15 @@ const ensureDeployDirectory = require('./ensure');
 		// this would fail if the above command did not
 		// add any files to the staging index, so
 		// it's okay to let this command to fail as well
+		console.log('no files changed, nothing to push');
+		return;
 	}
 
 	// push
-	await exec('git push');
-	// the above command suceeds regardless of
-	// whether anything was actually pushed or not
+	try {
+		await exec('git push');
+	} catch {
+		console.error('failed to push changes to remote');
+		process.exit(EXIT_ERROR_CODE);
+	}
 }());

--- a/build/deploys/push.js
+++ b/build/deploys/push.js
@@ -35,5 +35,5 @@ const EXIT_ERROR_CODE = 1;
 	}
 }()).catch((error) => {
 	console.error(error.message);
-	process.exit(1);
+	process.exit(EXIT_ERROR_CODE);
 });

--- a/build/deploys/push.js
+++ b/build/deploys/push.js
@@ -33,4 +33,7 @@ const EXIT_ERROR_CODE = 1;
 		console.error('failed to push changes to remote');
 		process.exit(EXIT_ERROR_CODE);
 	}
-}());
+}()).catch((error) => {
+	console.error(error.message);
+	process.exit(1);
+});


### PR DESCRIPTION
if pushing a styleguide or lab deploy failed during CI it would fail silently which makes it hard to find in the github UI, this updates the script to fail loudly when a push fails