### PR TITLE
fix: layer api key imports

### DIFF
--- a/src/components/Accordion/README.md
+++ b/src/components/Accordion/README.md
@@ -326,12 +326,14 @@ export default {
 
 Supports attributes from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div).
 
-| Prop       | Type             | Default | Possible values | Description                                                                           |
-| ---------- | ---------------- | ------- | --------------- | ------------------------------------------------------------------------------------- |
-| v-model    | `boolean|string` | —       | —               | if truthy or equal to expandKey the accordion will expand, otherwise it will collapse |
-| expand-key | `string`         | —       | —               | used to orchestrate the collapsing & expanding of multiple accordions                 |
-| title      | `string`         | `''`    | —               | accordion title, will be overriden if title slot is used                              |
-| secondary  | `string`         | `''`    | —               | secondary info, will be overridden if secondary slot is used                          |
+| Prop           | Type             | Default | Possible values | Description                                                                           |
+| -------------- | ---------------- | ------- | --------------- | ------------------------------------------------------------------------------------- |
+| v-model        | `boolean|string` | —       | —               | if truthy or equal to expandKey the accordion will expand, otherwise it will collapse |
+| expand-key     | `string`         | —       | —               | used to orchestrate the collapsing & expanding of multiple accordions                 |
+| title          | `string`         | `''`    | —               | accordion title, will be overriden if title slot is used                              |
+| secondary      | `string`         | `''`    | —               | secondary info, will be overridden if secondary slot is used                          |
+| side           | `string`         | `''`    | —               | accordion side title, will be overriden if title slot is used                         |
+| side-secondary | `string`         | `''`    | —               | secondary side info, will be overridden if side-secondary slot is used                |
 
 
 ## Slots

--- a/src/components/Blade/src/BladeLayer.vue
+++ b/src/components/Blade/src/BladeLayer.vue
@@ -34,8 +34,8 @@ import {
 	mobileMinWidth,
 	tabletMinWidth,
 } from '@square/maker/utils/transitions';
-import { bladeApi } from '@square/maker/components/Blade';
 import RenderFn from '@square/maker/utils/RenderFn';
+import bladeApi from './blade-api';
 
 const apiMixin = {
 	provide() {

--- a/src/components/Dialog/src/DialogLayer.vue
+++ b/src/components/Dialog/src/DialogLayer.vue
@@ -44,8 +44,8 @@ import {
 	mobileMinWidth,
 	tabletMinWidth,
 } from '@square/maker/utils/transitions';
-import { dialogApi } from '@square/maker/components/Dialog';
 import RenderFn from '@square/maker/utils/RenderFn';
+import dialogApi from './dialog-api';
 
 const apiMixin = {
 	provide() {

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -53,8 +53,8 @@ import {
 	mobileMinWidth,
 	tabletMinWidth,
 } from '@square/maker/utils/transitions';
-import { modalApi } from '@square/maker/components/Modal';
 import RenderFn from '@square/maker/utils/RenderFn';
+import modalApi from './modal-api';
 import { PopoverAPIKey } from '../../Popover/src/keys';
 
 const apiMixin = {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
the injected api keys for the layer components aren't working in Website for whatever bizarre reason... it might be that there's a subtle difference between how our dev webpack config (which builds local dev, the styleguide, and the lab) from our prod webpack config (which builds & bundles the components for use in prod) resolves api key symbol imports.

some screenshots of some stacktraces

![image](https://user-images.githubusercontent.com/7769424/191591089-4e892065-c2fb-42c8-a0ab-e4ac06798fae.png)

and

![image](https://user-images.githubusercontent.com/7769424/191591189-f8d01db3-8c7b-4e33-bebe-b3bb16115a4e.png)


## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
reverts absolute imports back to relative imports

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
i have no clue or idea how or why this would fix the issue, this is basically a shot in the dark