### PR TITLE
feat(ordercard): add OrderCard component

### DIFF
--- a/src/components/OrderCard/README.md
+++ b/src/components/OrderCard/README.md
@@ -1,0 +1,97 @@
+# OrderCard
+
+Use OrderCard to display order information
+
+
+## Examples
+```vue
+<template>
+	<div class="container">
+		<m-order-card
+			:label="'Order Label'"
+			:title="'Order Title'"
+			:thumbnails="thumbnails"
+			:primary-action-text="'Primary'"
+			:secondary-action-text="'Secondary'"
+		/>
+		<m-divider />
+		<m-order-card
+			:title="'Order with no label'"
+			:thumbnails="thumbnails"
+			:primary-action-text="'Primary'"
+			:secondary-action-text="'Secondary'"
+		/>
+		<m-divider />
+		<m-order-card
+			:label="'Order Label'"
+			:title="'Order with fewer thumbnails'"
+			:thumbnails="fewerThumbnails"
+			:primary-action-text="'Primary'"
+		/>
+		<m-divider />
+		<m-order-card
+			:label="'Order Label'"
+			:title="'Order with no thumbnails'"
+			:primary-action-text="'Primary'"
+			:secondary-action-text="'Secondary'"
+		/>
+		<m-divider />
+		<m-order-card
+			:label="'Order Label'"
+			:title="'Order with no secondary action'"
+			:thumbnails="thumbnails"
+			:primary-action-text="'Primary'"
+		/>
+	</div>
+</template>
+
+<script>
+import { MOrderCard } from '@square/maker/components/OrderCard';
+import { MDivider } from '@square/maker/components/Divider';
+
+export default {
+	components: {
+		MOrderCard,
+		MDivider,
+	},
+
+	data() {
+		return {
+			thumbnails: [
+				'https://source.unsplash.com/random/400x600',
+				'https://source.unsplash.com/random/400x600',
+				'https://source.unsplash.com/random/400x600',
+				'https://source.unsplash.com/random/400x600',
+				'https://source.unsplash.com/random/400x600',
+				'https://source.unsplash.com/random/400x600',
+			],
+			fewerThumbnails: [
+				'https://source.unsplash.com/random/400x600',
+				'https://source.unsplash.com/random/400x600',
+			],
+		};
+	},
+};
+</script>
+<style scoped>
+.container {
+	width: 500px;
+}
+
+.container > * {
+	margin: 20px 0;
+}
+</style>
+```
+
+<!-- api-tables:start -->
+## Props
+
+| Prop       | Type     | Default | Possible values | Description |
+| ---------- | -------- | ------- | --------------- | ----------- |
+| label      | `string` | —       | —               | The label for the order card                        |
+| title      | `string` | —       | —               | The title for the order card                        |
+| thumbnails | `array`  | `[]`    | —               | The thumbnails to display for the order card        |
+| primaryActionText | `string`  | —   | —               | The primary action label                        |
+| secondaryActionText | `string`  | —    | —               | The secondary action label                   |
+<!-- api-tables:end `-->`

--- a/src/components/OrderCard/README.md
+++ b/src/components/OrderCard/README.md
@@ -13,6 +13,8 @@ Use OrderCard to display order information
 			:thumbnails="thumbnails"
 			:primary-action-text="'Primary'"
 			:secondary-action-text="'Secondary'"
+			@action:click-primary="clickPrimary"
+			@action:click-secondary="clickSecondary"
 		/>
 		<m-divider />
 		<m-order-card
@@ -20,6 +22,8 @@ Use OrderCard to display order information
 			:thumbnails="thumbnails"
 			:primary-action-text="'Primary'"
 			:secondary-action-text="'Secondary'"
+			@action:click-primary="clickPrimary"
+			@action:click-secondary="clickSecondary"
 		/>
 		<m-divider />
 		<m-order-card
@@ -27,6 +31,7 @@ Use OrderCard to display order information
 			:title="'Order with fewer thumbnails'"
 			:thumbnails="fewerThumbnails"
 			:primary-action-text="'Primary'"
