### PR TITLE
build: build to `dist` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,7 @@ node_modules/
 .env
 
 # NPM package distribution files
-/components/
-/utils/
+/dist
 
 # Styleguide & Lab deploy distribution files
 /.dist/

--- a/build/webpack-build-config.js
+++ b/build/webpack-build-config.js
@@ -64,7 +64,7 @@ const buildComponent = (componentPath) => merge({}, webpackBuildConfig, {
 	entry: componentPath,
 	output: {
 		filename: 'script.js',
-		path: path.resolve(getComponentDirectory(componentPath)),
+		path: path.resolve('dist', getComponentDirectory(componentPath)),
 	},
 	plugins: [
 		componentEntryPlugin,
@@ -80,7 +80,7 @@ const buildUtil = (utilPath) => merge({}, webpackBuildConfig, {
 	entry: utilPath,
 	output: {
 		filename: path.basename(utilPath),
-		path: path.dirname(path.resolve(getUtilDirectory(utilPath))),
+		path: path.dirname(path.resolve('dist', getUtilDirectory(utilPath))),
 	},
 });
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sync-to-latest": "node ./build/sync-to-latest",
     "pull-deploys": "node ./build/deploys/pull.js",
     "push-deploys": "node ./build/deploys/push.js",
-    "prepublishOnly": "npm run build"
+    "prepack": "npm run build && mv dist/* ."
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
Multiple distribution files were emitted to the root of the project and was disorganized. This made ignoring them more cumbersome because they had to be manually hard-coded.


## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
- Emit all distribution files to `dist`, and move them to the root on [prepack](https://docs.npmjs.com/cli/v8/using-npm/scripts#:~:text=npm%20publish.-,prepack,-Runs%20BEFORE%20a).
- Ignore `dist` directory from git. (I'll be able to start ignoring `dist` in other tools too.)

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->

### Context
I'm working on a ECOM/Weebly linting library and it makes it a lot easier if we can ignore one directory to ignore all distribution files. I also want to start linting the whole project and exclude specific folders, instead of linting specific folders.

### Follow up questions
Curious what impact this may have on local development.

- Is `npm link`commonly used?
  For this purpose, devs should be able to run `npm run prepack` to yield the same result as before.

- Do consuming projects support export maps?