### PR TITLE
ci: increase deploy styleguide & lab job success rate

### DIFF
--- a/.github/workflows/deploy-styleguide-lab.yml
+++ b/.github/workflows/deploy-styleguide-lab.yml
@@ -11,6 +11,7 @@ jobs:
   deploy-styleguide-lab:
     name: Deploy Styleguide & Lab
     runs-on: ubuntu-latest
+    concurrency: changes-deploys
 
     steps:
       - name: Checkout Maker master branch
@@ -35,7 +36,7 @@ jobs:
           git config user.email github-actions@github.com
           cd ..
           export DEPLOY_NAME=git_branch
-          npm run deploy-all
+          npm run deploy-all-ci
       - name: Comment Styleguide & Lab links on PR
         uses: pretzelhammer/comment-on-pr@master
         env:

--- a/.github/workflows/deploy-styleguide-lab.yml
+++ b/.github/workflows/deploy-styleguide-lab.yml
@@ -41,5 +41,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: ${{ format('Deployed [Styleguide](https://square.github.io/maker/styleguide/{0}/#/) and [Lab](https://square.github.io/maker/lab/{0}/#/).<br><details><summary>Notes</summary><ol><li>Links may take a few minutes to update after PR is opened or commit is pushed.</li><li>Links may become invalidated after PR is merged or closed.</li><li>Links for all releases and open PRs can be found on the <a href="https://square.github.io/maker/">Maker Deploys 🚀</a> page.</li></ol></details>', github.head_ref) }}
+          msg: ${{ format('Deployed [Styleguide](https://square.github.io/maker/styleguide/{0}/#/) and [Lab](https://square.github.io/maker/lab/{0}/#/).<br><details><summary>Notes</summary><ol><li>Links may take a few minutes to update after PR is opened or commit is pushed.</li><li>Links may become invalidated after PR is merged or closed.</li><li>Links for all releases and open PRs can be found on the <a href="https://square.github.io/maker/">Maker Deploys</a> page.</li></ol></details>', github.head_ref) }}
           check_for_duplicate_msg: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency: changes-deploys
+
     steps:
       - name: Checkout Maker master branch
         uses: actions/checkout@v2
@@ -37,4 +39,4 @@ jobs:
           git config user.email github-actions@github.com
           cd ..
           export DEPLOY_NAME=library_version
-          npm run deploy-all
+          npm run deploy-all-ci

--- a/.github/workflows/remove-styleguide-lab.yml
+++ b/.github/workflows/remove-styleguide-lab.yml
@@ -15,6 +15,7 @@ jobs:
   remove-styleguide-lab:
     name: Remove Styleguide & Lab
     runs-on: ubuntu-latest
+    concurrency: changes-deploys
 
     steps:
       - name: Checkout Maker deploys branch

--- a/build/deploys/pull.js
+++ b/build/deploys/pull.js
@@ -1,11 +1,18 @@
+/* eslint-disable no-console */
+
 const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
 const ensureDeployDirectory = require('./ensure');
+
+const EXIT_ERROR_CODE = 1;
 
 (async function pullDeploys() {
 	const deployDirectory = await ensureDeployDirectory();
 	process.chdir(deployDirectory);
 
 	// pull
-	await exec('git pull');
-}());
+	await exec('git pull --rebase');
+}()).catch((error) => {
+	console.error(error.message);
+	process.exit(EXIT_ERROR_CODE);
+});

--- a/build/deploys/push.js
+++ b/build/deploys/push.js
@@ -4,6 +4,7 @@ const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
 const ensureDeployDirectory = require('./ensure');
 