+			@action:click-primary="clickPrimary"
 		/>
 		<m-divider />
 		<m-order-card
@@ -34,6 +39,8 @@ Use OrderCard to display order information
 			:title="'Order with no thumbnails'"
 			:primary-action-text="'Primary'"
 			:secondary-action-text="'Secondary'"
+			@action:click-primary="clickPrimary"
+			@action:click-secondary="clickSecondary"
 		/>
 		<m-divider />
 		<m-order-card
@@ -41,19 +48,27 @@ Use OrderCard to display order information
 			:title="'Order with no secondary action'"
 			:thumbnails="thumbnails"
 			:primary-action-text="'Primary'"
+			@action:click-primary="clickPrimary"
 		/>
+		<m-toast-layer />
 	</div>
 </template>
 
 <script>
+import { MToastLayer, MToast } from '@square/maker/components/Toast';
 import { MOrderCard } from '@square/maker/components/OrderCard';
 import { MDivider } from '@square/maker/components/Divider';
 
 export default {
 	components: {
+		MToastLayer,
 		MOrderCard,
 		MDivider,
 	},
+
+	mixins: [
+		MToastLayer.apiMixin,
+	],
 
 	data() {
 		return {
@@ -70,6 +85,20 @@ export default {
 				'https://source.unsplash.com/random/400x600',
 			],
 		};
+	},
+
+	methods: {
+		clickPrimary() {
+			this.toastApi.open(() => <MToast
+					text={'Hello. Primary clicked.'}
+			/>);
+		},
+
+		clickSecondary() {
+			this.toastApi.open(() => <MToast
+					text={'Hello. Secondary clicked.'}
+			/>);
+		},
 	},
 };
 </script>

--- a/src/components/OrderCard/index.js
+++ b/src/components/OrderCard/index.js
@@ -1,0 +1,2 @@
+export { default as MOrderCard } from './src/OrderCard.vue';
+export { default as MOrderThumbnails } from './src/OrderThumbnails.vue';

--- a/src/components/OrderCard/src/OrderCard.vue
+++ b/src/components/OrderCard/src/OrderCard.vue
@@ -1,0 +1,141 @@
+<template>
+	<div
+		:class="$s.OrderCard"
+	>
+		<m-text
+			v-if="label"
+			:class="$s.OrderCardLabel"
+			:font-weight="'500'"
+			:size="-1"
+			:color="labelColor"
+		>
+			{{ label }}
+		</m-text>
+		<m-text
+			v-if="title"
+			:class="$s.OrderCardTitle"
+			:font-weight="'500'"
+			:size="0"
+			:color="titleColor"
+		>
+			{{ title }}
+		</m-text>
+		<m-order-thumbnails
+			v-if="hasThumbnails"
+			:class="$s.OrderCardThumbnails"
+			:thumbnails="thumbnails"
+		/>
+		<div
+			:class="$s.OrderCardActions"
+		>
+			<div
+				:class="$s.OrderCardButtons"
+			>
+				<m-button
+					v-if="primaryActionText"
+					pattern="primarySubtle"
+					shape="rounded"
+					size="small"
+					@click="$emit('action:click-primary')"
+				>
+					{{ primaryActionText }}
+				</m-button>
+				<m-button
+					v-if="secondaryActionText"
+					:class="$s.OrderCardSecondaryAction"
+					pattern="primarySubtle"
+					shape="rounded"
+					size="small"
+					@click="$emit('action:click-secondary')"
+				>
+					{{ secondaryActionText }}
+				</m-button>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { MText } from '@square/maker/components/Text';
+import { MButton } from '@square/maker/components/Button';
+import { MThemeKey, defaultTheme } from '@square/maker/components/Theme';
+import MOrderThumbnails from './OrderThumbnails.vue';
+
+export default {
+	components: {
+		MText,
+		MButton,
+		MOrderThumbnails,
+	},
+
+	inject: {
+		theme: {
+			default: defaultTheme(),
+			from: MThemeKey,
+		},
+	},
+
+	props: {
+		label: {
+			type: String,
+			default: undefined,
+		},
+		title: {
+			type: String,
+			required: true,
+		},
+		thumbnails: {
+			type: Array,
+			default: () => ([]),
+		},
+		primaryActionText: {
+			type: String,
+			default: undefined,
+		},
+		secondaryActionText: {
+			type: String,
+			default: undefined,
+		},
+	},
+
+	computed: {
+		hasThumbnails() {
+			return this.thumbnails.length > 0;
+		},
+
+		titleColor() {
+			return this.theme.colors['neutral-90'];
+		},
+
+		labelColor() {
+			return this.theme.colors['neutral-80'];
+		},
+	},
+};
+</script>
+
+<style module="$s">
+.OrderCard {
+	display: block;
+}
+
+.OrderCardLabel,
+.OrderCardTitle,
+.OrderCardThumbnails {
+	margin-bottom: 4px;
+}
+
+.OrderCardActions {
+	display: flex;
+	margin-top: 20px;
+}
+
+.OrderCardButtons {
+	margin-right: 0;
+	margin-left: auto;
+}
+
+.OrderCardSecondaryAction {
+	margin-left: 8px;
+}
+</style>

