### PR TITLE
fix(stepper): clicking off manual input without changing value now works (#450)

### DIFF
--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -25,8 +25,8 @@
 				:max="max"
 				type="number"
 				inputmode="numeric"
-				align="center"
 				@change="commitManualValue"
+				@blur="commitManualValue"
 			>
 			<span
 				:class="[
@@ -178,7 +178,6 @@ export default {
 			event.preventDefault();
 			event.stopPropagation();
 
-			// eslint-disable-next-line no-magic-numbers
 			const newValue = Math.round(Number.parseFloat(this.manualValue, BASE_TEN));
 			this.isSettingManualValue = false;
 


### PR DESCRIPTION
backports this pr https://github.com/square/maker/pull/450 which was released on 15.x to 14.x