### PR TITLE
feat(accordion): add side slots to accordion header

### DIFF
--- a/src/components/Accordion/README.md
+++ b/src/components/Accordion/README.md
@@ -14,6 +14,8 @@ Accordions must have titles and can optionally have secondary info and content. 
 		class="container"
 		title="my accordion title"
 		secondary="optional secondary info"
+		side="side title"
+		side-secondary="side secondary info"
 	>
 		<div class="content">
 			accordion content and stuff
@@ -263,6 +265,7 @@ If you'd like to stack multiple Accordions and have at most one expanded at a ti
 			v-model="expandKey"
 			expand-key="2"
 			title="2nd Accordion"
+			side="Side title"
 		>
 			<div class="content">
 				accordion content and stuff
@@ -333,12 +336,14 @@ Supports attributes from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/
 
 ## Slots
 
-| Slot      | Description                      |
-| --------- | -------------------------------- |
-| title     | title of accordion               |
-| secondary | secondary info, goes under title |
-| icon      | open & close icon                |
-| default   | content to expand & collapse     |
+| Slot           | Description                               |
+| -------------- | ----------------------------------------- |
+| title          | title of accordion                        |
+| secondary      | secondary info, goes under title          |
+| side           | side info, goes left of open/close icon   |
+| side-secondary | side secondary info, goes under side slot |
+| icon           | open & close icon                         |
+| default        | content to expand & collapse              |
 
 
 ## Events

--- a/src/components/Accordion/src/Accordion.vue
+++ b/src/components/Accordion/src/Accordion.vue
@@ -34,6 +34,31 @@
 					</m-text>
 				</slot>
 			</template>
+			<template #side>
+				<!-- @slot side info, goes left of open/close icon -->
+				<slot name="side">
+					<m-text
+						v-if="side"
+						pattern="title"
+						:size="-2"
+						text-transform="uppercase"
+					>
+						{{ side }}
+					</m-text>
+				</slot>
+			</template>
+			<template #side-secondary>
+				<!-- @slot side secondary info, goes under side slot -->
+				<slot name="side-secondary">
+					<m-text
+						v-if="sideSecondary"
+						pattern="paragraph"
+						:size="-1"
+					>
+						{{ sideSecondary }}
+					</m-text>
+				</slot>
+			</template>
 			<template #suffix>
 				<!-- @slot open & close icon -->
 				<slot name="icon">
@@ -107,6 +132,22 @@ export default {
 		 * secondary info, will be overridden if secondary slot is used
 		 */
 		secondary: {
+			type: String,
+			required: false,
+			default: '',
+		},
+		/**
+		 * accordion side title, will be overriden if title slot is used
+		 */
+		side: {
+			type: String,
+			required: false,
+			default: '',
+		},
+		/**
+		 * secondary side info, will be overridden if side-secondary slot is used
+		 */
+		sideSecondary: {
 			type: String,
 			required: false,
 			default: '',


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
Accordion header does not have side slots

## Describe the changes in this PR
Adds side slots to the Accordion header.

<img width="529" alt="Screen Shot 2022-09-21 at 9 00 37 AM" src="https://user-images.githubusercontent.com/1486885/191510583-58175534-396c-43b7-8b41-354e9a42c39d.png">

<!--
  📸 Inline screenshots to better communicate the changes
-->

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