+const EXIT_SUCCESS_CODE = 0;
 const EXIT_ERROR_CODE = 1;
 
 (async function pushDeploys() {
@@ -22,16 +23,40 @@ const EXIT_ERROR_CODE = 1;
 		// this would fail if the above command did not
 		// add any files to the staging index, so
 		// it's okay to let this command to fail as well
-		console.log('no files changed, nothing to push');
-		return;
+		// and we exit early successfully
+		console.log('no files changed, nothing to push, exiting early');
+		process.exit(EXIT_SUCCESS_CODE);
+	}
+
+	// pull
+	try {
+		// this command isn't strictly necessary, but it reduces
+		// the failure rate of the next command which is necessary,
+		// so it's worth running
+		await exec('git pull --rebase');
+		// if local is up-to-date with remote, or if remote's changes
+		// can be auto-merged into local, then this command succeeds
+	} catch (error) {
+		// if this command fails then the next would certainly fail,
+		// so we log the error and exit early unsuccessfully
+		console.error('remote had changes we couldn\'t auto-merge locally');
+		throw error;
 	}
 
 	// push
 	try {
 		await exec('git push');
-	} catch {
+	} catch (error) {
+		// this command usually only fails if remote has
+		// changes that we don't have locally, which usually
+		// only occurs if multiple CI jobs which push changes
+		// to the "deploys" branch are run within the same
+		// few minutes of each other, there's no automatic
+		// way to solve these failures, an engineer just has
+		// to notice that the job failed and manually re-run it
+		// from the github UI 🤷
 		console.error('failed to push changes to remote');
-		process.exit(EXIT_ERROR_CODE);
+		throw error;
 	}
 }()).catch((error) => {
 	console.error(error.message);

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -93,6 +93,7 @@ const BUILT_INDEX = `
 			color: black;
 			background-color: white;
 			font-family: var(--sans-serif-stack);
+			padding: 0 16px;
 		}
 		h1, h2, h3, h4, h5, h6 {
 			margin: 0 0 0.5em 0;
@@ -120,7 +121,7 @@ const BUILT_INDEX = `
 		}
 		.categories {
 			gap: 32px;
-			margin-bottom: 16px;
+			margin: 16px 0;
 		}
 		.deploy-links {
 			margin: 0;

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -110,6 +110,9 @@ const BUILT_INDEX = `
 			color: white;
 			background-color: black;
 		}
+		.updated-msg {
+			font-style: italic;
+		}
 		.categories, .subcategories {
 			display: flex;
 			flex-wrap: wrap;
@@ -169,6 +172,28 @@ const BUILT_INDEX = `
 <body>
 	<h1><a class="maker-link" href="https://github.com/square/maker" target="_blank" rel="noopener noreferrer">Maker</a> Deploys</h1>
 
+	<span class="updated-msg">
+		Last updated on <span class="updated-absolute"></span> (<span class="updated-relative"></span>).
+	</span>
+	<script>
+		// calc absolute time in locale
+		const lastUpdated = new Date(${Date.now()});
+		document
+			.querySelector('.updated-absolute')
+			.innerText = lastUpdated.toLocaleString();
+
+		// calc relative time in locale
+		// https://github.com/yairEO/relative-time/blob/v1.0.2/relative-time.min.js
+		!function(e,t){var o=o||{};"function"==typeof o&&o.amd?o([],t):"object"==typeof exports&&"object"==typeof module?module.exports=t():"object"==typeof exports?exports.RelativeTime=t():e.RelativeTime=t()}(this,(function(){const e={year:31536e6,month:2628e6,day:864e5,hour:36e5,minute:6e4,second:1e3},t="en",o={numeric:"auto"};function n(e){e={locale:(e=e||{}).locale||t,options:{...o,...e.options}},this.rtf=new Intl.RelativeTimeFormat(e.locale,e.options)}return n.prototype={from(t,o){const n=t-(o||new Date);for(let t in e)if(Math.abs(n)>e[t]||"second"==t)return this.rtf.format(Math.round(n/e[t]),t)}},n}));
+		// adds RelativeTime to global scope
+		// https://github.com/yairEO/relative-time/tree/v1.0.2
+
+		const relativeTime = new RelativeTime();
+		document
+			.querySelector('.updated-relative')
+			.innerText = relativeTime.from(lastUpdated);
+	</script>
+
 	<div class="categories">
 		<div class="category">
 			<h2>Styleguides</h2>
@@ -176,13 +201,13 @@ const BUILT_INDEX = `
 				<div class="subcategory">
 					<h3>Releases</h3>
 					<ul class="deploy-links">
-${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isVersion), true)}
+						${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isVersion), true)}
 					</ul>
 				</div>
 				<div class="subcategory">
 					<h3>PRs</h3>
 					<ul class="deploy-links">
-${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isntVersion))}
+						${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isntVersion))}
 					</ul>
 				</div>
 			</div>
@@ -194,13 +219,13 @@ ${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isn
 				<div class="subcategory">
 					<h3>Releases</h3>
 					<ul class="deploy-links">
-${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isVersion), true)}
+						${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isVersion), true)}
 					</ul>
 				</div>
 				<div class="subcategory">
 					<h3>PRs</h3>
 					<ul class="deploy-links">
-${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isntVersion))}
+						${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isntVersion))}
 					</ul>
 				</div>
 			</div>

--- a/build/generate-deploy-index/index.js
+++ b/build/generate-deploy-index/index.js
@@ -82,9 +82,17 @@ const BUILT_INDEX = `
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🚀</text></svg>">
+	<title>Maker Deploys</title>
 	<style>
+		:root {
+			--sans-serif-stack: system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue","Noto Sans","Liberation Sans",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
+			--monospace-stack: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+		}
 		body {
-			font-family: sans-serif;
+			color: black;
+			background-color: white;
+			font-family: var(--sans-serif-stack);
 		}
 		h1, h2, h3, h4, h5, h6 {
 			margin: 0 0 0.5em 0;
@@ -115,7 +123,7 @@ const BUILT_INDEX = `
 			margin: 0;
 			padding: 0;
 			list-style-type: none;
-			font-family: monospace;
+			font-family: var(--monospace-stack);
 			font-size: 16px;
 		}
 		.deploy-link {
@@ -133,13 +141,33 @@ const BUILT_INDEX = `
 		.deploy-link:hover:visited {
 			background-color: purple;
 		}
-		.updated-msg {
-			font-style: italic;
+		@media (prefers-color-scheme: dark) {
+			body {
+				color: white;
+				background-color: black;
+			}
+			.maker-link:hover {
+				color: black;
+				background-color: white;
+			}
+			.deploy-link {
+				color: cyan;
+			}
+			.deploy-link:visited {
+				color: violet;
+			}
+			.deploy-link:hover {
+				color: black;
+				background-color: cyan;
+			}
+			.deploy-link:hover:visited {
+				background-color: violet;
+			}
 		}
 	</style>
 </head>
 <body>
-	<h1><a class="maker-link" href="https://github.com/square/maker" target="_blank" rel="noopener noreferrer">Maker</a> Deploys 🚀</h1>
+	<h1><a class="maker-link" href="https://github.com/square/maker" target="_blank" rel="noopener noreferrer">Maker</a> Deploys</h1>
 
 	<div class="categories">
 		<div class="category">
@@ -148,13 +176,13 @@ const BUILT_INDEX = `
 				<div class="subcategory">
 					<h3>Releases</h3>
 					<ul class="deploy-links">
-						${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isVersion), true)}
+${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isVersion), true)}
 					</ul>
 				</div>
 				<div class="subcategory">
 					<h3>PRs</h3>
 					<ul class="deploy-links">
-						${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isntVersion))}
+${toDeployLinks(STYLEGUIDE_URL_PREFIX, URL_SUFFIX, STYLEGUIDE_DEPLOYS.filter(isntVersion))}
 					</ul>
 				</div>
 			</div>
@@ -166,29 +194,18 @@ const BUILT_INDEX = `
 				<div class="subcategory">
 					<h3>Releases</h3>
 					<ul class="deploy-links">
-						${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isVersion), true)}
+${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isVersion), true)}
 					</ul>
 				</div>
 				<div class="subcategory">
 					<h3>PRs</h3>
 					<ul class="deploy-links">
