### PR TITLE
fix(theme): update contextual colors

### DIFF
--- a/lab/experiments/ThemeTest.vue
+++ b/lab/experiments/ThemeTest.vue
@@ -301,31 +301,9 @@
 								<check-circle :class="$s.Icon" /> Estimated prep time: 15 minutes
 							</m-text>
 						</m-card>
-						<m-notice
-							type="info"
-							display="block"
-						>
-							Switching to shipping will change the scheduled time you selected
-						</m-notice>
 					</div>
 					<m-divider :class="$s.Divider" />
 					<div>
-						<m-input
-							placeholder="Delivery address"
-						/>
-						<m-input
-							placeholder="Disabled text input"
-							disabled
-						/>
-						<m-input
-							variant="outline"
-							placeholder="Delivery address"
-						/>
-						<m-input
-							placeholder="Disabled text input"
-							variant="outline"
-							disabled
-						/>
 						<div :class="$s.pills">
 							<m-pill
 								v-for="pattern in pillPatterns"
@@ -380,6 +358,20 @@
 						>
 							Action has been successfully completed
 						</m-notice>
+						<div :class="$s.buttons">
+							<template
+								v-for="pattern in buttonPatterns"
+							>
+								<m-button
+									v-if="!pattern.includes('Ghost')"
+									:key="pattern"
+									:pattern="pattern"
+									size="small"
+								>
+									{{ pattern }}
+								</m-button>
+							</template>
+						</div>
 					</div>
 					<m-divider :class="$s.Divider" />
 					<div>
@@ -494,6 +486,22 @@
 								obligatory sublabel
 							</template>
 						</m-checkbox>
+						<m-input
+							placeholder="Delivery address"
+						/>
+						<m-input
+							placeholder="Disabled text input"
+							disabled
+						/>
+						<m-input
+							variant="outline"
+							placeholder="Delivery address"
+						/>
+						<m-input
+							placeholder="Disabled text input"
+							variant="outline"
+							disabled
+						/>
 						<m-textarea placeholder="Additional requests" />
 						<m-textarea
 							placeholder="Disabled textbox"
@@ -877,6 +885,7 @@ export default {
 				'32px',
 			],
 			pillPatterns: Object.keys(defaultTheme().pill.patterns),
+			buttonPatterns: Object.keys(defaultTheme().button.patterns),
 			iconStyle: 'filled',
 		};
 	},
