### PR TITLE
fix(modal): closing bugs

### DIFF
--- a/lab/App.vue
+++ b/lab/App.vue
@@ -19,6 +19,6 @@ export default {
 <style>
 body {
 	margin: 0;
-	background-color: #f8f8fb;
+	font-family: -apple-system, 'Helvetica Neue', sans-serif;
 }
 </style>

--- a/lab/components/MultiModal.vue
+++ b/lab/components/MultiModal.vue
@@ -80,17 +80,18 @@
 			async beforeClose hooks: mixed
 			<br>
 			<button @click="openNested({ propSync: false, propReturn: true, optSync: false, optReturn: false })">
-				async prop: true, sync option: false
+				async prop: true, async option: false
 			</button>
 			<br>
 			<button @click="openNested({ propSync: false, propReturn: false, optSync: false, optReturn: true })">
-				async prop: false, sync option: true
+				async prop: false, async option: true
 			</button>
 			<br>
 			mixed a/sync beforeClose hooks: mixed
 			<br>
-			<!-- todo implement this part -->
-
+			<button @click="openNested({ propSync: false, propReturn: true, optSync: false, optReturn: false })">
+				async prop: true, sync option: false
+			</button>
 			<br>
 			closing via popover
 			<br>

--- a/lab/components/MultiModal.vue
+++ b/lab/components/MultiModal.vue
@@ -89,7 +89,7 @@
 			<br>
 			mixed a/sync beforeClose hooks: mixed
 			<br>
-			<button @click="openNested({ propSync: false, propReturn: true, optSync: false, optReturn: false })">
+			<button @click="openNested({ propSync: false, propReturn: true, optSync: true, optReturn: false })">
 				async prop: true, sync option: false
 			</button>
 			<br>

--- a/lab/components/MultiModal.vue
+++ b/lab/components/MultiModal.vue
@@ -1,82 +1,232 @@
 <template>
-	<m-modal>
+	<!-- eslint-disable max-len -->
+	<m-modal :before-close="beforeClose">
 		<m-modal-content>
+			depth: {{ depth }}
+			<br>
+			no beforeClose hooks
+			<br>
 			<button @click="openNested">
-				open nested modal with no beforeClose hook
+				no beforeClose hooks
 			</button>
-			<button @click="openNestedHook({sync: true, returns: true})">
-				open nested modal with sync beforeClose hook that returns true
+			<br>
+			sync beforeClose hooks: true
+			<br>
+			<button @click="openNested({ propSync: true, propReturn: true })">
+				sync prop: true
 			</button>
-			<button @click="openNestedHook({sync: true, returns: false})">
-				open nested modal with sync beforeClose hook that returns false
+			<br>
+			<button @click="openNested({ optSync: true, optReturn: true })">
+				sync option: true
 			</button>
-			<button @click="openNestedHook({sync: false, returns: true})">
-				open nested modal with async beforeClose hook that returns true
+			<br>
+			<button @click="openNested({ propSync: true, propReturn: true, optSync: true, optReturn: true })">
+				sync prop & option: true
 			</button>
-			<button @click="openNestedHook({sync: false, returns: false})">
-				open nested modal with async beforeClose hook that returns false
+			<br>
+			sync beforeClose hooks: false
+			<br>
+			<button @click="openNested({ propSync: true, propReturn: false })">
+				sync prop: false
 			</button>
+			<br>
+			<button @click="openNested({ optSync: true, optReturn: false })">
+				sync option: false
+			</button>
+			<br>
+			<button @click="openNested({ propSync: true, propReturn: false, optSync: true, optReturn: false })">
+				sync prop & option: false
+			</button>
+			<br>
+			sync beforeClose hooks: mixed
+			<br>
+			<button @click="openNested({ propSync: true, propReturn: true, optSync: true, optReturn: false })">
+				sync prop: true, sync option: false
+			</button>
+			<br>
+			<button @click="openNested({ propSync: true, propReturn: false, optSync: true, optReturn: true })">
+				sync prop: false, sync option: true
+			</button>
+
+			<br>
+			async beforeClose hooks: true
+			<br>
+			<button @click="openNested({ propSync: false, propReturn: true })">
+				async prop: true
+			</button>
+			<br>
+			<button @click="openNested({ optSync: false, optReturn: true })">
+				async option: true
+			</button>
+			<br>
+			<button @click="openNested({ propSync: false, propReturn: true, optSync: false, optReturn: true })">
+				async prop & option: true
+			</button>
+			<br>
+			async beforeClose hooks: false
+			<br>
+			<button @click="openNested({ propSync: false, propReturn: false })">
+				async prop: false
+			</button>
+			<br>
+			<button @click="openNested({ optSync: false, optReturn: false })">
+				async option: false
+			</button>
+			<br>
+			<button @click="openNested({ propSync: false, propReturn: false, optSync: false, optReturn: false })">
+				async prop & option: false
+			</button>
+			<br>
+			async beforeClose hooks: mixed
+			<br>
+			<button @click="openNested({ propSync: false, propReturn: true, optSync: false, optReturn: false })">
+				async prop: true, sync option: false
+			</button>
+			<br>
+			<button @click="openNested({ propSync: false, propReturn: false, optSync: false, optReturn: true })">
+				async prop: false, sync option: true
+			</button>
+			<br>
+			mixed a/sync beforeClose hooks: mixed
+			<br>
+			<!-- todo implement this part -->
+
+			<br>
+			closing via popover
+			<br>
+			<m-popover>
+				<template #action="popover">
+					<button
+						@click="popover.toggle()"
+					>
+						open popover
+					</button>
+				</template>
+				<template #content>
+					<m-popover-content>
+						<button @click="modalApi.close()">
+							close this modal
+						</button>
+						<button @click="modalApi.closeAll()">
+							close all modals
+						</button>
+					</m-popover-content>
+				</template>
+			</m-popover>
+			<br>
+			closing
+			<br>
+			<button @click="modalApi.close()">
+				close this modal
+			</button>
+			<button @click="modalApi.closeAll()">
+				close all modals
+			</button>
+			<m-popover-layer />
 		</m-modal-content>
 	</m-modal>
 </template>
 
 <script>
-import { MText } from '@square/maker/components/Text';
+/* eslint-disable no-console,no-debugger,import/no-self-import,max-len */
 import { MModal, modalApi, MModalContent } from '@square/maker/components/Modal';
-import { MInlineActionBar, MActionBarButton } from '@square/maker/components/ActionBar';
-import XIcon from '@square/maker-icons/X';
-import NestedModal from './NestedModal.vue';
+import { MPopoverLayer, MPopover, MPopoverContent } from '@square/maker/components/Popover';
 
-function returns(bool) {
+const TIMEOUT_DURATION = 1000; // 1 second
+
+function returns(setter, bool) {
 	return () => {
+		console.log(`in sync beforeClose set by ${setter}, returning ${bool}`);
 		return bool;
 	};
 }
 
-function asyncReturns(bool) {
-	const TIMEOUT_DURATION = 1000; // 1 second
-	return new Promise((resolve, _reject) => {
+function asyncReturns(setter, bool) {
+	return () => new Promise((resolve) => {
 		setTimeout(() => {
+			console.log(`in async beforeClose set by ${setter}, returning ${bool}`);
 			resolve(bool);
 		}, TIMEOUT_DURATION);
 	});
 }
 
+const DEFAULT_DEPTH = 1;
+const INC_DEPTH = 1;
+
 export default {
 	components: {
-		MText,
 		MModal,
-		MActionBarButton,
-		MInlineActionBar,
 		MModalContent,
-		XIcon,
+		MPopoverLayer,
+		MPopover,
+		MPopoverContent,
 	},
+
+	mixins: [
+		MPopoverLayer.popoverMixin,
+	],
 
 	inject: {
 		modalApi,
 	},
 
-	methods: {
-		openNested() {
-			this.modalApi.open(() => <NestedModal />);
+	props: {
+		depth: {
+			type: Number,
+			default: DEFAULT_DEPTH,
 		},
-		openNestedHook(options) {
+		beforeClose: {
+			type: Function,
+			default: undefined,
+		},
+	},
 
-		}
+	data() {
+		return {
+			NestedModal: undefined,
+		};
+	},
+
+	async mounted() {
+		// the module has to import itself
+		// because the "import" causes it to be
+		// built by vue-loader, which is necessary
+		// in order to use it in the JSX below
+		this.NestedModal = (await import('./MultiModal.vue')).default;
+	},
+
+	methods: {
+		openNested(options = {}) {
+			debugger;
+			let beforeCloseProp;
+			if (options.propSync !== undefined) {
+				let beforeClosePropFactory;
+				if (options.propSync) {
+					beforeClosePropFactory = returns;
+				} else {
+					beforeClosePropFactory = asyncReturns;
+				}
+				beforeCloseProp = beforeClosePropFactory('prop', options.propReturn);
+			}
+			let beforeCloseOpt;
+			if (options.optSync !== undefined) {
+				let beforeCloseOptFactory;
+				if (options.optSync) {
+					beforeCloseOptFactory = returns;
+				} else {
+					beforeCloseOptFactory = asyncReturns;
+				}
+				beforeCloseOpt = beforeCloseOptFactory('options', options.optReturn);
+			}
+			debugger;
+			const { NestedModal } = this;
+			this.modalApi.open(() => <NestedModal
+				depth={this.depth + INC_DEPTH}
+				beforeClose={beforeCloseProp}
+			/>, {
+				beforeCloseHook: beforeCloseOpt,
+			});
+		},
 	},
 };
 </script>
-
-<style scoped>
-.cover-photo {
-	width: 100%;
-	height: 300px;
-	object-fit: cover;
-	object-position: center;
-}
-
-.icon {
-	width: 24px;
-	height: 24px;
-}
-</style>

--- a/lab/components/MultiModal.vue
+++ b/lab/components/MultiModal.vue
@@ -1,0 +1,82 @@
+<template>
+	<m-modal>
+		<m-modal-content>
+			<button @click="openNested">
+				open nested modal with no beforeClose hook
+			</button>
+			<button @click="openNestedHook({sync: true, returns: true})">
+				open nested modal with sync beforeClose hook that returns true
+			</button>
+			<button @click="openNestedHook({sync: true, returns: false})">
+				open nested modal with sync beforeClose hook that returns false
+			</button>
+			<button @click="openNestedHook({sync: false, returns: true})">
+				open nested modal with async beforeClose hook that returns true
+			</button>
+			<button @click="openNestedHook({sync: false, returns: false})">
+				open nested modal with async beforeClose hook that returns false
+			</button>
+		</m-modal-content>
+	</m-modal>
+</template>
+
+<script>
+import { MText } from '@square/maker/components/Text';
+import { MModal, modalApi, MModalContent } from '@square/maker/components/Modal';
+import { MInlineActionBar, MActionBarButton } from '@square/maker/components/ActionBar';
+import XIcon from '@square/maker-icons/X';
+import NestedModal from './NestedModal.vue';
+
+function returns(bool) {
+	return () => {
+		return bool;
+	};
+}
+
+function asyncReturns(bool) {
+	const TIMEOUT_DURATION = 1000; // 1 second
+	return new Promise((resolve, _reject) => {
+		setTimeout(() => {
+			resolve(bool);
+		}, TIMEOUT_DURATION);
+	});
+}
+
+export default {
+	components: {
+		MText,
+		MModal,
+		MActionBarButton,
+		MInlineActionBar,
+		MModalContent,
+		XIcon,
+	},
+
+	inject: {
+		modalApi,
+	},
+
+	methods: {
+		openNested() {
+			this.modalApi.open(() => <NestedModal />);
+		},
+		openNestedHook(options) {
+
+		}
+	},
+};
+</script>
+
+<style scoped>
+.cover-photo {
+	width: 100%;
+	height: 300px;
+	object-fit: cover;
+	object-position: center;
+}
+
+.icon {
+	width: 24px;
+	height: 24px;
+}
+</style>

--- a/lab/experiments/CloseAllModals.vue
+++ b/lab/experiments/CloseAllModals.vue
@@ -3,6 +3,9 @@
 		<button @click="openModal">
 			open modal
 		</button>
+		<button @click="openAndCloseModal">
+			open & close modal
+		</button>
 		<m-modal-layer />
 	</div>
 </template>
@@ -23,6 +26,11 @@ export default {
 	methods: {
 		openModal() {
 			this.modalApi.open(() => <MultiModal />);
+		},
+		openAndCloseModal() {
+			const close = this.modalApi.open(() => <MultiModal />);
+			const CLOSE_TIMEOUT = 5000;
+			setTimeout(close, CLOSE_TIMEOUT);
 		},
 	},
 };

--- a/lab/experiments/CloseAllModals.vue
+++ b/lab/experiments/CloseAllModals.vue
@@ -1,0 +1,35 @@
+<template>
+	<div>
+		<button @click="openModal">
+			open modal
+		</button>
+		<m-modal-layer />
+	</div>
+</template>
+
+<script>
+import { MModalLayer } from '@square/maker/components/Modal';
+import ActionBarModal from '../components/ActionBarModal.vue';
+
+export default {
+	components: {
+		MModalLayer,
+	},
+
+	mixins: [
+		MModalLayer.apiMixin,
+	],
+
+	data() {
+		return {
+			count: 0,
+		};
+	},
+
+	methods: {
+		openModal() {
+			this.modalApi.open(() => <ActionBarModal />);
+		},
+	},
+};
+</script>

--- a/lab/experiments/CloseAllModals.vue
+++ b/lab/experiments/CloseAllModals.vue
@@ -9,7 +9,7 @@
 
 <script>
 import { MModalLayer } from '@square/maker/components/Modal';
-import ActionBarModal from '../components/ActionBarModal.vue';
+import MultiModal from '../components/MultiModal.vue';
 
 export default {
 	components: {
@@ -20,15 +20,9 @@ export default {
 		MModalLayer.apiMixin,
 	],
 
-	data() {
-		return {
-			count: 0,
-		};
-	},
-
 	methods: {
 		openModal() {
-			this.modalApi.open(() => <ActionBarModal />);
+			this.modalApi.open(() => <MultiModal />);
 		},
 	},
 };

--- a/lab/experiments/CloseAllModals.vue
+++ b/lab/experiments/CloseAllModals.vue
@@ -4,7 +4,7 @@
 			open modal
 		</button>
 		<button @click="openAndCloseModal">
-			open & close modal
+			open & close modal in 5 secs
 		</button>
 		<m-modal-layer />
 	</div>

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -822,12 +822,14 @@ export default {
 
 	methods: {
 		closeAll() {
-			this.modalApi.close();
+			// this.modalApi.closeAll();
 
-			const { parentModal } = this.modalApi.state;
-			if (parentModal) {
-				parentModal.close();
-			}
+			this.modalApi.forceCloseParent();
+
+			// const { parentModal } = this.modalApi.state;
+			// if (parentModal) {
+			// 	parentModal.close();
+			// }
 		},
 	},
 };

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -21,8 +21,6 @@ import { MModalLayer } from '@square/maker/components/Modal';
 import DemoModal from 'doc/DemoModal.vue';
 
 export default {
-	name: 'DemoSetup',
-
 	components: {
 		MModalLayer,
 		MButton,
@@ -34,12 +32,7 @@ export default {
 
 	methods: {
 		openModal() {
-			this.modalApi.open(
-				() => <DemoModal />,
-				{
-					closeOnClickOutside: true,
-				},
-			);
+			this.modalApi.open(() => <DemoModal />);
 		},
 	},
 };
@@ -50,9 +43,7 @@ _DemoModal.vue_
 
 ```vue
 <template>
-	<m-modal
-		:before-close="beforeCloseHook"
-	>
+	<m-modal>
 		<img
 			class="cover-photo"
 			src="https://picsum.photos/800/300"
@@ -62,7 +53,9 @@ _DemoModal.vue_
 				Modal heading
 			</m-text>
 			<m-text>
-				Modal content
+				<slot>
+					Modal content
+				</slot>
 			</m-text>
 			<m-button
 				size="small"
@@ -80,8 +73,6 @@ import { MText } from '@square/maker/components/Text';
 import { MModal, MModalContent, modalApi } from '@square/maker/components/Modal';
 
 export default {
-	name: 'DemoModal',
-
 	components: {
 		MModal,
 		MButton,
@@ -91,13 +82,6 @@ export default {
 
 	inject: {
 		modalApi,
-	},
-
-	methods: {
-		beforeCloseHook() {
-			// intercept close here
-			return true; // or false if you want to block modal from closing
-		},
 	},
 };
 </script>
@@ -143,12 +127,7 @@ export default {
 	methods: {
 		openMyModal() {
 			// this.modalApi is provided by MModalLayer.apiMixin
-			this.modalApi.open(
-				() => <MyModal />,
-				{
-					closeOnClickOutside: true,
-				},
-			);
+			this.modalApi.open(() => <MyModal />);
 		}
 	}
 };
@@ -157,7 +136,7 @@ export default {
 
 ## Usage
 
-Modals must always be created in its own Single File Component (SFC) file to separate concerns because it introduces a new mode or context to your app. Use the `MModal` component at the root of your Modal SFC to signify the modal and to communicate with the Modal Layer.
+Modals must always be created in their own Single File Component (SFC) file to separate concerns because it introduces a new mode or context to your app. Use the `MModal` component at the root of your Modal SFC to signify the modal and to communicate with the Modal Layer.
 
 ```html
 <template>
@@ -186,7 +165,7 @@ export default {
 </script>
 ```
 
-To open a modal programmatically, import `modalApi` and _inject_ it into your component to access the Modal Layer API. In the function you want to open the modal from (eg. a click-event handler), invoke `this.modalApi.open()` with a function that returns the modal instance. This function receives [`createElement`](https://vuejs.org/v2/guide/render-function.html#createElement-Arguments) (aliased to `h`) as an argument to instantiate the modal component with, but it's recommended to use the [Vue JSX Babel plugin](https://vuejs.org/v2/guide/render-function.html#createElement-Arguments) instead for better readability.
+To open a modal programmatically, import `modalApi` and _inject_ it into your component to access the Modal Layer API. In the function you want to open the modal from (e.g. a click-event handler), invoke `this.modalApi.open()` with a function that returns the modal instance. This function receives [`createElement`](https://vuejs.org/v2/guide/render-function.html#createElement-Arguments) (aliased to `h`) as an argument to instantiate the modal component with, but it's recommended to use the [Vue JSX Babel plugin](https://vuejs.org/v2/guide/render-function.html#createElement-Arguments) instead for better readability.
 
 ```html
 <template>
@@ -229,70 +208,129 @@ export default {
 };
 </script>
 ```
-### Configurable options
-The `modalApi.open()` function has a second optional object parameter that offers configurable options. Current available options are:
+## modalApi
+
+Full type definitions for `modalApi`:
 
 ```ts
-{
-	// Modal will close when clicked outside of it - default false
+// Vue render function
+type VueRenderFn = () => VueVNodes;
+
+type OpenOptions = {
+	// Modal will close when clicked outside of it - default false.
 	closeOnClickOutside: boolean;
 
-	// Modal will close when esc key is pressed - default false
-	// Only use this in Modals without ActionBars
+	// Modal will close when esc key is pressed - default false.
+	// Only use this in Modals without ActionBars, if the Modal
+	// has an ActionBar it's strongly encouraged to use listen
+	// on the window-esc event emitted from ActionBarButtons.
 	closeOnEsc: boolean;
+
+	// Hook that will run right before the Modal is closed. If
+	// the hook returns false then closing is cancelled. This
+	// hook can be async, e.g. it returns a Promise that resolves
+	// to a boolean.
+	beforeCloseHook: () => boolean | Promise<boolean>;
+}
+
+// Closes a specific instance of an opened modal.
+type CloseOpenedModalFn = () => void;
+
+type modalApi = {
+	// Renders modal into nearest parent modal layer using
+	// the render function & provided options, returns
+	// a function to close that specific opened modal if called.
+	open: (VueRenderFn, OptionOptions) => CloseOpenedModalFn;
+
+	// This method only works inside of modals. Will attempt
+	// to close the current modal and will return true if closing
+	// was successful and false otherwise. Can be async.
+	close: () => boolean | Promise<boolean>;
+
+	// This method only works inside of modals. Will attempt
+	// to close the current modal and all modals beneath it. Returns
+	// true if successful, false otherwise. Can be async.
+	closeAll: () => boolean | Promise<boolean>;
 }
 ```
 
-If the modal has an action bar, and you'd like it to close on the escape key, it's more semantic to use the `@window-esc` from the `MActionBarButton` component.
+## Examples
 
-To hook into the close function, add the `beforeClose` prop on the modal component.
-The function must return a boolean - true to close the modal or false to block closing.
+### beforeCloseHook
 
-```html
+```vue
 <template>
-	<m-modal
-		:before-close="beforeCloseHook"
-	>
-		Modal content
-
-		<!-- modalApi is provided by the injected the modalApi key below -->
-		<m-action-bar-button
-			@click="modalApi.close()"
-			@window-esc="modalApi.close()"
+	<div>
+		<m-button
+			size="small"
+			@click="openModal"
 		>
-			Close modal
-		</m-action-bar-button>
-	</m-modal>
+			Open modal
+		</m-button>
+		<m-modal-layer />
+	</div>
 </template>
 
 <script>
-import { MModal, modalApi } from '@square/maker/components/Modal';
-import { MActionBarButton } from '@square/maker/components/ActionBar';
+import { MButton } from '@square/maker/components/Button';
+import { MModalLayer } from '@square/maker/components/Modal';
+import DemoModal from 'doc/DemoModal.vue';
 
 export default {
 	components: {
-		MModal,
-		MActionBarButton,
+		MModalLayer,
+		MButton,
 	},
 
-	inject: {
-		modalApi,
-	},
+	mixins: [
+		MModalLayer.apiMixin,
+	],
 
 	methods: {
-		async beforeCloseHook() {
-			// intercept close here
-			return true; // or false if you want to block modal from closing
+		openModal() {
+			let firstCall = true;
+			const beforeCloseHook = () => {
+				// synchronously blocks closing
+				// on first invocation
+				if (firstCall) {
+					firstCall = false;
+					return false;
+				}
+
+				// asynchronously allows closing
+				// on second invocation
+				const ONE_SECOND = 1000;
+				return new Promise((resolve) => {
+					setTimeout(() => {
+						resolve(true);
+					}, ONE_SECOND);
+				});
+			};
+			const content = 'This modal can be closed by clicking outside or pressing esc key. The first close will be synchronously blocked by the beforeCloseHook and the second close will be asynchronously allowed after one second.';
+			this.modalApi.open(
+				// 1st param: render function
+				() => <DemoModal>{content}</DemoModal>,
+				// 2nd param: options
+				{
+					// runs right before close, can block or delay closing
+					beforeCloseHook,
+					// this modal will close if user clicks outside
+					closeOnClickOutside: true,
+					// this modal will close if user presses esc key
+					closeOnEsc: true,
+				},
+			);
 		},
 	},
 };
 </script>
 ```
-## Examples
+
+A hook can also be passed via the Modal's `beforeClose` prop but setting the hook via the `modalApi`'s options is recommended. If different hooks are set via the prop and via the options both will be run right before close, and both can block or delay closing.
 
 ### Modal + ActionBar
 
-Modals are responsive and should be used with `InlineActionBar` which renders the `ActionBar` inline inside the modal instead of the root `ActionBarLayer`.
+Modals are responsive and should be used with `InlineActionBar` which renders the `ActionBar` inline inside the modal.
 
 ```vue
 <template>
@@ -313,8 +351,6 @@ import { MModalLayer } from '@square/maker/components/Modal';
 import ActionBarDemoModal from 'doc/ActionBarDemoModal.vue';
 
 export default {
-	name: 'ActionBarDemoSetup',
-
 	components: {
 		MModalLayer,
 		MButton,
@@ -340,7 +376,7 @@ _ActionBarDemoModal.vue_
 	<m-modal>
 		<img
 			class="cover-photo"
-			src="https://picsum.photos/600/300"
+			src="https://picsum.photos/800/300"
 		>
 		<m-modal-content>
 			<m-text pattern="title">
@@ -354,7 +390,6 @@ _ActionBarDemoModal.vue_
 					key="close"
 					color="#f6f6f6"
 					@click="modalApi.close()"
-					@window-esc="modalApi.close()"
 				>
 					<x-icon class="icon" />
 				</m-action-bar-button>
@@ -377,8 +412,6 @@ import { MInlineActionBar, MActionBarButton } from '@square/maker/components/Act
 import XIcon from '@square/maker-icons/X';
 
 export default {
-	name: 'ActionBarDemoModal',
-
 	components: {
 		MText,
 		MModal,
@@ -411,7 +444,7 @@ export default {
 
 ### Stacking modals
 
-It's possible to stack modals, i.e. open another modal from inside a modal.
+It's possible to stack modals, i.e. open another modal from inside a modal. Simply call `modalApi.open` from within one modal to open another on top. Each modal can be closed by calling `modalApi.close`, but if you'd like to close all of them at once then call `modalApi.closeAll`.
 
 ```vue
 <template>
@@ -432,8 +465,6 @@ import { MModalLayer } from '@square/maker/components/Modal';
 import StackingDemoFirstModal from 'doc/StackingDemoFirstModal.vue';
 
 export default {
-	name: 'StackingDemoSetup',
-
 	components: {
 		MModalLayer,
 		MButton,
@@ -445,12 +476,7 @@ export default {
 
 	methods: {
 		openModal() {
-			this.modalApi.open(
-				() => <StackingDemoFirstModal />,
-				{
-					closeOnClickOutside: true,
-				},
-			);
+			this.modalApi.open(() => <StackingDemoFirstModal />);
 		},
 	},
 };
@@ -464,7 +490,7 @@ _StackingDemoFirstModal.vue_
 	<m-modal>
 		<img
 			class="cover-photo"
-			src="https://picsum.photos/600/300"
+			src="https://picsum.photos/800/300"
 		>
 		<m-modal-content>
 			<m-text pattern="title">
@@ -478,7 +504,6 @@ _StackingDemoFirstModal.vue_
 					key="close"
 					color="#f6f6f6"
 					@click="modalApi.close()"
-					@window-esc="modalApi.close()"
 				>
 					<x-icon class="icon" />
 				</m-action-bar-button>
@@ -502,8 +527,6 @@ import StackingDemoSecondModal from 'doc/StackingDemoSecondModal.vue';
 import XIcon from '@square/maker-icons/X';
 
 export default {
-	name: 'StackingDemoFirstModal',
-
 	components: {
 		MModal,
 		MText,
@@ -519,15 +542,7 @@ export default {
 
 	methods: {
 		openSecondModal() {
-			this.modalApi.open(
-				() => <StackingDemoSecondModal />,
-				{
-					closeOnClickOutside: true,
-				},
-			);
-		},
-		closeFirst() {
-			this.modalApi.close();
+			this.modalApi.open(() => <StackingDemoSecondModal />);
 		},
 	},
 };
@@ -536,7 +551,7 @@ export default {
 <style scoped>
 .cover-photo {
 	width: 100%;
-	height: 600px;
+	height: 300px;
 	object-fit: cover;
 	object-position: center;
 }
@@ -555,7 +570,7 @@ _StackingDemoSecondModal.vue_
 	<m-modal>
 		<img
 			class="cover-photo"
-			src="https://picsum.photos/400/300"
+			src="https://picsum.photos/800/300"
 		>
 		<m-modal-content>
 			<m-text pattern="title">
@@ -575,221 +590,7 @@ _StackingDemoSecondModal.vue_
 				<m-action-bar-button
 					key="confirm"
 					full-width
-					@click="modalApi.close()"
-				>
-					Confirm
-				</m-action-bar-button>
-			</m-inline-action-bar>
-		</m-modal-content>
-	</m-modal>
-</template>
-
-<script>
-import { MText } from '@square/maker/components/Text';
-import { MModal, MModalContent, modalApi } from '@square/maker/components/Modal';
-import { MInlineActionBar, MActionBarButton } from '@square/maker/components/ActionBar';
-import XIcon from '@square/maker-icons/X';
-
-export default {
-	name: 'StackingDemoSecondModal',
-
-	components: {
-		MModal,
-		MText,
-		MModalContent,
-		MActionBarButton,
-		XIcon,
-		MInlineActionBar,
-	},
-
-	inject: {
-		modalApi,
-	},
-};
-</script>
-
-<style scoped>
-.cover-photo {
-	width: 100%;
-	height: 400px;
-	object-fit: cover;
-	object-position: center;
-}
-
-.icon {
-	width: 24px;
-	height: 24px;
-}
-</style>
-```
-
-### Close stacking modals at once
-
-It's possible to close parent modal and child modal at once. Call `this.modalApi.state.parentModal.close()` to close parent modal.
-
-```vue
-<template>
-	<div>
-		<m-button
-			size="small"
-			@click="openModal"
-		>
-			Open modal
-		</m-button>
-		<m-modal-layer />
-	</div>
-</template>
-
-<script>
-import { MButton } from '@square/maker/components/Button';
-import { MModalLayer } from '@square/maker/components/Modal';
-import StackingDemoFirstModalCloseAll from 'doc/StackingDemoFirstModalCloseAll.vue';
-
-export default {
-	name: 'StackingDemoSetup',
-
-	components: {
-		MModalLayer,
-		MButton,
-	},
-
-	mixins: [
-		MModalLayer.apiMixin,
-	],
-
-	methods: {
-		openModal() {
-			this.modalApi.open(
-				() => <StackingDemoFirstModalCloseAll />,
-				{
-					closeOnClickOutside: true,
-				},
-			);
-		},
-	},
-};
-</script>
-```
-
-_StackingDemoFirstModalCloseAll.vue_
-
-```vue
-<template>
-	<m-modal>
-		<img
-			class="cover-photo"
-			src="https://picsum.photos/600/300"
-		>
-		<m-modal-content>
-			<m-text pattern="title">
-				First modal heading
-			</m-text>
-			<m-text>
-				First modal content
-			</m-text>
-			<m-inline-action-bar>
-				<m-action-bar-button
-					key="close"
-					color="#f6f6f6"
-					@click="modalApi.close()"
-					@window-esc="modalApi.close()"
-				>
-					<x-icon class="icon" />
-				</m-action-bar-button>
-				<m-action-bar-button
-					key="confirm"
-					full-width
-					@click="openSecondModal"
-				>
-					Open second modal
-				</m-action-bar-button>
-			</m-inline-action-bar>
-		</m-modal-content>
-	</m-modal>
-</template>
-
-<script>
-import { MText } from '@square/maker/components/Text';
-import { MModal, MModalContent, modalApi } from '@square/maker/components/Modal';
-import { MInlineActionBar, MActionBarButton } from '@square/maker/components/ActionBar';
-import StackingDemoSecondModalCloseAll from 'doc/StackingDemoSecondModalCloseAll.vue';
-import XIcon from '@square/maker-icons/X';
-
-export default {
-	name: 'StackingDemoFirstModal',
-
-	components: {
-		MModal,
-		MText,
-		MModalContent,
-		MInlineActionBar,
-		MActionBarButton,
-		XIcon,
-	},
-
-	inject: {
-		modalApi,
-	},
-
-	methods: {
-		openSecondModal() {
-			this.modalApi.open(
-				() => <StackingDemoSecondModalCloseAll />,
-				{
-					closeOnClickOutside: true,
-				},
-			);
-		},
-		closeFirst() {
-			this.modalApi.close();
-		},
-	},
-};
-</script>
-
-<style scoped>
-.cover-photo {
-	width: 100%;
-	height: 600px;
-	object-fit: cover;
-	object-position: center;
-}
-
-.icon {
-	width: 24px;
-	height: 24px;
-}
-</style>
-```
-
-_StackingDemoSecondModalCloseAll.vue_
-
-```vue
-<template>
-	<m-modal>
-		<img
-			class="cover-photo"
-			src="https://picsum.photos/400/300"
-		>
-		<m-modal-content>
-			<m-text pattern="title">
-				Second modal heading
-			</m-text>
-			<m-text>
-				Second modal content
-			</m-text>
-			<m-inline-action-bar>
-				<m-action-bar-button
-					key="close"
-					color="#f6f6f6"
-					@click="modalApi.close()"
-				>
-					<x-icon class="icon" />
-				</m-action-bar-button>
-				<m-action-bar-button
-					key="confirm"
-					full-width
-					@click="closeAll()"
+					@click="modalApi.closeAll()"
 				>
 					Close all modals
 				</m-action-bar-button>
@@ -805,8 +606,6 @@ import { MInlineActionBar, MActionBarButton } from '@square/maker/components/Act
 import XIcon from '@square/maker-icons/X';
 
 export default {
-	name: 'StackingDemoSecondModal',
-
 	components: {
 		MModal,
 		MText,
@@ -819,26 +618,13 @@ export default {
 	inject: {
 		modalApi,
 	},
-
-	methods: {
-		closeAll() {
-			// this.modalApi.closeAll();
-
-			this.modalApi.forceCloseParent();
-
-			// const { parentModal } = this.modalApi.state;
-			// if (parentModal) {
-			// 	parentModal.close();
-			// }
-		},
-	},
 };
 </script>
 
 <style scoped>
 .cover-photo {
 	width: 100%;
-	height: 400px;
+	height: 300px;
 	object-fit: cover;
 	object-position: center;
 }

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -89,7 +89,7 @@ export default {
 		beforeClose: {
 			immediate: true,
 			handler(hook) {
-				this.modalApi.state.options.beforeCloseHook = hook;
+				this.modalApi.registerBeforeCloseHook(hook);
 			},
 		},
 	},


### PR DESCRIPTION
## Describe the problem this PR addresses

The bugs:

❌ (1) a beforeClose hook set via options would never run

One way to set a beforeClose hook was via the options object in the 2nd param of `modalApi.open`, e.g.

```js
this.modalApi.open(
  // 1st param, render function
  () => <MyModal />,
  // 2nd param, modalApi options object
  {
    beforeCloseHook: () => console.log('I will never run 🤦'),
  },
);
```

This is bad obviously because the whole purpose of the beforeClose hook is to potentially block the modal from closing if the user forgot or failed to do something, but it would close regardless potentially leading to bad user experience or data in a corrupt or incomplete state. The beforeClose hook technically could also be used to perform final data clean up steps after a user was done interacting with a modal, and it failing to run could also lead to corrupt or incomplete data state.

Nobody noticed it was broken because... nobody was using it, which begs the question: why was it implemented in the first place 🤷? It was likely used for a time, then dropped or refactored, and then broken in later commit.


❌ (2) setting a beforeClose hook via the Modal's `beforeClose` prop would overwrite the beforeClose hook set via options

This is a very subtle bug that no one would have ever likely noticed because of bug (1) but even if that bug was fixed in an earlier or later version of Maker then this bug would pop up, e.g.

```js
this.modalApi.open(
  // hook set via Modal prop
  () => <MyModal
    beforeClose={() => console.log('this hook overwrites the one below')}
  />,
  // hook set via modalApi options
  {
    beforeCloseHook: () => console.log("I'll be overwritten by propHook"),
    // this hook will never run 🤦
  },
);
```

❌ (3) calling the close function returned by `modalApi.open` would force close an entire stack of modals _from the bottom_

Calling `modalApi.close` is suppose to only close the current modal, and if there is another modal stacked on top of the current modal then closing is blocked. This was correctly enforced for `modalApi.close` but not correctly enforced for the close function returned from `modalApi.open`, e.g.

```js
const closeFn = this.modalApi.open(() => <MyModal />);
closeFn(); // this could possibly force close multiple modals
```

Note: force closing a stack of modals _from the bottom_ is not good because: the bottommost modal usually isn't aware of the state of the modals above it, and if the user is performing some action in the upper modals like filling out a form then randomly closing it on them is horrible user experience. This is why we encourage and attempt to enforce closing modals _from the top only_ since the topmost modals have the most context and are the ones which are guiding the user experience.

❌ (4) calling the close function returned by `modalApi.open` would not run any beforeClose hooks on the closed modal

```js
const closeFn = this.modalApi.open(
  () => <MyModal beforeClose={hookOne} />,
  {
    beforeCloseHook: hookTwo,
  },
);
closeFn(); // this would skip running hookOne & hookTwo 🤦
```

❌ (5) calling `modalApi.state.parentModal.close` no longer works, but even when it "worked" it was broken in the same way as described by bug (4)

Originally `modalApi.state.parentModal.close` was implemented to close a stack of modals from the top. Since then it broke during some commit and stopped working, however even when it did "work" it was still broken in the same way as described by bug (4), i.e. none of the beforeClose hook would run.

❌ (6) calling `modalApi.state.parentModal.close` would only close a stack of exactly 2 modals, but would break for any other number, e.g. 1 or 3+

I think it's okay to want to close an entire stack of modals _from the top_. However, the way to do it should be reliable and independent regardless of how many modals there are in the stack, e.g. 1, 2, 3, 4 and so on. The original implementation of this feature only enabled users to close a stack of exactly 2 modals, and for any other number it was useless.

## Describe the changes in this PR

The fixes:

✅ (1) beforeClose hook set via options now runs

```js
this.modalApi.open(
  () => <MyModal />,
  {
    beforeCloseHook: () => console.log('Yay, I run now! 🙌'),
  },
);
```

✅ (2) beforeClose hook set via Modal's `beforeClose` prop no longer overwrites the beforeClose hook set via options, both are run

```js
this.modalApi.open(
  // hook set via Modal prop
  () => <MyModal
    beforeClose={() => console.log('I will run first! 🙌')}
  />,
  // hook set via modalApi options
  {
    beforeCloseHook: () => console.log('I will run second! 🙌'),
    // this hook will never run 🤦
  },
);
```

Both hooks have the opportunity to block closing. The hook set via props is run first and the hook set via options is run second. The hooks are run lazily, i.e. if the first hook blocks closing then the second hook isn't run.

✅  (3) calling the close function returned by `modalApi.open` will at most close the single specific opened modal, but will not close if there is a stack of multiple modals

It's not possible to accidentally or unintentionally close a stack of modals from the bottom anymore, as the close function returned from `modalApi.open` will now only close that specific single opened modal, and if there are modals stacked on top of it then closing will fail and the function will return `false`, e.g.

```js
const closeFn = this.modalApi.open(() => <MyModal />);
const result = closeFn();
// if result is true then MyModal was closed,
// if result is false then MyModal was not closed,
// which may mean there are other modals stacked
// on top of it which must be closed first
```

✅  (4) calling the close function returned by `modalApi.open` will run all beforeClose hooks registered on the opened modal

```js
const closeFn = this.modalApi.open(
  () => <MyModal beforeClose={hookOne} />,
  {
    beforeCloseHook: hookTwo,
  },
);
// this will now run hookOne & hookTwo before closing 🙌 
const result = await closeFn();
// if result is true then MyModal was closed,
// if result is false then MyModal was not closed,
// which may mean at least one of the beforeClose
// hooks blocked closing, i.e. returned false
// NOTE: if all of the hooks are sync then result will be a
// boolean, if any are async then result will be a Promise<boolean>
```

✅  (5) you can now call `modalApi.closeAll` to close an entire stack of modals from the top, and it will correctly run all of the beforeClose hooks on each modal

```js
// inside some part of the app
this.modalApi.open(
  () => <MyModal beforeClose={hookOne} />,
  {
    beforeCloseHook: hookTwo,
  },
);
// inside MyModal
this.modalApi.open(
  () => <MyNestedModal beforeClose={hookThree} />,
  {
    beforeCloseHook: hookFour,
  },
);
// inside MyNestedModal
const result = await this.modalApi.closeAll();
// hookThree & hookFour are run, if both return true MyNestedModal is closed
// hookOne & hookTwo are run, if both return true MyModal is closed
// if any of the hooks return false closing is stopped at that modal
// if all of the hooks are sync then result will be a boolean, if any of
// the hooks are async then result will be a Promise<boolean>
```

✅  (6) calling `modalApi.closeAll` works for closing a stack of modals of any size

`modalApi.closeAll` works for closing a single modal, or a couple modals, or 3, or 4, or so on.

## Other information
- beforeClose hooks can be sync or async
- any code using `modalApi.state.parentModal.close` should be refactored to use `modalApi.closeAll` after this PR is merged & released
- I renamed the internal modalApi state variable `currentLayer` to `parentModalApi` because I felt that name is more descriptive
- I added a bunch of comments to ModalLayer where the bulk of the confusing nested layer code exists
- I updated & improved the [Modal styleguide docs](https://square.github.io/maker/styleguide/close-all-modals/#/Modal)
- I created a [modal stacking & closing lab](https://square.github.io/maker/lab/close-all-modals/#/CloseAllModals) to debug and test all of my code works correctly