### PR TITLE
feat(divider): themable color & size props

### DIFF
--- a/src/components/Divider/README.md
+++ b/src/components/Divider/README.md
@@ -22,13 +22,114 @@ export default {
 </script>
 ```
 
+## Examples
+
+Sometimes you may want to visually separate a list of containers, you can do so using the built-in `gap-8` and `gap-16` patterns like so:
+
+```vue
+<template>
+	<div>
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="toggleSize"
+		>
+			toggle gap size ({{ gapSize }}px)
+		</m-button>
+		<m-container
+			label="Container one"
+			sublabel="Some sublabel"
+			requirement-label="Also do X"
+		>
+			Content inside the container.
+		</m-container>
+		<m-divider :pattern="gapPattern" />
+		<m-container
+			label="Container two"
+			sublabel="Other sublabel"
+			requirement-label="Also do Y"
+		>
+			Content inside another container.
+		</m-container>
+		<m-divider :pattern="gapPattern" />
+		<m-container
+			label="Container three"
+			sublabel="Another sublabel"
+			requirement-label="Also do Z"
+		>
+			Content inside the last container.
+		</m-container>
+	</div>
+</template>
+
+<script>
+import { MButton } from '@square/maker/components/Button';
+import { MContainer } from '@square/maker/components/Container';
+import { MDivider } from '@square/maker/components/Divider';
+
+const STEP = 8;
+const MAX = 16;
+
+export default {
+	components: {
+		MContainer,
+		MDivider,
+		MButton,
+	},
+	data() {
+		return {
+			size: 0,
+		};
+	},
+	computed: {
+		gapSize() {
+			return (this.size % MAX) + STEP;
+		},
+		gapPattern() {
+			return `gap-${this.gapSize}`;
+		},
+	},
+	methods: {
+		toggleSize() {
+			this.size += STEP;
+		},
+	},
+};
+</script>
+
+<style scoped>
+.mobile {
+	overflow: hidden;
+	border-radius: 30px;
+	padding: 32px 16px;
+	width: 400px;
+	border: 2px solid $maker-color-neutral-10;
+	box-shadow:
+		4.8px 6.4px 10.8px -40px rgba(0, 0, 0, 0.34),
+		12.2px 16.4px 18.2px -40px rgba(0, 0, 0, 0.213),
+		23.7px 31.8px 26.4px -40px rgba(0, 0, 0, 0.159),
+		38px 51px 54px -40px rgba(0, 0, 0, 0.098);
+}
+
+.mobile-scroll {
+	border: 2px solid $maker-color-neutral-10;
+}
+</style>
+```
+
 <!-- api-tables:start -->
 ## Props
 
-Supports attributes from [`<hr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr).
+Supports attributes from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div).
+
+| Prop    | Type     | Default | Possible values | Description                    |
+| ------- | -------- | ------- | --------------- | ------------------------------ |
+| pattern | `string` | —       | —               | pattern defined at theme level |
+| size    | `string` | —       | —               | Size (height) of the divider   |
+| color   | `string` | —       | —               | Color of the divider           |
 
 
 ## Events
 
-Supports events from [`<hr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr).
+Supports events from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div).
 <!-- api-tables:end -->

--- a/src/components/Divider/src/Divider.vue
+++ b/src/components/Divider/src/Divider.vue
@@ -1,32 +1,79 @@
 <template>
-	<hr
+	<div
 		:class="$s.Divider"
+		:style="styles"
 		v-bind="$attrs"
 		v-on="$listeners"
-	>
+	/>
 </template>
 
 <script>
+import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
+import cssValidator from '@square/maker/utils/css-validator';
 
 /**
- * @inheritAttrs hr
- * @inheritListeners hr
+ * @inheritAttrs div
+ * @inheritListeners div
  */
 export default {
+	inject: {
+		theme: {
+			default: defaultTheme(),
+			from: MThemeKey,
+		},
+	},
+
 	inheritAttrs: false,
+
+	props: {
+		/**
+		 * pattern defined at theme level
+		 */
+		pattern: {
+			type: String,
+			default: undefined,
+		},
+		/**
+		 * Size (height) of the divider
+		 */
+		size: {
+			type: String,
+			default: undefined,
+			validator: cssValidator('height'),
+		},
+		/**
+		 * Color of the divider
+		 */
+		color: {
+			type: String,
+			default: undefined,
+			validator: cssValidator('color'),
+		},
+	},
+
+	computed: {
+		...resolveThemeableProps('divider', [
+			'pattern',
+			'color',
+			'size',
+		]),
+		styles() {
+			return {
+				'--divider-color': this.resolvedColor,
+				'--divider-size': this.resolvedSize,
+			};
+		},
+	},
 };
 </script>
 
 <style module="$s">
-/*
-	hr needed so selector has higher specificity
-	than our markdown css style selectors
-*/
-hr.Divider {
-	height: 1px;
+.Divider {
+	height: var(--divider-size);
 	margin: 0;
 	padding: 0;
-	background-color: $maker-color-neutral-20;
+	background-color: var(--divider-color);
 	border: none;
+	transition: height 0.5s;
 }
 </style>

--- a/src/components/Theme/src/default-theme.js
+++ b/src/components/Theme/src/default-theme.js
@@ -6,11 +6,16 @@ import defaultShapes from './default-shapes';
 
 export default function defaultTheme() {
 	return {
+		// utility functions which enable pointer values
+		resolve,
+		getPath,
+		// "global" theme settings
 		colors: defaultColors(),
 		fonts: defaultFonts(),
 		icons: defaultIcons(),
 		shapes: defaultShapes(),
 		profiles: {},
+		// "local" component theme settings
 		button: {
 			size: 'medium',
 			variant: 'fill',
@@ -373,7 +378,19 @@ export default function defaultTheme() {
 			color: undefined,
 			bgColor: undefined,
 		},
-		resolve,
-		getPath,
+		divider: {
+			color: '@colors["neutral-20"]',
+			size: '1px',
+			patterns: {
+				'gap-8': {
+					color: '@colors["neutral-10"]',
+					size: '8px',
+				},
+				'gap-16': {
+					color: '@colors["neutral-10"]',
+					size: '16px',
+				},
+			},
+		},
 	};
 }


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
divider was a skinny boi but users wanted divider to be a T H I C C boi

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
adds themable `color` and `size` props to Divider, can now be made thicker and lighter or darker, as the user pleases

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
https://square.github.io/maker/styleguide/gaps/#/Divider