### PR TITLE
fix: custom icons having poor contrast in Row, Accordion, Select

### DIFF
--- a/src/components/Accordion/README.md
+++ b/src/components/Accordion/README.md
@@ -42,7 +42,7 @@ export default {
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	background-color: #ccc;
+	background-color: var(--maker-color-neutral-10);
 }
 </style>
 ```
@@ -84,7 +84,7 @@ export default {
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	background-color: #ccc;
+	background-color: var(--maker-color-neutral-10);
 }
 </style>
 ```
@@ -96,9 +96,13 @@ If necessary, Accordions can be controlled programmatically by passing a boolean
 ```vue
 <template>
 	<div class="container">
-		<button @click="expanded = !expanded">
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="expanded = !expanded"
+		>
 			external button (expanded: {{ expanded }})
-		</button>
+		</m-button>
 		<br><br>
 		<m-accordion
 			v-model="expanded"
@@ -113,11 +117,13 @@ If necessary, Accordions can be controlled programmatically by passing a boolean
 </template>
 
 <script>
+import { MButton } from '@square/maker/components/Button';
 import { MAccordion } from '@square/maker/components/Accordion';
 
 export default {
 	components: {
 		MAccordion,
+		MButton,
 	},
 	data() {
 		return {
@@ -136,7 +142,7 @@ export default {
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	background-color: #ccc;
+	background-color: var(--maker-color-neutral-10);
 }
 </style>
 ```
