### PR TITLE
fix(button): make textPattern themeable

### DIFF
--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -794,31 +794,31 @@ export default {
 
 Supports attributes from [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button).
 
-| Prop                | Type      | Default         | Possible values                    | Description                                                 |
-| ------------------- | --------- | --------------- | ---------------------------------- | ----------------------------------------------------------- |
-| pattern             | `string`  | —               | `pattern defined in theme`         | patterns are defined at the theme level                     |
-| tag                 | `string`  | `'a'`           | `button`, `a`                      | Tag of button                                               |
-| type                | `string`  | `'button'`      | —                                  | Type of the button                                          |
-| size                | `string`  | —               | `small`, `medium`, `large`         | Size of the button                                          |
-| full-width          | `boolean` | —               | —                                  | Whether to make the button full-width                       |
-| text-pattern        | `string`  | `'buttonLabel'` | —                                  | MText pattern in button label                               |
-| color               | `string`  | —               | —                                  | Main color of button                                        |
-| color-hover         | `string`  | —               | —                                  | Main hover color of button                                  |
-| text-color          | `string`  | —               | —                                  | Text color of button (only applied on fill buttons)         |
-| text-color-hover    | `string`  | —               | —                                  | Text hover color of button (only applied on fill buttons)   |
-| variant             | `string`  | —               | `fill`, `outline`, `ghost`         | Variant                                                     |
-| shape               | `string`  | —               | `squared`, `rounded`, `pill`       | Shape of preset button (overridden by borderRadius prop)    |
-| border-radius       | `string`  | —               | `'Npx'`, `'N%'`                    | Shape of button                                             |
-| border-radius-hover | `string`  | —               | `'Npx'`, `'N%'`                    | Shape of button                                             |
-| border-width        | `string`  | —               | —                                  | Border width of button (e.g. '3px')                         |
-| border-width-hover  | `string`  | —               | —                                  | Border hover width of button (e.g. '3px')                   |
-| border-color        | `string`  | —               | —                                  | Border color of button (only applied on fill buttons)       |
-| border-color-hover  | `string`  | —               | —                                  | Border hover color of button (only applied on fill buttons) |
-| box-shadow          | `string`  | —               | —                                  | Box-shadow of button                                        |
-| box-shadow-hover    | `string`  | —               | —                                  | Box-shadow hover of button                                  |
-| disabled            | `boolean` | `false`         | —                                  | Toggles button disabled state                               |
-| align               | `string`  | —               | `center`, `stack`, `space-between` | How to align button's contents                              |
-| loading             | `boolean` | `false`         | —                                  | Toggles button loading state                                |
+| Prop                | Type      | Default    | Possible values                    | Description                                                 |
+| ------------------- | --------- | ---------- | ---------------------------------- | ----------------------------------------------------------- |
+| pattern             | `string`  | —          | `pattern defined in theme`         | patterns are defined at the theme level                     |
+| tag                 | `string`  | `'button'` | `button`, `a`                      | Tag of button                                               |
+| type                | `string`  | `'button'` | —                                  | Type of the button                                          |
+| size                | `string`  | —          | `small`, `medium`, `large`         | Size of the button                                          |
+| full-width          | `boolean` | —          | —                                  | Whether to make the button full-width                       |
+| text-pattern        | `string`  | —          | —                                  | MText pattern in button label                               |
+| color               | `string`  | —          | —                                  | Main color of button                                        |
+| color-hover         | `string`  | —          | —                                  | Main hover color of button                                  |
+| text-color          | `string`  | —          | —                                  | Text color of button (only applied on fill buttons)         |
+| text-color-hover    | `string`  | —          | —                                  | Text hover color of button (only applied on fill buttons)   |
+| variant             | `string`  | —          | `fill`, `outline`, `ghost`         | Variant                                                     |
+| shape               | `string`  | —          | `squared`, `rounded`, `pill`       | Shape of preset button (overridden by borderRadius prop)    |
+| border-radius       | `string`  | —          | `'Npx'`, `'N%'`                    | Shape of button                                             |
+| border-radius-hover | `string`  | —          | `'Npx'`, `'N%'`                    | Shape of button                                             |
+| border-width        | `string`  | —          | —                                  | Border width of button (e.g. '3px')                         |
+| border-width-hover  | `string`  | —          | —                                  | Border hover width of button (e.g. '3px')                   |
+| border-color        | `string`  | —          | —                                  | Border color of button (only applied on fill buttons)       |
+| border-color-hover  | `string`  | —          | —                                  | Border hover color of button (only applied on fill buttons) |
+| box-shadow          | `string`  | —          | —                                  | Box-shadow of button                                        |
+| box-shadow-hover    | `string`  | —          | —                                  | Box-shadow hover of button                                  |
+| disabled            | `boolean` | `false`    | —                                  | Toggles button disabled state                               |
+| align               | `string`  | —          | `center`, `stack`, `space-between` | How to align button's contents                              |
+| loading             | `boolean` | `false`    | —                                  | Toggles button loading state                                |
 
 
 ## Slots

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -169,7 +169,7 @@ export default {
 		 */
 		textPattern: {
 			type: String,
-			default: 'buttonLabel',
+			default: undefined,
 		},
 		/**
 		 * Main color of button

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -15,6 +15,7 @@ export default function defaultTheme() {
 			size: 'medium',
 			variant: 'fill',
 			shape: undefined,
+			textPattern: 'buttonLabel',
 			color: '@colors.primary',
 			textColor: undefined,
 			fullWidth: false,


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Currently `MButton`'s `textPattern` prop is not themeable.
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
Makes `MButton`'s `textPattern` prop themeable.
<!--
  📸 Inline screenshots to better communicate the changes
-->

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
