### PR TITLE
fix: contextual error color for form components

### DIFF
--- a/src/components/Checkbox/src/CheckboxControl.vue
+++ b/src/components/Checkbox/src/CheckboxControl.vue
@@ -102,7 +102,7 @@ export default {
 	--color-border: $maker-color-neutral-20;
 	--color-border-focus: $maker-color-body;
 	--color-active: $maker-color-body;
-	--color-error: rgba(206, 50, 23, 1);
+	--color-error: $maker-color-critical-fill;
 }
 
 .Checkbox {

--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -69,7 +69,7 @@ export default {
 <template>
 	<m-input placeholder="Placeholder">
 		<template #error>
-			<m-notice type="error">
+			<m-notice pattern="error">
 				error message here
 			</m-notice>
 		</template>

--- a/src/components/Input/src/InputControl.vue
+++ b/src/components/Input/src/InputControl.vue
@@ -170,7 +170,7 @@ export default {
 	--color-placeholder: $maker-color-neutral-80;
 	--color-foreground: $maker-color-neutral-90;
 	--color-border-active: $maker-color-neutral-80;
-	--color-error: rgba(206, 50, 23, 1);
+	--color-error: $maker-color-critical-fill;
 
 	display: flex;
 	align-items: center;

--- a/src/components/PinInput/README.md
+++ b/src/components/PinInput/README.md
@@ -22,7 +22,7 @@ call `shakeAndClearInputs()` on the referenced component.
 			v-if="invalidEntry"
 			#error
 		>
-			<m-notice type="error">
+			<m-notice pattern="error">
 				Error slot
 			</m-notice>
 		</template>
@@ -72,7 +72,7 @@ export default {
 			v-if="invalidEntry"
 			#error
 		>
-			<m-notice type="error">
+			<m-notice pattern="error">
 				Error slot
 			</m-notice>
 		</template>
@@ -121,7 +121,7 @@ export default {
 			v-if="invalidEntry"
 			#error
 		>
-			<m-notice type="error">
+			<m-notice pattern="error">
 				Error slot
 			</m-notice>
 		</template>
@@ -170,7 +170,7 @@ export default {
 			v-if="invalidEntry"
 			#error
 		>
-			<m-notice type="error">
+			<m-notice pattern="error">
 				Error slot
 			</m-notice>
 		</template>
@@ -221,7 +221,7 @@ export default {
 			v-if="invalidEntry"
 			#error
 		>
-			<m-notice type="error">
+			<m-notice pattern="error">
 				Error slot
 			</m-notice>
 		</template>
@@ -330,7 +330,7 @@ _DemoDialog.vue_
 					v-if="invalidEntry"
 					#error
 				>
-					<m-notice type="error">
+					<m-notice pattern="error">
 						Error slot
 					</m-notice>
 				</template>

--- a/src/components/PinInput/src/PinInputControl.vue
+++ b/src/components/PinInput/src/PinInputControl.vue
@@ -304,7 +304,7 @@ export default {
 	}
 
 	&.error {
-		border-color: rgba(206, 50, 23, 1);
+		border-color: $maker-color-critical-fill;
 	}
 }
 

--- a/src/components/Radio/src/RadioControl.vue
+++ b/src/components/Radio/src/RadioControl.vue
@@ -102,7 +102,7 @@ export default {
 	--color-border: $maker-color-neutral-20;
 	--color-border-focus: $maker-color-body;
 	--color-active: $maker-color-body;
-	--color-error: rgba(206, 50, 23, 1);
+	--color-error: $maker-color-critical-fill;
 }
 
 .Radio {

--- a/src/components/Select/README.md
+++ b/src/components/Select/README.md
@@ -152,7 +152,7 @@ export default {
 		:options="options"
 	>
 		<template #error>
-			<m-notice type="error">
+			<m-notice pattern="error">
 				error message here
 			</m-notice>
 		</template>

--- a/src/components/Select/src/SelectControl.vue
+++ b/src/components/Select/src/SelectControl.vue
@@ -188,7 +188,7 @@ export default {
 	--color-placeholder: $maker-color-neutral-80;
 	--color-foreground: $maker-color-neutral-90;
 	--color-border-active: $maker-color-neutral-80;
-	--color-error: rgba(206, 50, 23, 1);
+	--color-error: $maker-color-critical-fill;
 
 	position: relative;
 	box-sizing: border-box;

--- a/src/components/Textarea/README.md
+++ b/src/components/Textarea/README.md
@@ -70,7 +70,7 @@ export default {
 <template>
 	<m-textarea placeholder="Placeholder">
 		<template #error>
-			<m-notice type="error">
+			<m-notice pattern="error">
 				error message here
 			</m-notice>
 		</template>

--- a/src/components/Textarea/src/TextareaControl.vue
+++ b/src/components/Textarea/src/TextareaControl.vue
@@ -111,7 +111,7 @@ export default {
 	--color-placeholder: $maker-color-neutral-80;
 	--color-foreground: $maker-color-neutral-90;
 	--color-border-active: $maker-color-neutral-80;
-	--color-error: rgba(206, 50, 23, 1);
+	--color-error: $maker-color-critical-fill;
 
 	box-sizing: border-box;
 	width: 100%;

--- a/src/components/Theme/src/publicize-vars.js
+++ b/src/components/Theme/src/publicize-vars.js
@@ -29,6 +29,9 @@ module.exports = function publicizeVars(theme) {
 		'--maker-color-elevation': colors.elevation,
 		'--maker-color-overlay': colors.overlay,
 
+		// contextual colors
+		'--maker-color-critical-fill': colors.critical.fill,
+
 		// typography
 		'--maker-font-heading-font-family': fonts.heading.fontFamily,
 		'--maker-font-heading-font-weight': fonts.heading.fontWeight,

--- a/src/components/Toggle/src/ToggleControl.vue
+++ b/src/components/Toggle/src/ToggleControl.vue
@@ -77,7 +77,7 @@ export default {
 /* default unchecked state */
 .Checkbox {
 	/* general vars */
-	--color-error: rgba(206, 50, 23, 1);
+	--color-error: $maker-color-critical-fill;
 	--transition: 0.2s ease;
 
 	/* toggle vars */


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
error colors in a lot of form components were not contextual

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
makes error color in all form components contextual

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
affected components:
- [checkbox](https://square.github.io/maker/styleguide/contextual-invalid-forms/#/Checkbox)
- [input](https://square.github.io/maker/styleguide/contextual-invalid-forms/#/Input)
- [pininput](https://square.github.io/maker/styleguide/contextual-invalid-forms/#/PinInput)
- [radio](https://square.github.io/maker/styleguide/contextual-invalid-forms/#/Radio)
- [select](https://square.github.io/maker/styleguide/contextual-invalid-forms/#/Select)
- [textarea](https://square.github.io/maker/styleguide/contextual-invalid-forms/#/Textarea)
- [toggle](https://square.github.io/maker/styleguide/contextual-invalid-forms/#/Toggle)