### PR TITLE
feat(notice): add icon slot and primary variant

### DIFF
--- a/lab/experiments/ThemeTest.vue
+++ b/lab/experiments/ThemeTest.vue
@@ -335,6 +335,9 @@
 								{{ pattern }} pill
 							</m-pill>
 						</div>
+						<m-notice pattern="primary">
+							Here's a primary notice
+						</m-notice>
 						<m-notice pattern="info">
 							Here's some info for you
 						</m-notice>
@@ -346,6 +349,12 @@
 						</m-notice>
 						<m-notice pattern="success">
 							Action has been successfully completed
+						</m-notice>
+						<m-notice
+							pattern="primary"
+							variant="block"
+						>
+							Here's a primary notice
 						</m-notice>
 						<m-notice
 							pattern="info"

--- a/src/components/Notice/README.md
+++ b/src/components/Notice/README.md
@@ -8,7 +8,30 @@ Notice has the following built-in patterns: error, warning, success, info.
 
 ```vue
 <template>
-	<div class="spaceout">
+	<m-theme
+		:theme="theme"
+		class="spaceout"
+	>
+		<label>
+			<input
+				v-model="primaryColor"
+				type="color"
+			>
+			primary color picker
+		</label><br>
+		<label>
+			<input
+				v-model="backgroundColor"
+				type="color"
+			>
+			background color picker
+		</label><br><br>
+		<m-notice pattern="primary">
+			<template #icon>
+				<plus class="icon" />
+			</template>
+			Primary inline message
+		</m-notice>
 		<m-notice pattern="error">
 			Error inline message
 		</m-notice>
@@ -22,6 +45,23 @@ Notice has the following built-in patterns: error, warning, success, info.
 			Info inline message
 		</m-notice>
 
+		<m-notice
+			pattern="primary"
+			variant="block"
+		>
+			<template #icon>
+				<plus class="icon" />
+			</template>
+			Primary block message
+			<template #actions>
+				<m-text-button pattern="primary">
+					Button
+				</m-text-button>
+				<m-text-button pattern="primary">
+					Dismiss
+				</m-text-button>
+			</template>
+		</m-notice>
 		<m-notice
 			pattern="error"
 			variant="block"
@@ -78,17 +118,38 @@ Notice has the following built-in patterns: error, warning, success, info.
 				</m-text-button>
 			</template>
 		</m-notice>
-	</div>
+	</m-theme>
 </template>
 
 <script>
 import { MNotice } from '@square/maker/components/Notice';
 import { MTextButton } from '@square/maker/components/TextButton';
+import { MTheme } from '@square/maker/components/Theme';
+import makerColors from '@square/maker/utils/maker-colors';
+import Plus from '@square/maker-icons/Plus';
 
 export default {
 	components: {
 		MNotice,
 		MTextButton,
+		Plus,
+		MTheme,
+	},
+	data() {
+		return {
+			primaryColor: '#9142ff',
+			bgColor: '#ffffff',
+		};
+	},
+	computed: {
+		theme() {
+			return {
+				colors: {
+					primary: this.primaryColor,
+					...makerColors(this.bgColor, this.primaryColor),
+				},
+			};
+		},
 	},
 };
 </script>
@@ -103,6 +164,10 @@ export default {
 .spaceout {
 	max-width: 400px;
 	padding: 16px;
+}
+.icon {
+	width: 16px;
+	height: 16px;
 }
 </style>
 ```
@@ -127,6 +192,7 @@ Supports attributes from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/
 
 | Slot    | Description           |
 | ------- | --------------------- |
+| icon    | icon in notice        |
 | default | notice content        |
 | actions | put text buttons here |
 

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -11,10 +11,13 @@
 	>
 		<div :class="$s.IconContentWrapper">
 			<div :class="$s.IconAligner">
-				<m-icon
-					:name="finalIconName"
-					:class="$s.Icon"
-				/>
+				<!-- @slot icon in notice -->
+				<slot name="icon">
+					<m-icon
+						:name="finalIconName"
+						:class="$s.Icon"
+					/>
+				</slot>
 			</div>
 			<div>
 				<!-- @slot notice content -->
@@ -183,6 +186,8 @@ export default {
 	align-items: center;
 	height: 24px;
 	margin-right: 8px;
+	color: var(--color-icon);
+	fill: var(--color-icon);
 }
 
 .Icon {

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -174,6 +174,11 @@ export default function defaultTheme() {
 		notice: {
 			type: 'info',
 			patterns: {
+				primary: {
+					iconColor: '@colors.contextualPrimary.fill',
+					color: '@colors.contextualPrimary.text',
+					bgColor: '@colors.contextualPrimary.subtle',
+				},
 				error: {
 					type: 'error',
 					iconName: 'critical',


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Notice only accepts theme icons and does not have a primary variant.
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
Adds an icon slot and primary variant for Notice.
<img width="397" alt="Screen Shot 2022-09-23 at 2 22 23 PM" src="https://user-images.githubusercontent.com/1486885/192032699-8542e31e-5ad3-4551-9157-a2cd5e335864.png">


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