@@ -213,7 +219,7 @@ export default {
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	background-color: #ccc;
+	background-color: var(--maker-color-neutral-10);
 }
 .icon {
 	width: 24px;
@@ -312,7 +318,7 @@ export default {
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	background-color: #ccc;
+	background-color: var(--maker-color-neutral-10);
 }
 .divider {
 	margin: 16px 0;

--- a/src/components/ActionBar/README.md
+++ b/src/components/ActionBar/README.md
@@ -12,51 +12,54 @@ There are 2 versions of ActionBar:
 ```vue
 <template>
 	<div>
-		<button @click="showClose = !showClose">
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="showClose = !showClose"
+		>
 			toggle close button
-		</button>
-		<div class="container">
-			<div class="card">
-				<div class="content">
-					<ol>
-						<li
-							v-for="i in 20"
-							:key="i"
-						>
-							content content content
-						</li>
-					</ol>
-					<m-inline-action-bar>
-						<m-action-bar-button
-							v-if="showClose"
-							key="close"
-							color="#f6f6f6"
-						>
-							<x-icon class="icon" />
-						</m-action-bar-button>
-						<m-action-bar-button
-							key="confirm"
-							full-width
-						>
-							Confirm action
-						</m-action-bar-button>
-					</m-inline-action-bar>
-				</div>
+		</m-button>
+		<div class="card">
+			<div class="content">
+				<ol>
+					<li
+						v-for="i in 20"
+						:key="i"
+					>
+						content content content
+					</li>
+				</ol>
+				<m-inline-action-bar>
+					<m-action-bar-button
+						v-if="showClose"
+						key="close"
+						color="#f6f6f6"
+					>
+						<x-icon class="icon" />
+					</m-action-bar-button>
+					<m-action-bar-button
+						key="confirm"
+						full-width
+					>
+						Confirm action
+					</m-action-bar-button>
+				</m-inline-action-bar>
 			</div>
 		</div>
 	</div>
 </template>
 
 <script>
+import { MButton } from '@square/maker/components/Button';
 import { MInlineActionBar, MActionBarButton } from '@square/maker/components/ActionBar';
 import XIcon from '@square/maker-icons/X';
 
 export default {
-	name: 'InlineDemo',
 	components: {
 		MInlineActionBar,
 		MActionBarButton,
 		XIcon,
+		MButton,
 	},
 	data() {
 		return {
@@ -80,9 +83,10 @@ export default {
 	border-radius: 16px;
 	box-shadow: 0 0 12px 4px rgba(0, 0, 0, 0.2);
 	padding: 16px;
+	margin: 16px 0;
 }
 .content {
-	overflow: scroll;
+	overflow-y: scroll;
 	height: 100%;
 }
 .icon {
@@ -115,7 +119,6 @@ import { MActionBarLayer } from '@square/maker/components/ActionBar';
 import DemoActionBar from 'doc/DemoActionBar.vue';
 
 export default {
-	name: 'Demo',
 	components: {
 		MActionBarLayer,
 		DemoActionBar,
@@ -175,7 +178,6 @@ import { MActionBar, MActionBarButton } from '@square/maker/components/ActionBar
 import XIcon from '@square/maker-icons/X';
 
 export default {
-	name: 'DemoResponsiveActionBar',
 	components: {
 		MActionBar,
 		MActionBarButton,
@@ -197,7 +199,7 @@ export default {
 </style>
 ```
 
-### ActionBar Buttons
+### ActionBarButtons
 
 ```vue
 <template>
@@ -353,7 +355,6 @@ import XIcon from '@square/maker-icons/X';
 import SearchIcon from '@square/maker-icons/Search';
 
 export default {
-	name: 'InlineDemo',
 	components: {
 		MInlineActionBar,
 		MActionBarButton,
@@ -379,7 +380,7 @@ export default {
 .grid > div {
 	position: relative;
 	height: 96px;
-	background: #e4e7eb;
+	background: var(--maker-color-neutral-10);
 }
 
 .icon {

--- a/src/components/Blade/README.md
+++ b/src/components/Blade/README.md
@@ -7,6 +7,7 @@ Use the Blade component to open a blade.
 	<div>
 		<m-button
 			size="small"
+			pattern="primaryOutline"
 			@click="openBlade"
 		>
 			Open blade
@@ -21,8 +22,6 @@ import DemoBlade from 'doc/DemoBlade.vue';
 import { MButton } from '@square/maker/components/Button';
 
 export default {
-	name: 'DemoSetup',
-
 	components: {
 		MButton,
 		MBladeLayer,
@@ -59,6 +58,7 @@ _DemoBlade.vue_
 			</m-text>
 			<m-button
 				size="small"
+				pattern="primaryOutline"
 				@click="bladeApi.close()"
 			>
 				Close
@@ -73,8 +73,6 @@ import { MButton } from '@square/maker/components/Button';
 import { MText } from '@square/maker/components/Text';
 
 export default {
-	name: 'DemoBlade',
-
 	components: {
 		MBlade,
 		MBladeContent,
@@ -107,6 +105,7 @@ export default {
 	<div>
 		<m-button
 			size="small"
+			pattern="primaryOutline"
 			@click="openBlade"
 		>
 			Open blade
@@ -121,8 +120,6 @@ import ActionBarDemoBlade from 'doc/ActionBarDemoBlade.vue';
 import { MButton } from '@square/maker/components/Button';
 
 export default {
-	name: 'ActionBarDemoSetup',
-
 	components: {
 		MButton,
 		MBladeLayer,
@@ -184,8 +181,6 @@ import { MInlineActionBar, MActionBarButton } from '@square/maker/components/Act
 import XIcon from '@square/maker-icons/X';
 
 export default {
-	name: 'ActionBarDemoBlade',
-
 	components: {
 		MBlade,
 		MBladeContent,

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -483,6 +483,7 @@ export default {
 <style scoped>
 .ButtonTable {
 	min-width: 50%;
+	width: 100%;
 	border-collapse: separate;
 	border-spacing: 0 16px;
 	text-align: left;
@@ -724,6 +725,7 @@ export default {
 <style scoped>
 .ButtonTable {
 	min-width: 50%;
+	width: 100%;
 	border-collapse: separate;
 	border-spacing: 0 16px;
 	text-align: left;

--- a/src/components/Dialog/README.md
+++ b/src/components/Dialog/README.md
@@ -7,6 +7,7 @@ Use the Dialog component to prompt the user with some immediate information that
 	<div>
 		<m-button
 			size="small"
+			pattern="primaryOutline"
 			@click="openDialog"
 		>
 			Open dialog
@@ -58,6 +59,7 @@ _DemoDialog.vue_
 			</m-text>
 			<m-button
 				size="small"
+				pattern="primaryOutline"
 				@click="dialogApi.close()"
 			>
 				Close
@@ -272,12 +274,16 @@ type dialogApi = {
 
 ## Examples
 
-### beforeBefore & afterClose hooks
+### beforeClose & afterClose hooks
 
 ```vue
 <template>
 	<div>
-		<m-button @click="openDialog">
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="openDialog"
+		>
 			Open Dialog
 		</m-button>
 
@@ -439,6 +445,7 @@ Dialogs are responsive and should be used with `InlineActionBar` which renders t
 	<div>
 		<m-button
 			size="small"
+			pattern="primaryOutline"
 			@click="openDialog"
 		>
 			Open dialog
@@ -549,6 +556,7 @@ As noted above, to open a Dialog on top of a Modal you must place `MDialogLayer`
 	<div>
 		<m-button
 			size="small"
+			pattern="primaryOutline"
 			@click="openModal"
 		>
 			Open modal
@@ -607,12 +615,14 @@ _DemoModal.vue_
 			</m-text>
 			<m-button
 				size="small"
+				pattern="primaryOutline"
 				@click="modalApi.close()"
 			>
 				Close
 			</m-button>
 			<m-button
 				size="small"
+				pattern="primaryOutline"
 				@click="openDialog"
 			>
 				Open Dialog

--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -250,6 +250,8 @@ export default {
 		/>
 		<br>
 		<m-button
+			size="small"
+			pattern="primaryOutline"
 			@click="handleClick"
 		>
 			Click to {{ focused ? 'blur' : 'focus' }}

--- a/src/components/Menu/README.md
+++ b/src/components/Menu/README.md
@@ -100,7 +100,10 @@
 			type="action"
 		>
 			<template #toggle>
-				<m-button>
+				<m-button
+					size="small"
+					pattern="primaryOutline"
+				>
 					<settings class="icon" />
 					Toggle
 				</m-button>

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -7,6 +7,7 @@ Use the modal component to enter the user into a new _mode_.
 	<div>
 		<m-button
 			size="small"
+			pattern="primaryOutline"
 			@click="openModal"
 		>
 			Open modal
@@ -59,6 +60,7 @@ _DemoModal.vue_
 			</m-text>
 			<m-button
 				size="small"
+				pattern="primaryOutline"
 				@click="modalApi.close()"
 			>
 				Close
@@ -263,6 +265,7 @@ type modalApi = {
 	<div>
 		<m-button
 			size="small"
+			pattern="primaryOutline"
 			@click="openModal"
 		>
 			Open modal
@@ -337,6 +340,7 @@ Modals are responsive and should be used with `InlineActionBar` which renders th
 	<div>
 		<m-button
 			size="small"
+			pattern="primaryOutline"
 			@click="openModal"
 		>
 			Open modal
@@ -451,6 +455,7 @@ It's possible to stack modals, i.e. open another modal from inside a modal. Simp
 	<div>
 		<m-button
 			size="small"
+			pattern="primaryOutline"
 			@click="openModal"
 		>
 			Open modal

--- a/src/components/PinInput/README.md
+++ b/src/components/PinInput/README.md
@@ -272,6 +272,7 @@ export default {
 	<div>
 		<m-button
 			size="small"
+			pattern="primaryOutline"
 			@click="openDialog"
 		>
 			Open dialog
@@ -336,6 +337,7 @@ _DemoDialog.vue_
 			</m-pin-input>
 			<m-button
 				size="small"
+				pattern="primaryOutline"
 				@click="dialogApi.close()"
 			>
 				Close

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -2,7 +2,6 @@
 
 Use the popover to provide the user with more context or options. The Popover Layer should be placed at the root of your application.
 
-## Basic Popover
 ```vue
 <template>
 	<div>
@@ -11,9 +10,11 @@ Use the popover to provide the user with more context or options. The Popover La
 		<m-popover>
 			<template #action="popover">
 				<m-button
+					size="small"
+					pattern="primaryOutline"
 					@click="popover.toggle()"
 				>
-					Popover Toggle
+					Toggle popover
 				</m-button>
 			</template>
 
@@ -31,8 +32,6 @@ import { MPopoverLayer, MPopover, MPopoverContent } from '@square/maker/componen
 import { MButton } from '@square/maker/components/Button';
 
 export default {
-	name: 'BasicDemo',
-
 	components: {
 		MPopoverLayer,
 		MPopover,
@@ -47,8 +46,10 @@ export default {
 </script>
 ```
 
+## Examples
 
-## Other Configurations
+### Theming
+
 ```vue
 <template>
 	<div>
@@ -71,14 +72,14 @@ export default {
 					/>
 				</label>
 				<label>
-					Text Color
+					Text color
 					<input
 						v-model="color"
 						type="color"
 					>
 				</label>
 				<label>
-					Background Color
+					Background color
 					<input
 						v-model="bgColor"
 						type="color"
@@ -106,7 +107,7 @@ export default {
 						<m-button
 							@click="popover.toggle()"
 						>
-							Popover Toggle
+							Toggle popover
 						</m-button>
 					</template>
 
@@ -132,8 +133,6 @@ import { MText } from '@square/maker/components/Text';
 import DemoPopover from 'doc/DemoPopoverContent.vue';
 
 export default {
-	name: 'SimpleDemo',
-
 	components: {
 		MPopoverLayer,
 		MPopover,
@@ -258,7 +257,7 @@ export default {
 </style>
 ```
 
-## External Trigger
+### External triggers
 
 If you need to trigger a popover to be opened from outside the `Popover` component, you can access the `open`, `close`, and `trigger` methods via a `ref`.
 
@@ -269,9 +268,11 @@ If you need to trigger a popover to be opened from outside the `Popover` compone
 
 		<m-button
 			ref="externalTrigger"
+			size="small"
+			pattern="primaryOutline"
 			@click="$refs.popover.toggle($refs.externalTrigger.$el)"
 		>
-			Popover Toggle
+			Toggle popover
 		</m-button>
 		<m-popover ref="popover">
 			<template #action>
@@ -297,8 +298,6 @@ import { MButton } from '@square/maker/components/Button';
 import DemoPopover from 'doc/DemoPopoverContent.vue';
 
 export default {
-	name: 'ExternalTriggerDemo',
-
 	components: {
 		MPopoverLayer,
 		MPopover,
@@ -314,26 +313,38 @@ export default {
 </script>
 ```
 
-## Modal/Dialog Usage
+## Usage within layer components
 
-The Dialog and Modal layers share the root-level Popover layer. In order for popovers to appear on top of the Dialogs and Modals, make sure to include the `MPopoverLayer` component _after_ the `MDialogLayer`/`MModalLayer` components in your template. Otherwise, Popovers will work inside Dialogs and Modals without extra configuration.
+Layer components, such as Modal, Dialog, and Blade, share the root-level Popover layer. In order for Popovers to appear over Modals, Dialogs, and Blades, the `MPopoverLayer` component must be placed _after_ `MModalLayer`, `MDialogLayer`, and `MBladeLayer` components in your root app template.
 
 ```vue
 <template>
 	<div>
+		<m-blade-layer />
 		<m-modal-layer />
 		<m-dialog-layer />
 		<m-popover-layer />
 
 		<m-button
-			@click="openModal()"
+			size="small"
+			pattern="primaryOutline"
+			@click="openModal"
 		>
-			Open Modal
+			Open modal
 		</m-button>
 		<m-button
-			@click="openDialog()"
+			size="small"
+			pattern="primaryOutline"
+			@click="openDialog"
 		>
-			Open Dialog
+			Open dialog
+		</m-button>
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="openBlade"
+		>
+			Open blade
 		</m-button>
 	</div>
 </template>
@@ -345,21 +356,23 @@ import { MModalLayer } from '@square/maker/components/Modal';
 import DemoModal from 'doc/DemoModal.vue';
 import { MDialogLayer } from '@square/maker/components/Dialog';
 import DemoDialog from 'doc/DemoDialog.vue';
+import { MBladeLayer } from '@square/maker/components/Blade';
+import DemoBlade from 'doc/DemoBlade.vue';
 
 export default {
-	name: 'ModalDemo',
-
 	components: {
 		MPopoverLayer,
 		MButton,
 		MModalLayer,
 		MDialogLayer,
+		MBladeLayer,
 	},
 
 	mixins: [
 		MPopoverLayer.popoverMixin,
 		MModalLayer.apiMixin,
 		MDialogLayer.apiMixin,
+		MBladeLayer.apiMixin,
 	],
 
 	methods: {
@@ -373,6 +386,9 @@ export default {
 		},
 		openDialog() {
 			this.dialogApi.open(() => <DemoDialog />);
+		},
+		openBlade() {
+			this.bladeApi.open(() => <DemoBlade />);
 		},
 	},
 };
@@ -397,17 +413,22 @@ _DemoModal.vue_
 				<template #action="popover">
 					<m-button
 						size="small"
+						pattern="primaryOutline"
 						@click="popover.toggle()"
 					>
-						Toggle Popover
+						Toggle popover
 					</m-button>
 				</template>
 
 				<template #content>
 					<m-popover-content>
 						<demo-popover>
-							<m-button @click="closeModal()">
-								Close Modal
+							<m-button
+								size="small"
+								pattern="primaryOutline"
+								@click="closeModal"
+							>
+								Close modal
 							</m-button>
 						</demo-popover>
 					</m-popover-content>
@@ -425,8 +446,6 @@ import { MModal, MModalContent, modalApi } from '@square/maker/components/Modal'
 import DemoPopover from 'doc/DemoPopoverContent.vue';
 
 export default {
-	name: 'DemoModal',
-
 	components: {
 		MPopover,
 		MPopoverContent,
@@ -473,17 +492,22 @@ _DemoDialog.vue_
 				<template #action="popover">
 					<m-button
 						size="small"
+						pattern="primaryOutline"
 						@click="popover.toggle()"
 					>
-						Toggle Popover
+						Toggle popover
 					</m-button>
 				</template>
 
 				<template #content>
 					<m-popover-content>
 						<demo-popover>
-							<m-button @click="closeDialog()">
-								Close Dialog
+							<m-button
+								size="small"
+								pattern="primaryOutline"
+								@click="closeDialog"
+							>
+								Close dialog
 							</m-button>
 						</demo-popover>
 					</m-popover-content>
@@ -501,8 +525,6 @@ import { MDialog, MDialogContent, dialogApi } from '@square/maker/components/Dia
 import DemoPopover from 'doc/DemoPopoverContent.vue';
 
 export default {
-	name: 'DemoDialog',
-
 	components: {
 		MPopover,
 		MPopoverContent,
@@ -525,6 +547,89 @@ export default {
 };
 </script>
 ```
+
+_DemoBlade.vue_
+
+```vue
+<template>
+	<m-blade>
+		<img
+			class="cover-photo"
+			src="https://picsum.photos/400/300"
+		>
+		<m-blade-content>
+			<m-text pattern="title">
+				Popover in a blade
+			</m-text>
+			<m-popover>
+				<template #action="popover">
+					<m-button
+						size="small"
+						pattern="primaryOutline"
+						@click="popover.toggle()"
+					>
+						Toggle popover
+					</m-button>
+				</template>
+
+				<template #content>
+					<m-popover-content>
+						<demo-popover>
+							<m-button
+								size="small"
+								pattern="primaryOutline"
+								@click="closeBlade"
+							>
+								Close blade
+							</m-button>
+						</demo-popover>
+					</m-popover-content>
+				</template>
+			</m-popover>
+		</m-blade-content>
+	</m-blade>
+</template>
+
+<script>
+import { MBlade, MBladeContent, bladeApi } from '@square/maker/components/Blade';
+import { MButton } from '@square/maker/components/Button';
+import { MText } from '@square/maker/components/Text';
+import { MPopover, MPopoverContent } from '@square/maker/components/Popover';
+import DemoPopover from 'doc/DemoPopoverContent.vue';
+
+export default {
+	components: {
+		MBlade,
+		MBladeContent,
+		MButton,
+		MText,
+		MPopover,
+		MPopoverContent,
+		DemoPopover,
+	},
+
+	inject: {
+		bladeApi,
+	},
+
+	methods: {
+		closeBlade() {
+			this.bladeApi.close();
+		},
+	},
+};
+</script>
+
+<style scoped>
+.cover-photo {
+	width: 100%;
+	height: 300px;
+	object-fit: cover;
+	object-position: center;
+}
+</style>
+```
+
 
 _DemoPopoverContent.vue_
 
@@ -556,8 +661,6 @@ _DemoPopoverContent.vue_
 import { MText } from '@square/maker/components/Text';
 
 export default {
-	name: 'DemoPopoverContent',
-
 	components: {
 		MText,
 	},

--- a/src/components/Select/src/SelectControl.vue
+++ b/src/components/Select/src/SelectControl.vue
@@ -195,6 +195,7 @@ export default {
 	min-width: 80px;
 	font-size: 16px;
 	border-radius: $maker-shape-default-border-radius;
+	fill: currentColor;
 }
 
 .Prefix {
@@ -226,7 +227,7 @@ export default {
 	height: 48px;
 	padding: 0 32px 0 16px;
 	overflow: hidden;
-	color: var(--color-foreground);
+	color: var(--color-placeholder);
 	font-weight: inherit;
 	font-size: inherit;
 	font-family: inherit;

--- a/src/components/Toast/README.md
+++ b/src/components/Toast/README.md
@@ -5,19 +5,25 @@ Use MToast to notify users of things.
 ```vue
 <template>
 	<div>
-		<button @click="openToast">
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="openToast"
+		>
 			open toast
-		</button>
+		</m-button>
 		<m-toast-layer />
 	</div>
 </template>
 
 <script>
 import { MToastLayer, MToast } from '@square/maker/components/Toast';
+import { MButton } from '@square/maker/components/Button';
 
 export default {
 	components: {
 		MToastLayer,
+		MButton,
 	},
 
 	mixins: [
@@ -84,38 +90,62 @@ Toasts will auto-dismiss after 5000 milliseconds (5 seconds) by default. You can
 ```vue
 <template>
 	<div>
-		<button @click="openToast(1000)">
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="openToast(1000)"
+		>
 			open short toast (1s)
-		</button>
-		<button @click="openToast(5000)">
+		</m-button>
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="openToast(5000)"
+		>
 			open default toast (5s)
-		</button>
-		<button @click="openToast(10000)">
+		</m-button>
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="openToast(10000)"
+		>
 			open long toast (10s)
-		</button>
-		<button @click="openToast(-1)">
+		</m-button>
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="openToast(-1)"
+		>
 			open persistent toast (indefinite)
-		</button>
+		</m-button>
 		<br>
-		<button @click="closeAllToasts">
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="closeAllToasts"
+		>
 			programmatically close all toasts
-		</button>
-		<button
+		</m-button>
+		<m-button
+			size="small"
+			pattern="primaryOutline"
 			:disabled="!persistentCloseFns.length"
 			@click="closePersistentToast"
 		>
 			programmatically close persistent toast
-		</button>
+		</m-button>
 		<m-toast-layer />
 	</div>
 </template>
 
 <script>
 import { MToastLayer, MToast } from '@square/maker/components/Toast';
+import { MButton } from '@square/maker/components/Button';
 
 export default {
 	components: {
 		MToastLayer,
+		MButton,
 	},
 
 	mixins: [
@@ -168,9 +198,13 @@ Toasts can have actions which can be passed via the `actions` prop. Every action
 ```vue
 <template>
 	<div>
-		<button @click="openToast">
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="openToast"
+		>
 			open toast
-		</button>
+		</m-button>
 		<br>
 		count: {{ count }}
 		<m-toast-layer />
@@ -178,10 +212,12 @@ Toasts can have actions which can be passed via the `actions` prop. Every action
 </template>
 
 <script>
+import { MButton } from '@square/maker/components/Button';
 import { MToastLayer, MToast } from '@square/maker/components/Toast';
 
 export default {
 	components: {
+		MButton,
 		MToastLayer,
 	},
 
@@ -223,9 +259,13 @@ Toasts can also optionally display progress. To render a progress bar pass a 0 -
 ```vue
 <template>
 	<div>
-		<button @click="openToast">
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="openToast"
+		>
 			open toast
-		</button>
+		</m-button>
 		<br>
 		<label>
 			progress {{ progress }}%
@@ -243,10 +283,12 @@ Toasts can also optionally display progress. To render a progress bar pass a 0 -
 </template>
 
 <script>
+import { MButton } from '@square/maker/components/Button';
 import { MToastLayer, MToast } from '@square/maker/components/Toast';
 
 export default {
 	components: {
+		MButton,
 		MToastLayer,
 	},
 
@@ -280,24 +322,28 @@ Toasts have the following built-in default patterns: `info` (default), `success`
 <template>
 	<div>
 		open toast:
-		<button
+		<m-button
 			v-for="pattern in defaultToastPatterns"
 			:key="pattern"
+			size="small"
+			pattern="primaryOutline"
 			class="toastbutton"
 			@click="openToast(pattern)"
 		>
 			{{ pattern }}
-		</button>
+		</m-button>
 		<m-toast-layer />
 	</div>
 </template>
 
 <script>
+import { MButton } from '@square/maker/components/Button';
 import { defaultTheme } from '@square/maker/components/Theme';
 import { MToastLayer, MToast } from '@square/maker/components/Toast';
 
 export default {
 	components: {
+		MButton,
 		MToastLayer,
 	},
 
@@ -336,9 +382,13 @@ An example combining all of the features above that you can copy & paste into yo
 ```vue
 <template>
 	<div>
-		<button @click="openToast">
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="openToast"
+		>
 			open toast
-		</button>
+		</m-button>
 		<m-toast-layer />
 	</div>
 </template>
@@ -346,10 +396,12 @@ An example combining all of the features above that you can copy & paste into yo
 <script>
 /* eslint-disable no-return-assign */
 import { MToastLayer, MToast } from '@square/maker/components/Toast';
+import { MButton } from '@square/maker/components/Button';
 
 export default {
 	components: {
 		MToastLayer,
+		MButton,
 	},
 
 	mixins: [
@@ -397,25 +449,29 @@ By default, icons are hidden for `info` and `primary` patterns and shown for the
 <template>
 	<div>
 		open toast:
-		<button
+		<m-button
 			v-for="config in invertedShowIcons"
 			:key="config.pattern"
+			size="small"
+			pattern="primaryOutline"
 			class="toastbutton"
 			@click="openToast(config.pattern, config.showIcon)"
 		>
 			{{ config.pattern }} {{ config.showIcon ? 'with' : 'without' }} an icon
-		</button>
+		</m-button>
 		<m-toast-layer />
 	</div>
 </template>
 
 <script>
+import { MButton } from '@square/maker/components/Button';
 import { defaultTheme } from '@square/maker/components/Theme';
 import { MToastLayer, MToast } from '@square/maker/components/Toast';
 
 export default {
 	components: {
 		MToastLayer,
+		MButton,
 	},
 
 	mixins: [
@@ -473,10 +529,14 @@ Use `actionbarOffset: true` when opening the toast.
 			style="padding-bottom: 0"
 		>
 			<div class="showOnMobile">
-				<button @click="showActionbar = !showActionbar">
+				<m-button
+					size="small"
+					pattern="primaryOutline"
+					@click="showActionbar = !showActionbar"
+				>
 					{{ showActionbar ? 'hide' : 'show' }}
 					global actionbar
-				</button>
+				</m-button>
 				<div
 					v-if="showActionbar"
 				>
@@ -496,12 +556,20 @@ Use `actionbarOffset: true` when opening the toast.
 							Confirm action
 						</m-action-bar-button>
 					</m-action-bar>
-					<button @click="openToastWithOffset">
+					<m-button
+						size="small"
+						pattern="primaryOutline"
+						@click="openToastWithOffset"
+					>
 						✅ show toast (with actionbar offset on mobile)
-					</button>
-					<button @click="openToast">
+					</m-button>
+					<m-button
+						size="small"
+						pattern="primaryOutline"
+						@click="openToast"
+					>
 						❌ show default toast (covering actionbar)
-					</button>
+					</m-button>
 				</div>
 			</div>
 			<div class="showOnTablet">
@@ -514,6 +582,7 @@ Use `actionbarOffset: true` when opening the toast.
 </template>
 
 <script>
+import { MButton } from '@square/maker/components/Button';
 import { MToastLayer, MToast } from '@square/maker/components/Toast';
 import { MActionBar, MActionBarButton, MActionBarLayer } from '@square/maker/components/ActionBar';
 import XIcon from '@square/maker-icons/X';
@@ -525,6 +594,7 @@ export default {
 		MActionBar,
 		MActionBarButton,
 		XIcon,
+		MButton,
 	},
 	mixins: [
 		MToastLayer.apiMixin,
@@ -581,17 +651,20 @@ Same as for dodging global actionbars. Use `actionbarOffset: true` when opening 
 ```vue
 <template>
 	<div>
-		<button
+		<m-button
+			size="small"
+			pattern="primaryOutline"
 			@click="openModal"
 		>
 			Open modal
-		</button>
+		</m-button>
 		<m-modal-layer />
 		<m-toast-layer />
 	</div>
 </template>
 
 <script>
+import { MButton } from '@square/maker/components/Button';
 import { MModalLayer } from '@square/maker/components/Modal';
 import { MToastLayer } from '@square/maker/components/Toast';
 import ActionbarModal from 'doc/ActionbarModal.vue';
@@ -600,6 +673,7 @@ export default {
 	components: {
 		MModalLayer,
 		MToastLayer,
+		MButton,
 	},
 
 	mixins: [
@@ -631,12 +705,20 @@ _ActionbarModal.vue_
 			</m-text>
 			resize your screen above/below 840px (breakpoint separately
 			mobile &amp; desktop styles)
-			<button @click="openToastWithOffset">
+			<m-button
+				size="small"
+				pattern="primaryOutline"
+				@click="openToastWithOffset"
+			>
 				✅ show toast (with actionbar offset on mobile)
-			</button>
-			<button @click="openToast">
+			</m-button>
+			<m-button
+				size="small"
+				pattern="primaryOutline"
+				@click="openToast"
+			>
 				❌ show default toast (covering actionbar)
-			</button>
+			</m-button>
 			<m-inline-action-bar>
 				<m-action-bar-button
 					key="close"
@@ -659,6 +741,7 @@ _ActionbarModal.vue_
 </template>
 
 <script>
+import { MButton } from '@square/maker/components/Button';
 import { MText } from '@square/maker/components/Text';
 import { MModal, modalApi, MModalContent } from '@square/maker/components/Modal';
 import { MInlineActionBar, MActionBarButton } from '@square/maker/components/ActionBar';
@@ -667,6 +750,7 @@ import { toastApi, MToast } from '@square/maker/components/Toast';
 
 export default {
 	components: {
+		MButton,
 		MText,
 		MModal,
 		MActionBarButton,
@@ -721,14 +805,19 @@ The close icon can be customized by changing the `close` icon in the `icons` sec
 ```vue
 <template>
 	<m-theme :theme="theme">
-		<button @click="openZapToast">
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="openZapToast"
+		>
 			open zap toast
-		</button>
+		</m-button>
 		<m-toast-layer />
 	</m-theme>
 </template>
 
 <script>
+import { MButton } from '@square/maker/components/Button';
 import { MTheme } from '@square/maker/components/Theme';
 import { MToastLayer, MToast } from '@square/maker/components/Toast';
 import Zap from '@square/maker-icons/Zap';
@@ -737,6 +826,7 @@ import ChevronRight from '@square/maker-icons/ChevronRight';
 export default {
 	components: {
 		MTheme,
+		MButton,
 		MToastLayer,
 	},
 
@@ -776,18 +866,24 @@ If MToast doesn't satify your needs and you need custom toast for a specific sit
 ```vue
 <template>
 	<div>
-		<button @click="openToast">
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="openToast"
+		>
 			open custom toast
-		</button>
+		</m-button>
 		<m-toast-layer />
 	</div>
 </template>
 
 <script>
+import { MButton } from '@square/maker/components/Button';
 import { MToastLayer, MBread } from '@square/maker/components/Toast';
 
 export default {
 	components: {
+		MButton,
 		MToastLayer,
 	},
 

--- a/src/utils/Row/README.md
+++ b/src/utils/Row/README.md
@@ -1,5 +1,7 @@
 # Row
 
+Use Row when you need layout a title and an optional subtitle, secondary title, secondary subtitle, prefix icon or control, and suffix icon or control. This component is used internally in [Accordion](#/Accordion) and [Menu](#/Menu).
+
 ```vue
 <template>
 	<div class="wrapper">

--- a/src/utils/Row/src/Row.vue
+++ b/src/utils/Row/src/Row.vue
@@ -72,6 +72,8 @@ export default {
 	gap: 8px;
 	align-items: center;
 	width: 100%;
+	color: var(--maker-color-body);
+	fill: currentColor;
 }
 
 .Label,

--- a/src/utils/Transition/README.md
+++ b/src/utils/Transition/README.md
@@ -60,7 +60,7 @@ export default {
 .box {
 	width: 100%;
 	height: 100%;
-	background-color: #ccc;
+	background-color: var(--maker-color-neutral-10);
 	border-radius: 16px;
 }
 </style>
@@ -121,7 +121,7 @@ export default {
 	width: 100%;
 	height: 100%;
 	border-radius: 16px 16px 0 0;
-	background-color: #ccc;
+	background-color: var(--maker-color-neutral-10);
 }
 </style>
 ```
@@ -181,7 +181,7 @@ export default {
 	width: 100%;
 	height: 100%;
 	border-radius: 16px 16px 0 0;
-	background-color: #ccc;
+	background-color: var(--maker-color-neutral-10);
 }
 </style>
 ```
@@ -241,7 +241,7 @@ export default {
 	width: 100%;
 	height: 100%;
 	border-radius: 16px 16px 0 0;
-	background-color: #ccc;
+	background-color: var(--maker-color-neutral-10);
 }
 </style>
 ```

--- a/src/utils/TransitionCollapse/README.md
+++ b/src/utils/TransitionCollapse/README.md
@@ -76,9 +76,9 @@ export default {
 	justify-content: center;
 	align-items: center;
 	box-sizing: border-box;
-    background-color: #ccc;
+    background-color: var(--maker-color-neutral-10);
 	padding: 40px;
-	border: 2px solid black;
+	border: 2px solid var(--maker-color-neutral-20);
 	width: 500px;
 }
 </style>

--- a/src/utils/TransitionFadeIn/README.md
+++ b/src/utils/TransitionFadeIn/README.md
@@ -45,7 +45,7 @@ export default {
 .gray-box {
     width: 300px;
     height: 500px;
-    background-color: #ccc;
+    background-color: var(--maker-color-neutral-10);
 }
 </style>
 ```

--- a/src/utils/TransitionResponsive/README.md
+++ b/src/utils/TransitionResponsive/README.md
@@ -74,7 +74,7 @@ export default {
 .box {
 	width: 100%;
 	height: 100%;
-	background-color: #ccc;
+	background-color: var(--maker-color-neutral-10);
 	border-radius: 16px;
 }
 </style>

--- a/src/utils/TransitionSpringLeft/README.md
+++ b/src/utils/TransitionSpringLeft/README.md
@@ -51,7 +51,7 @@ export default {
     width: 100%;
     height: 100%;
     border-radius: 16px 0 0 16px;
-    background-color: #ccc;
+    background-color: var(--maker-color-neutral-10);
 }
 </style>
 ```

--- a/src/utils/TransitionSpringUp/README.md
+++ b/src/utils/TransitionSpringUp/README.md
@@ -46,7 +46,7 @@ export default {
     width: 100%;
     height: 100%;
     border-radius: 16px 16px 0 0;
-    background-color: #ccc;
+    background-color: var(--maker-color-neutral-10);
 }
 </style>
 ```

--- a/src/utils/TransitionStack/README.md
+++ b/src/utils/TransitionStack/README.md
@@ -12,32 +12,42 @@ How items are animated into the stack can be controlled via the `transition-from
 <template>
 	<div class="demo">
 		<div class="buttons">
-			<button
+			<m-button
+				size="small"
+				pattern="primaryOutline"
 				@click="insertItem"
 			>
 				insert randomly
-			</button>
-			<button
+			</m-button>
+			<m-button
+				size="small"
+				pattern="primaryOutline"
 				@click="removeItem"
 			>
 				remove randomly
-			</button>
-			<button
+			</m-button>
+			<m-button
+				size="small"
+				pattern="primaryOutline"
 				@click="cycleTransitionFrom"
 			>
 				transition from {{ transitionFrom }}
-			</button>
+			</m-button>
 			<br>
-			<button
+			<m-button
+				size="small"
+				pattern="primaryOutline"
 				@click="cycleTransitionDuration"
 			>
 				transition duration {{ transitionDuration }}s
-			</button>
-			<button
+			</m-button>
+			<m-button
+				size="small"
+				pattern="primaryOutline"
 				@click="cycleAlign"
 			>
 				align {{ align }}
-			</button>
+			</m-button>
 		</div>
 		<m-transition-stack
 			class="stack"
@@ -62,6 +72,7 @@ How items are animated into the stack can be controlled via the `transition-from
 </template>
 
 <script>
+import { MButton } from '@square/maker/components/Button';
 import { MTransitionStack } from '@square/maker/utils/TransitionStack';
 
 function randomInt(exclusiveMax) {
@@ -156,6 +167,7 @@ function cycle(current, available) {
 export default {
 	components: {
 		MTransitionStack,
+		MButton,
 	},
 
 	data() {
@@ -261,21 +273,27 @@ It's possible to turn MTransitionStack into a full-screen overlay with `position
 <template>
 	<div class="demo">
 		<div class="buttons">
-			<button
+			<m-button
+				size="small"
+				pattern="primaryOutline"
 				@click="insertItem"
 			>
 				add item
-			</button>
-			<button
+			</m-button>
+			<m-button
+				size="small"
+				pattern="primaryOutline"
 				@click="removeItem"
 			>
 				remove item
-			</button>
-			<button
+			</m-button>
+			<m-button
+				size="small"
+				pattern="primaryOutline"
 				@click="cyclePosition"
 			>
 				position {{ position }}
-			</button>
+			</m-button>
 		</div>
 		<m-transition-stack
 			class="stack"
@@ -295,6 +313,7 @@ It's possible to turn MTransitionStack into a full-screen overlay with `position
 </template>
 
 <script>
+import { MButton } from '@square/maker/components/Button';
 import { MTransitionStack } from '@square/maker/utils/TransitionStack';
 
 function randomInt(exclusiveMax) {
@@ -370,6 +389,7 @@ function cycle(current, available) {
 export default {
 	components: {
 		MTransitionStack,
+		MButton,
 	},
 
 	data() {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->


## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

1. poor contrast for custom icons in Row, Accordion, Select
2. normalizes buttons & background colors across examples in all readmes

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
1. commit: https://github.com/square/maker/pull/483/commits/fdea470c0008f37c86be86377043c481a12be402
2. commit: https://github.com/square/maker/pull/483/commits/aaa299ec84693105e65f3abb9b32a47cb37e30f2

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
affected components:
- Row: https://square.github.io/maker/styleguide/custom-icons-contrast/#/Row
- Accordion: https://square.github.io/maker/styleguide/custom-icons-contrast/#/Accordion
- Menu: https://square.github.io/maker/styleguide/custom-icons-contrast/#/Menu