### PR TITLE
feat(menu): add open and close events for menu, click events for menu-option

### DIFF
--- a/src/components/Menu/README.md
+++ b/src/components/Menu/README.md
@@ -227,4 +227,11 @@ export default {
 | side           | —           |
 | side-secondary | —           |
 | suffix         | —           |
+
+
+## MenuOption Events
+
+| Event        | Type | Description |
+| ------------ | ---- | ----------- |
+| option:click | -    | —           |
 <!-- api-tables:end -->

--- a/src/components/Menu/README.md
+++ b/src/components/Menu/README.md
@@ -197,6 +197,8 @@ export default {
 
 | Event       | Type | Description |
 | ----------- | ---- | ----------- |
+| menu:open   | -    | —           |
+| menu:close  | -    | —           |
 | menu:update | -    | —           |
 
 

--- a/src/components/Menu/src/Menu.vue
+++ b/src/components/Menu/src/Menu.vue
@@ -7,6 +7,8 @@
 		<m-popover
 			ref="popover"
 			placement="bottom-start"
+			@open="$emit('menu:open')"
+			@close="$emit('menu:close')"
 		>
 			<template #action="popover">
 				<select-control

--- a/src/components/Menu/src/MenuOption.vue
+++ b/src/components/Menu/src/MenuOption.vue
@@ -125,6 +125,8 @@ export default {
 			}
 
 			this.controlState.currentValue = currentValue;
+
+			this.$emit('option:click');
 		},
 
 		handleKeyboardEvent(event) {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Emit events when Menu is opened or closed, which are currently not available

<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
* Add `menu:open` and `menu:close` emitted when implemented `Popover` component is opened or closed
* Add `option:click` event when a `MenuOption` component is clicked or enter is pressed
<!--
  📸 Inline screenshots to better communicate the changes
-->

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
