### PR TITLE
fix(image): relative src, sizes, & srcset attribute ordering (#458)

### DIFF
--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -18,9 +18,9 @@
 					[$s.thumbnail]: isThumbnail,
 				}"
 				:style="style"
-				:src="src"
 				:srcset="srcset"
 				:sizes="sizes"
+				:src="src"
 				v-bind="$attrs"
 				v-on="$listeners"
 			>


### PR DESCRIPTION
backport of this approved PR back to the 14.x major line: https://github.com/square/maker/pull/458