### PR TITLE
refactor(notice)!: renames variant prop to display

### DIFF
--- a/lab/experiments/ThemeTest.vue
+++ b/lab/experiments/ThemeTest.vue
@@ -303,7 +303,7 @@
 						</m-card>
 						<m-notice
 							type="info"
-							variant="block"
+							display="block"
 						>
 							Switching to shipping will change the scheduled time you selected
 						</m-notice>
@@ -352,31 +352,31 @@
 						</m-notice>
 						<m-notice
 							pattern="primary"
-							variant="block"
+							display="block"
 						>
 							Here's a primary notice
 						</m-notice>
 						<m-notice
 							pattern="info"
-							variant="block"
+							display="block"
 						>
 							Here's some info for you
 						</m-notice>
 						<m-notice
 							pattern="error"
-							variant="block"
+							display="block"
 						>
 							There has been error notice
 						</m-notice>
 						<m-notice
 							pattern="warning"
-							variant="block"
+							display="block"
 						>
 							Warning please take note
 						</m-notice>
 						<m-notice
 							pattern="success"
-							variant="block"
+							display="block"
 						>
 							Action has been successfully completed
 						</m-notice>

--- a/src/components/ActionBar/src/ActionBarButton.vue
+++ b/src/components/ActionBar/src/ActionBarButton.vue
@@ -149,7 +149,7 @@ export default {
 		align: {
 			type: String,
 			default: undefined,
-			validator: (variant) => ['center', 'stack', 'space-between'].includes(variant),
+			validator: (align) => ['center', 'stack', 'space-between'].includes(align),
 		},
 		/**
 		 * Toggles button loading state

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -175,7 +175,7 @@ export default {
 		align: {
 			type: String,
 			default: undefined,
-			validator: (variant) => ['center', 'stack', 'space-between'].includes(variant),
+			validator: (align) => ['center', 'stack', 'space-between'].includes(align),
 		},
 		/**
 		 * Toggles button loading state

--- a/src/components/Notice/README.md
+++ b/src/components/Notice/README.md
@@ -4,7 +4,7 @@ Use Notice to notify users of things.
 
 ## Examples
 
-Notice has the following built-in patterns: error, warning, success, info.
+Notice has the following built-in patterns: primary, error, warning, success, info.
 
 ```vue
 <template>
@@ -21,7 +21,7 @@ Notice has the following built-in patterns: error, warning, success, info.
 		</label><br>
 		<label>
 			<input
-				v-model="backgroundColor"
+				v-model="bgColor"
 				type="color"
 			>
 			background color picker
@@ -47,7 +47,7 @@ Notice has the following built-in patterns: error, warning, success, info.
 
 		<m-notice
 			pattern="primary"
-			variant="block"
+			display="block"
 		>
 			<template #icon>
 				<plus class="icon" />
@@ -64,7 +64,7 @@ Notice has the following built-in patterns: error, warning, success, info.
 		</m-notice>
 		<m-notice
 			pattern="error"
-			variant="block"
+			display="block"
 		>
 			Error block message
 			<template #actions>
@@ -78,7 +78,7 @@ Notice has the following built-in patterns: error, warning, success, info.
 		</m-notice>
 		<m-notice
 			pattern="success"
-			variant="block"
+			display="block"
 		>
 			Success block message
 			<template #actions>
@@ -92,7 +92,7 @@ Notice has the following built-in patterns: error, warning, success, info.
 		</m-notice>
 		<m-notice
 			pattern="warning"
-			variant="block"
+			display="block"
 		>
 			Warning block message
 			<template #actions>
@@ -106,7 +106,7 @@ Notice has the following built-in patterns: error, warning, success, info.
 		</m-notice>
 		<m-notice
 			pattern="info"
-			variant="block"
+			display="block"
 		>
 			Info block message
 			<template #actions>
@@ -181,7 +181,7 @@ Supports attributes from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/
 | ---------- | -------- | ---------- | ------------------------------------- | ---------------------------------- |
 | pattern    | `string` | —          | —                                     | pattern defined at theme level     |
 | type       | `string` | —          | `error`, `success`, `warning`, `info` | type of notice                     |
-| variant    | `string` | `'inline'` | `inline`, `block`                     | notice variant                     |
+| display    | `string` | `'inline'` | `inline`, `block`                     | notice display                     |
 | icon-name  | `string` | —          | —                                     | name of icon, defined in theme     |
 | icon-color | `string` | —          | —                                     | icon color                         |
 | color      | `string` | —          | —                                     | text color for inline notices      |

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -3,7 +3,7 @@
 		:class="[
 			$s.Notice,
 			$s[`type_${resolvedType}`],
-			$s[`variant_${variant}`],
+			$s[`display_${display}`],
 		]"
 		:style="style"
 		v-bind="$attrs"
@@ -75,12 +75,12 @@ export default {
 			validator: (type) => ['error', 'success', 'warning', 'info'].includes(type),
 		},
 		/**
-		 * notice variant
+		 * notice display
 		 */
-		variant: {
+		display: {
 			type: String,
 			default: 'inline',
-			validator: (variant) => ['inline', 'block'].includes(variant),
+			validator: (display) => ['inline', 'block'].includes(display),
 		},
 		/**
 		 * name of icon, defined in theme
@@ -140,10 +140,10 @@ export default {
 			return 'info';
 		},
 		showActions() {
-			return this.$slots.actions && this.variant === 'block';
+			return this.$slots.actions && this.display === 'block';
 		},
 		style() {
-			const textColor = this.variant === 'inline'
+			const textColor = this.display === 'inline'
 				? this.resolvedColor
 				: 'var(--maker-color-neutral-90, #1b1b1b)';
 			return {
@@ -155,7 +155,7 @@ export default {
 	},
 
 	created() {
-		assert.warn(!(this.variant === 'inline' && this.$slots.actions), 'inline Notices cannot have an actions slot');
+		assert.warn(!(this.display === 'inline' && this.$slots.actions), 'inline Notices cannot have an actions slot');
 	},
 };
 </script>
@@ -222,7 +222,7 @@ export default {
 	--color-bg: $maker-color-neutral-10;
 }
 
-.variant_block {
+.display_block {
 	padding: 16px;
 	background-color: var(--color-bg);
 }


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
Notice's `variant` prop did not function like any other `variant` prop on any other component, so we're renaming it to `display` since it functions more like the CSS `display` property

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
in answer above

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
this is a breaking change and all users of maker will have to grep their codebase for `<m-notice variant="block">` and `<m-notice variant="inline">` and change them to `<m-notice display="block">` and `<m-notice display="inline">` respectively.