--- a/src/components/OrderCard/src/OrderThumbnails.vue
+++ b/src/components/OrderCard/src/OrderThumbnails.vue
@@ -1,0 +1,93 @@
+<template>
+	<div
+		:class="$s.OrderThumbnails"
+		:style="thumbnailsStyles"
+	>
+		<template
+			v-for="(thumbnail, index) in thumbnails.slice(0, MAX_THUMBNAIL_COUNT)"
+		>
+			<m-image
+				:key="`image-${index}`"
+				:class="$s.OrderThumbnailImage"
+				:src="thumbnail"
+			/>
+		</template>
+		<div
+			v-if="hasThumbnailOverflow"
+		>
+			<m-text
+				:size="-1"
+			>
+				+{{ overflowImageCount }}
+			</m-text>
+		</div>
+	</div>
+</template>
+
+<script>
+import { MImage } from '@square/maker/components/Image';
+import { MText } from '@square/maker/components/Text';
+
+const MAX_THUMBNAIL_COUNT = 5;
+
+export default {
+	name: 'OrderThumbnails',
+
+	components: {
+		MImage,
+		MText,
+	},
+
+	props: {
+		thumbnails: {
+			type: Array,
+			required: true,
+		},
+		size: {
+			type: Number,
+			default: 32,
+		},
+	},
+
+	data() {
+		return {
+			MAX_THUMBNAIL_COUNT,
+		};
+	},
+
+	computed: {
+		hasThumbnailOverflow() {
+			return this.thumbnails.length > MAX_THUMBNAIL_COUNT;
+		},
+
+		overflowImageCount() {
+			if (this.hasThumbnailOverflow) {
+				return this.thumbnails.length - MAX_THUMBNAIL_COUNT;
+			}
+			return 0;
+		},
+
+		thumbnailsStyles() {
+			return {
+				'--size': `${this.size}px`,
+			};
+		},
+	},
+};
+</script>
+
+<style module="$s">
+.OrderThumbnails {
+	display: flex;
+	align-items: center;
+}
+
+.OrderThumbnailImage {
+	width: var(--size);
+	min-width: var(--size);
+	max-width: var(--size);
+	height: var(--size);
+	margin-right: 8px;
+	border-radius: 4px;
+}
+</style>


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
We plan to use this for order history cards and subscription cards in buyer management.
Following figma designs here: https://www.figma.com/file/kmUoROmFpcprMw7xW2YIT9/Subscriptions-in-Customer-Accounts-%E3%83%BC-Buyer-%E2%80%94-Erin-%E2%80%94-Q322?node-id=7699%3A29177

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
Added new OrderCard component to display an Order with title, label, thumbnails and action buttons. 

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->

https://square.github.io/maker/styleguide/order-card-component/#/OrderCard

![Screen Shot 2022-11-02 at 4 55 23 PM](https://user-images.githubusercontent.com/95251608/199623830-7549bc2f-4961-43ca-a1cd-b8c36153aaae.png)


