### PR TITLE
fix(stepper): clicking off manual input without changing value now works

### DIFF
--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -25,8 +25,8 @@
 				:max="max"
 				type="number"
 				inputmode="numeric"
-				align="center"
 				@change="commitManualValue"
+				@blur="commitManualValue"
 			>
 			<span
 				:class="[
@@ -178,7 +178,6 @@ export default {
 			event.preventDefault();
 			event.stopPropagation();
 
-			// eslint-disable-next-line no-magic-numbers
 			const newValue = Math.round(Number.parseFloat(this.manualValue, BASE_TEN));
 			this.isSettingManualValue = false;
 


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
clicking on the stepper to manually input would break the stepper IF you clicked off the manual input without first changing the value

look up `MAKER-197` on jira for more detailed info

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
catches this edge case so now it works as expected

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
nope