### PR TITLE
feat(container): stop rendering header when there's no header content

### DIFF
--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -8,7 +8,10 @@
 		:style="style"
 		v-on="$listeners"
 	>
-		<header :class="$s.Header">
+		<header
+			v-if="hasHeaderContent"
+			:class="$s.Header"
+		>
 			<div
 				v-if="hasLabel"
 				:class="$s.Label"
@@ -127,6 +130,9 @@ export default {
 		},
 		hasRequirementLabel() {
 			return this.$slots.requirementLabel || this.$slots['requirement-label'] || this.requirementLabel;
+		},
+		hasHeaderContent() {
+			return this.hasLabel || this.hasSublabel || this.hasRequirementLabel;
 		},
 	},
 


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
When there's no header content, `MContainer` still renders an empty header wrapper.
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
Render no header wrapper if there's no header content.
<!--
  📸 Inline screenshots to better communicate the changes
-->

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
