### PR TITLE
refactor!: changes primary default color from #000 to #006aff

### DIFF
--- a/lab/experiments/ThemeTest.vue
+++ b/lab/experiments/ThemeTest.vue
@@ -649,6 +649,7 @@
 </template>
 
 <script>
+/* eslint-disable no-console */
 import { MTheme, defaultTheme } from '@square/maker/components/Theme';
 import { MChoice, MChoiceOption } from '@square/maker/components/Choice';
 import { MDivider } from '@square/maker/components/Divider';
@@ -920,6 +921,8 @@ export default {
 					},
 				},
 			};
+			// console.log({ theme });
+			// console.log({ defaultMakerColors: makerColors() });
 			return theme;
 		},
 	},

--- a/src/components/Theme/src/default-colors.js
+++ b/src/components/Theme/src/default-colors.js
@@ -13,13 +13,13 @@ module.exports = function defaultColors() {
 		heading: '#000000',
 		body: '#000000',
 		elevation: '#ffffff',
-		overlay: 'rgba(0, 0, 0, 0.3)',
-		primary: '#000000',
+		overlay: 'rgba(0, 0, 0, 0.32)',
+		primary: '#006aff',
 		contextualPrimary: {
-			fill: '#000000',
+			fill: '#006aff',
 			onFill: '#ffffff',
-			text: '#000000',
-			subtle: '#f5efef',
+			subtle: '#eff2f5',
+			text: '#1c54c7',
 		},
 		critical: {
 			fill: '#cd2026',


### PR DESCRIPTION
## breaking changes
- changes default primary color from `#000000` to `#006aff` (so styleguide examples look better)
  - this will not have any impact on our end users, all of which use the Theme component in their apps and already explicitly override the primary color
- updates corresponding derived contextual primary colors as well
  - also will not impact our end users for the same reasons as above
- changes default overlay color from `rgb(0, 0, 0, 0.3)` to `rgb(0, 0, 0, 0.32)` (as this is what was being computed and set by maker-colors.js)
  - also will not impact our end users for the same reasons above
- updates maker-colors.js to assume the primary color is `#006aff` instead of `#000000` is none is provided (so it matches the default theme)
  - assuming end users already updated their code from `makerColors(background)` to `makerColors(background, primary)` which they likely did months ago then this change should also have no impact on them
- updates maker-colors.js to also return the `primary` color
  - might possibly have a very very small impact in some rare unlikely edge cases (1)
- updates maker-colors.js to also always set the `onFill` color for each contextual color (before it wasn't)
  - again, might possibly have a very very small impact in some rare unlikely edge cases (2)
  
(1) end users code might break if they compute their themes using a different primary color to calculate their contextual primary colors than the one they set in their theme:

```js
// this would break after this PR is released
theme = {
  primary: primaryColor1,
  ...makerColors(bgColor, primaryColor2),
};
```

I'm pretty sure nobody is doing this though, and if they really really wanted to do this they would be able to continue to do so by just rearranging the fields in the object assignment:

```js
// this would continue to work the same after this PR is released
theme = {
  ...makerColors(bgColor, primaryColor2),
  primary: primaryColor1,
};
```

(2) I'm not sure why this wasn't happening already, must have been overlooked after some refactors, but maker-colors.js should always be generating all of the contextual colors, including `onFill`. At the time of this PR it wasn't, and was instead inheriting from the default theme... which isn't a good idea since there are subtle edge cases where things can break or look wrong, so it's better to just have maker-colors.js generate everything, including the `onFill` color, in all situations, which it does so now. I highly highly doubt anyone was exploiting this weird gap in our code and I highly highly doubt this would have any impact on any real-world end-user code.