@@ -965,7 +974,8 @@ export default {
 </script>
 
 <style module="$s">
-.pills > * {
+.pills > *,
+.buttons > * {
 	margin: 4px;
 }
 
@@ -1000,7 +1010,7 @@ export default {
 	}
 }
 
-hr.Divider {
+.Divider {
 	margin: 8px 0;
 	padding: 0 !important;
 }
@@ -1032,7 +1042,7 @@ hr.Divider {
 	}
 
 	& > div > * {
-		margin-bottom: 16px;
+		margin-bottom: 8px;
 	}
 
 	& > div > *:last-child {

--- a/src/utils/maker-colors.js
+++ b/src/utils/maker-colors.js
@@ -73,8 +73,8 @@ function isDark(hex) {
 }
 
 function enoughContrastForFill(hex1, hex2) {
-	const CONTRAST_FILL = 0.25;
-	return colord(hex1).delta(hex2) >= CONTRAST_FILL;
+	const MAKER_DELTA_FILL = 0.25;
+	return colord(hex1).delta(hex2) >= MAKER_DELTA_FILL;
 }
 
 function enoughContrastForText(hex1, hex2) {

--- a/src/utils/maker-colors.js
+++ b/src/utils/maker-colors.js
@@ -1,9 +1,9 @@
 import { colord, extend } from 'colord';
 import a11yPlugin from 'colord/plugins/a11y';
 import mixPlugin from 'colord/plugins/mix';
+import labPlugin from 'colord/plugins/lab';
 import { cloneDeep } from 'lodash';
 import {
-	WCAG_CONTRAST_TEXT,
 	WCAG_CONTRAST_TITLE,
 	DARK_COLOR_LUMINANCE_THRESHOLD,
 	getContrast,
@@ -12,7 +12,7 @@ import defaultColors from '../components/Theme/src/default-colors';
 
 const DEFAULT_COLORS = defaultColors();
 
-extend([a11yPlugin, mixPlugin]);
+extend([a11yPlugin, mixPlugin, labPlugin]);
 
 const NEUTRAL_RATIOS = {
 	light: {
@@ -25,7 +25,7 @@ const NEUTRAL_RATIOS = {
 	},
 	dark: {
 		'neutral-0': 0,
-		'neutral-10': 0.255,
+		'neutral-10': 0.225,
 		'neutral-20': 0.37,
 		'neutral-80': 0.55,
 		'neutral-90': 0.95,
@@ -73,6 +73,11 @@ function isDark(hex) {
 }
 
 function enoughContrastForFill(hex1, hex2) {
+	const CONTRAST_FILL = 0.25;
+	return colord(hex1).delta(hex2) >= CONTRAST_FILL;
+}
+
+function enoughContrastForText(hex1, hex2) {
 	return colord(hex1).contrast(hex2) >= WCAG_CONTRAST_TITLE;
 }
 
@@ -81,32 +86,31 @@ function generateContextualPrimaryColors(
 	primary = DEFAULT_COLORS.primary,
 	neutralColors,
 ) {
-	const isDarkBg = isDark(background);
 	const backgroundContrast = getContrast(background);
+	const primaryHsl = colord(primary).toHsl();
 	const primaryColors = {};
 	if (enoughContrastForFill(primary, background)) {
 		primaryColors.fill = primary;
-		const DARKEN_PRIMARY_FOR_TEXT = 0.2;
-		primaryColors.text = colord(primary)
-			.mix(backgroundContrast, DARKEN_PRIMARY_FOR_TEXT)
-			.toHex();
+		const ADJUST_PRIMARY_FOR_TEXT = 0.2;
+		primaryColors.text = enoughContrastForText(primary, background)
+			? colord(primary).mix(backgroundContrast, ADJUST_PRIMARY_FOR_TEXT).toHex()
+			: backgroundContrast;
 		primaryColors.onFill = getContrast(primaryColors.fill);
 	} else {
 		primaryColors.fill = backgroundContrast;
 		primaryColors.text = backgroundContrast;
 		primaryColors.onFill = primary;
 	}
-	if (isDarkBg) {
-		primaryColors.subtle = neutralColors['neutral-10'];
-	} else {
+	if (colord(background).toHex() === '#ffffff') {
 		const SUBTLE_SATURATION = 25;
 		const SUBTLE_LIGHTNESS = 95;
-		const primaryHsl = colord(primary).toHsl();
 		primaryColors.subtle = colord({
 			h: primaryHsl.h,
 			s: SUBTLE_SATURATION,
 			l: SUBTLE_LIGHTNESS,
 		}).toHex();
+	} else {
+		primaryColors.subtle = neutralColors['neutral-10'];
 	}
 	return primaryColors;
 }
@@ -142,16 +146,16 @@ export default function makerColors(
 
 	// derive contextual critical, warning, success colors
 	['critical', 'warning', 'success'].forEach((name) => {
-		if (colord(contextualColors[name].text).contrast(background) < WCAG_CONTRAST_TEXT) {
+		if (!enoughContrastForFill(contextualColors[name].fill, background)) {
 			contextualColors[name].onFill = contextualColors[name].fill;
-			contextualColors[name].text = backgroundContrast;
 			contextualColors[name].fill = backgroundContrast;
 		}
-
-		if (!contextualColors[name].subtle) {
+		if (!enoughContrastForText(contextualColors[name].text, background)) {
+			contextualColors[name].text = backgroundContrast;
+		}
+		if (colord(background).toHex() !== '#ffffff') {
 			contextualColors[name].subtle = neutralColors['neutral-10'];
 		}
-
 		if (!contextualColors[name].onFill) {
 			contextualColors[name].onFill = getContrast(contextualColors[name].fill);
 		}


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Our current contextual colors are not as optimized against colorful MTheme backgrounds as they are against black and white backgrounds.
<img width="453" alt="Screen Shot 2022-10-31 at 1 14 11 PM" src="https://user-images.githubusercontent.com/1486885/199073912-b90be122-6589-4e0a-993d-60420bfff658.png">
<img width="448" alt="Screen Shot 2022-10-31 at 1 15 25 PM" src="https://user-images.githubusercontent.com/1486885/199073938-bda53ace-4044-47eb-af5b-ec463472d8d1.png">

<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
Some design-suggested changes to the contextual color logic for colorful backgrounds.
<img width="450" alt="Screen Shot 2022-10-31 at 1 07 32 PM" src="https://user-images.githubusercontent.com/1486885/199074098-9bcf7eda-6622-4d40-9599-b2e34ea129d4.png">
<img width="452" alt="Screen Shot 2022-10-31 at 1 09 49 PM" src="https://user-images.githubusercontent.com/1486885/199074199-7003339f-2bef-4d61-bbf7-5ac3c277e67d.png">
<!--
  📸 Inline screenshots to better communicate the changes
-->

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
