### PR TITLE
fix(modal): fail loudly if Modal w/beforeClose prop is mounted outside of a ModalLayer

### DIFF
--- a/lab/experiments/CloseAllModals.vue
+++ b/lab/experiments/CloseAllModals.vue
@@ -6,16 +6,21 @@
 		<button @click="openAndCloseModal">
 			open & close modal in 5 secs
 		</button>
+		<m-modal :before-close="() => true">
+			this is a layerless modal with a beforeClose hook,
+			it should emit an error to the console
+		</m-modal>
 		<m-modal-layer />
 	</div>
 </template>
 
 <script>
-import { MModalLayer } from '@square/maker/components/Modal';
+import { MModalLayer, MModal } from '@square/maker/components/Modal';
 import MultiModal from '../components/MultiModal.vue';
 
 export default {
 	components: {
+		MModal,
 		MModalLayer,
 	},
 

--- a/src/components/Choice/src/Choice.vue
+++ b/src/components/Choice/src/Choice.vue
@@ -122,7 +122,7 @@ export default {
 	methods: {
 		validateProps() {
 			if (this.isMultiSelect) {
-				assert.error(Array.isArray(this.selected), 'The v-model value for a multi-select must be of type Array.');
+				assert.error(Array.isArray(this.selected), 'The v-model value for a multi-select must be of type Array.', 'Choice');
 			}
 		},
 

--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -131,9 +131,9 @@ export default {
 	},
 
 	mounted() {
-		assert.warn(!(this.$slots.label && this.label), 'Label slot cannot be used together with label prop, former overrides the latter.');
-		assert.warn(!(this.$slots.sublabel && this.sublabel), 'Sublabel slot cannot be used together with sublabel prop, former overrides the latter.');
-		assert.warn(!((this.$slots.requirementLabel || this.$slots['requirement-label']) && this.requirementLabel), 'Requirement Label slot cannot be used together with requirement label prop, former overrides the latter.');
+		assert.warn(!(this.$slots.label && this.label), 'Label slot cannot be used together with label prop, former overrides the latter.', 'Container');
+		assert.warn(!(this.$slots.sublabel && this.sublabel), 'Sublabel slot cannot be used together with sublabel prop, former overrides the latter.', 'Container');
+		assert.warn(!((this.$slots.requirementLabel || this.$slots['requirement-label']) && this.requirementLabel), 'Requirement Label slot cannot be used together with requirement label prop, former overrides the latter.', 'Container');
 	},
 };
 </script>

--- a/src/components/Icon/src/Icon.vue
+++ b/src/components/Icon/src/Icon.vue
@@ -53,7 +53,7 @@ export default {
 	computed: {
 		iconComponent() {
 			const component = this.theme.icons[this.name];
-			assert.error(component, `'${this.name}' icon not defined in theme`);
+			assert.error(component, `'${this.name}' icon not defined in theme`, 'Icon');
 			return component;
 		},
 		inlineStyles() {

--- a/src/components/Menu/src/Menu.vue
+++ b/src/components/Menu/src/Menu.vue
@@ -130,7 +130,7 @@ export default {
 	methods: {
 		validateProps() {
 			if (this.isMultiSelect) {
-				assert.error(Array.isArray(this.selected), 'The v-model value for a multi-select must be of type Array.');
+				assert.error(Array.isArray(this.selected), 'The v-model value for a multi-select must be of type Array.', 'Menu');
 			}
 		},
 

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -42,7 +42,6 @@ export default {
 		 */
 		beforeClose: {
 			type: Function,
-			required: false,
 			default: undefined,
 		},
 		/**

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -44,6 +44,7 @@
 <script>
 import Vue from 'vue';
 import PseudoWindow from 'vue-pseudo-window';
+import assert from '@square/maker/utils/assert';
 import { MTransitionFadeIn } from '@square/maker/utils/TransitionFadeIn';
 import { MTransitionResponsive } from '@square/maker/utils/TransitionResponsive';
 import {
@@ -238,6 +239,15 @@ const apiMixin = {
 			// only called from child
 			// allows child modal to register hook with parent
 			registerBeforeCloseHook(hook) {
+				// modal was rendered outside of a ModalLayer
+				if (!vm.parentModalApi) {
+					// no hook, no problem, fail silently
+					if (!hook) {
+						return;
+					}
+					// hook but no layer, big problem, fail loudly
+					assert.error(false, 'Cannot set the beforeClose prop on a Modal if it is mounted outside of an ModalLayer', 'Modal');
+				}
 				vm.parentModalApi.state.localBeforeCloseHook = hook;
 			},
 

--- a/src/components/Notice/src/Notice.vue
+++ b/src/components/Notice/src/Notice.vue
@@ -155,7 +155,7 @@ export default {
 	},
 
 	created() {
-		assert.warn(!(this.display === 'inline' && this.$slots.actions), 'inline Notices cannot have an actions slot');
+		assert.warn(!(this.display === 'inline' && this.$slots.actions), 'inline Notices cannot have an actions slot', 'Notice');
 	},
 };
 </script>

--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -126,9 +126,8 @@ export default {
 	},
 
 	created() {
-		assert.warn(this.$slots.default, 'TextButton should be used with a label');
+		assert.warn(this.$slots.default, 'TextButton should be used with a label', 'TextButton');
 	},
-
 };
 </script>
 

--- a/src/components/Theme/src/utils.js
+++ b/src/components/Theme/src/utils.js
@@ -90,12 +90,12 @@ export function resolveThemeableProps(componentKeyInTheme, propNames) {
 
 				// validate using pattern prop validator if exists
 				if (patternValidator) {
-					assert.error(patternValidator(resolvedPattern), `Invalid value "${resolvedPattern}" for prop "pattern" for component "${componentKeyInTheme}" in theme.`);
+					assert.error(patternValidator(resolvedPattern), `Invalid value "${resolvedPattern}" for prop "pattern" for component "${componentKeyInTheme}" in theme.`, 'Theme');
 
 				// otherwise try validating by checking patterns config for component
 				} else {
 					const themePattern = this.theme[componentKeyInTheme].patterns?.[resolvedPattern];
-					assert.error(themePattern, `Invalid pattern "${resolvedPattern}" for component "${componentKeyInTheme}" in theme.`);
+					assert.error(themePattern, `Invalid pattern "${resolvedPattern}" for component "${componentKeyInTheme}" in theme.`, 'Theme');
 				}
 				return resolvedPattern;
 			};
@@ -134,7 +134,7 @@ export function resolveThemeableProps(componentKeyInTheme, propNames) {
 				const propValidator = this.$vnode.componentOptions
 					.Ctor.extendOptions.props[propName].validator;
 				if (propValidator) {
-					assert.error(propValidator(resolvedValue), `Invalid value "${resolvedValue}" for prop "${propName}" for component "${componentKeyInTheme}" in theme.`);
+					assert.error(propValidator(resolvedValue), `Invalid value "${resolvedValue}" for prop "${propName}" for component "${componentKeyInTheme}" in theme.`, 'Theme');
 				}
 				return resolvedValue;
 			};

--- a/src/utils/InlineFormControlLayout/src/InlineFormControlLayout.vue
+++ b/src/utils/InlineFormControlLayout/src/InlineFormControlLayout.vue
@@ -36,7 +36,7 @@ export default {
 		},
 	},
 	mounted() {
-		assert.error(this.$slots.label, 'Missing "label" slot in inline form control');
+		assert.error(this.$slots.label, 'Missing "label" slot in inline form control', 'InlineFormControlLayout');
 	},
 };
 </script>


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
some of our users were mounting MModals outside of MModalLayers which... is not a use-case we ever anticipated but now have to deal with, hence this PR. any time a MModal was mounted outside of an MModalLayer an error would get thrown, however most of these errors are harmless, so we should silence the harmless ones and only emit errors when there are real errors that can damage the behavior of the app.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
mounting a MModal outside of an MModalLayer will now not emit an error... UNLESS an explicit `beforeClose` prop is set on the MModal, since that prop requires the presence of an MModalLayer to function correctly, so an error will get emitted then

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
see console in: https://square.github.io/maker/lab/layerless-modals/#/CloseAllModals