-						${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isntVersion))}
+${toDeployLinks(LAB_URL_PREFIX, URL_SUFFIX, LAB_DEPLOYS.filter(isntVersion))}
 					</ul>
 				</div>
 			</div>
 		</div>
 	</div>
-
-	<span class="updated-msg">
-		Last updated on <span class="updated-time"></span>
-	</span>
-
-	<script>
-		const lastUpdated = new Date(${Date.now()});
-		document
-			.querySelector('.updated-time')
-			.innerText = lastUpdated.toLocaleString();
-	</script>
 </body>
 </html>
 `;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "styleguide-deploy": "npm run pull-deploys && npm run styleguide-build && npm run sync-to-latest && npm run generate-deploy-index && npm run push-deploys",
     "generate-deploy-index": "node ./build/generate-deploy-index",
     "deploy-all": "npm run pull-deploys && npm run lab-build && npm run styleguide-build && npm run sync-to-latest && npm run generate-deploy-index && npm run push-deploys",
+		"deploy-all-ci": "npm run lab-build && npm run styleguide-build && npm run sync-to-latest && npm run generate-deploy-index && npm run push-deploys",
     "lint": "npm run lint:js && npm run lint:css",
     "lint:js": "eslint --format=pretty --ext vue,js,md --cache src lab styleguide build",
     "lint:css": "stylelint src/**/*.{vue,css}",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "styleguide-deploy": "npm run pull-deploys && npm run styleguide-build && npm run sync-to-latest && npm run generate-deploy-index && npm run push-deploys",
     "generate-deploy-index": "node ./build/generate-deploy-index",
     "deploy-all": "npm run pull-deploys && npm run lab-build && npm run styleguide-build && npm run sync-to-latest && npm run generate-deploy-index && npm run push-deploys",
-		"deploy-all-ci": "npm run lab-build && npm run styleguide-build && npm run sync-to-latest && npm run generate-deploy-index && npm run push-deploys",
+    "deploy-all-ci": "npm run lab-build && npm run styleguide-build && npm run sync-to-latest && npm run generate-deploy-index && npm run push-deploys",
     "lint": "npm run lint:js && npm run lint:css",
     "lint:js": "eslint --format=pretty --ext vue,js,md --cache src lab styleguide build",
     "lint:css": "stylelint src/**/*.{vue,css}",

--- a/styleguide/INDEX.md
+++ b/styleguide/INDEX.md
@@ -16,7 +16,7 @@ npx i-peers -a
 
 ## Other versions
 
-You can browse every version of the styleguide that has ever been deployed by visiting the [Maker Deploys 🚀](https://square.github.io/maker/) page. You can find docs for older versions, pre-release versions, and WIP features & fixes on this page.
+You can browse every version of the styleguide that has ever been deployed by visiting the [Maker Deploys](https://square.github.io/maker/) page. You can find docs for older versions, pre-release versions, and WIP features & fixes on this page.
 
 ## Other links
 


### PR DESCRIPTION
## Describe the problem this PR addresses
so the deploy styleguide & lab job already had a very high success rate, the only times it would fail is if multiple instances of the job were run in parallel, in which case the first job to finish would complete successfully but all of the following jobs would fail because they would attempt to push their changes to remote but remote had changes that they didn't have locally so they would fail to push their changes and thus the job as a whole would fail

## Describe the changes in this PR
adds a `git pull --rebase` right before the `git push` to increase the success rate of the job, it'll still sometimes fail, but in general should fail much much less often as the pushes of independent jobs rarely conflict with each other and can be auto-merged

also, while poking around, i also made some CSS improvements to the Maker Deploys page, including styles for people who prefer dark mode (like myself)

## Other information
nope