### PR TITLE
fix(choice): add wrapChoices prop

### DIFF
--- a/src/components/Choice/README.md
+++ b/src/components/Choice/README.md
@@ -229,6 +229,7 @@ export default {
 	<div class="wrapper">
 		<m-choice
 			v-model="selected"
+			wrap-choices
 		>
 			<m-choice-card value="choice-1">
 				Choice
@@ -310,6 +311,7 @@ export default {
 | disabled       | `boolean`   | `false`           | —                               | Disables choice option                                  |
 | mode           | `string`    | `'single-select'` | `single-select`, `multi-select` | Selects single choice option or multiple choice options |
 | selected-color | `string`    | —                 | —                               | Background color of a selected option                   |
+| wrap-choices   | `boolean`   | `false`           | —                               | Wraps the choice options                                |
 
 
 ## Choice Slots

--- a/src/components/Choice/src/Choice.vue
+++ b/src/components/Choice/src/Choice.vue
@@ -1,6 +1,9 @@
 <template>
 	<div
-		:class="$s.Choice"
+		:class="{
+			[$s.Choice]: true,
+			[$s.wrapChoices]: wrapChoices
+		}"
 		:style="style"
 	>
 		<slot />
@@ -68,6 +71,13 @@ export default {
 			type: String,
 			default: undefined,
 			validator: (color) => colord(color).isValid,
+		},
+		/**
+		 * Wraps the choice options
+		 */
+		wrapChoices: {
+			type: Boolean,
+			default: false,
 		},
 	},
 
@@ -156,12 +166,15 @@ export default {
 	--line-height: 24px;
 
 	display: flex;
-	flex-wrap: wrap;
 	gap: 8px;
 	box-sizing: border-box;
 	font-weight: var(--maker-font-label-font-weight, 500);
 	font-size: var(--font-size);
 	font-family: var(--maker-font-label-font-family, inherit);
 	line-height: var(--line-height);
+
+	&.wrapChoices {
+		flex-wrap: wrap;
+	}
 }
 </style>


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Wrapping the Choice container introduced a breaking change in the component behavior when the Choice component was used in a parent Carousel component and users of Choice were explicitly relying on Choice NOT to wrap.

<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
Adds `wrapChoices` as a prop so wrapping of Choice options can be turned on/off.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
