### PR TITLE
fix(button): enforce bottom padding, margin on truncated text

### DIFF
--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -626,10 +626,10 @@ export default {
 	width: fit-content;
 
 	/* cancels out padding-bottom below */
-	margin-bottom: -0.5em;
+	margin-bottom: -0.5em !important;
 
 	/* https://stackoverflow.com/a/64039674/2766908 */
-	padding-bottom: 0.5em;
+	padding-bottom: 0.5em !important;
 	overflow: hidden;
 	line-height: 1.1 !important;
 	text-overflow: ellipsis;


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
The padding/margin-bottom fix for button text being cut off can sometimes result in misalignment, when the `margin: 0` style of MText is loaded after `margin-bottom: 0` and receives precedence.
<img width="149" alt="Screen Shot 2022-11-01 at 12 20 37 PM" src="https://user-images.githubusercontent.com/1486885/199284492-9fb90622-6562-411b-80e8-05275da07657.png">
<img width="221" alt="Screen Shot 2022-11-01 at 12 20 41 PM" src="https://user-images.githubusercontent.com/1486885/199284511-22de1451-c809-4875-80d1-a04b02404b09.png">

<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
Adds `!important` property to the padding/margin styles for the button text fix.
<!--
  📸 Inline screenshots to better communicate the changes
-->

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
