### PR TITLE
docs: better docs for first time users & contributors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Maker Team heirarchy
+# Maker Team hierarchy
 #
 # Maker Contributors (@square/maker-contributors)
 # - have write access to repo, can push commits & open PRs

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,36 @@
-# 🛠 Contributing
+# Contributing
 
 This document contains all of the dry technical details of how to contribute to Maker. This document assumes your proposed contribution is sensible and within Maker's scope and guiding philosophies. If you are unsure if the last sentence applies to you please read [What is Maker?](./WHAT_IS_MAKER.md)
+
+## Create an issue first
+
+Before you begin coding, please consider making an [issue](https://github.com/square/maker/issues/new/choose) first. In your issue describe your request, add screenshots if possible, and if you're interested in contributing to Maker describe your implementation approach for solving the issue, e.g.
+
+1. _"I would like to fix this bug by doing X"_
+2. _"I would like to add a new Component Y to Maker"_
+3. _"I would like to add new props, events, or slots to existing Component Z"_
+4. _"I would like to make breaking change Q"_
+
+A Maker Core Team member will review your issue and give you suggestions and feedback on your implementation approach. Once you've gotten tacit or explicit approval feel free to go ahead and create a PR.
+
+You _can_ skip creating an issue first, but you might sink a lot of time producing a PR that will generate a lot of feedback and take a lot longer to get through the PR review stage. Discussing your general approach in an issue first will generally save you time for most Maker tasks.
+
+## Maker Team heirarchy
+
+### Maker Contributors ([@square/maker-contributors](https://github.com/orgs/square/teams/maker-contributors/members))
+ - have write access to repo, can push commits & open PRs
+
+### Maker Reviewers ([@square/maker-reviewers](https://github.com/orgs/square/teams/maker-reviewers/members))
+- are also contributors
+ - have write access to repo, can push commits & open PRs
+ - can approve PRs that change components, docs, or lab experiments
+
+### Maker Core Team ([@square/maker-core-team](https://github.com/orgs/square/teams/maker-core-team/members))
+- are also reviewers
+- have admin access to repo, can do anything
+- can approve any PRs
+
+If you'd like to contribute to Maker ping @kirill on Slack (@pretzelhammer on Github) and he can add you to the Maker Contributors team. Your Github account has to already be a member of the [Square](https://github.com/orgs/square/people) org. If it isn't, you can ask for your Github account to be added to the org in the #opensource channel on Slack.
 
 ## Supported environments
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,7 @@ A Maker Core Team member will review your issue and give you suggestions and fee
 
 You _can_ skip creating an issue first, but you might sink a lot of time producing a PR that will generate a lot of feedback and take a lot longer to get through the PR review stage. Discussing your general approach in an issue first will generally save you time for most Maker tasks.
 
-## Maker Team heirarchy
+## Maker Team hierarchy
 
 ### Maker Contributors ([@square/maker-contributors](https://github.com/orgs/square/teams/maker-contributors/members))
  - have write access to repo, can push commits & open PRs

--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -1,0 +1,338 @@
+# Migration guides for Maker major releases
+
+## [14.x](https://square.github.io/maker/styleguide/14.18.3/#/) -> [15.x](https://square.github.io/maker/styleguide/latest-stable/#/) ([PR](https://github.com/square/maker/pull/441))
+
+### MButton pattern & variant renames
+
+MButton patterns `primary`, `secondary`, and `tertiary` have been removed since they're identical to variants `fill`, `outline`, and `ghost` respectively. MButton variants `primary`, `secondary`, and `tertiary` have also been renamed to `fill`, `outline`, and `ghost` respectively. Filled button patterns `primaryFilled`, `errorFilled `, `successFilled `, `warningFilled`, `infoFilled ` have been renamed to `primaryFill`, `errorFill `, `successFill`, `warningFill`, `infoFill`.
+
+| before (14.x) | after (15.x) |
+|-|-|
+| `<m-button>` | `<m-button>` (no changes) |
+| `<m-button variant="primary">` | `<m-button variant="fill">` |
+| `<m-button variant="secondary">` | `<m-button variant="outline">` |
+| `<m-button variant="tertiary">` | `<m-button variant="ghost">` |
+| `<m-button pattern="primary">` ** | `<m-button variant="fill">` |
+| `<m-button pattern="secondary">` ** | `<m-button variant="outline">` |
+| `<m-button pattern="tertiary">`  **| `<m-button variant="ghost">` |
+| `<m-button pattern="primaryFilled">`| `<m-button pattern="primaryFill">` |
+| `<m-button pattern="errorFilled">`| `<m-button pattern="errorFill">` |
+| `<m-button pattern="successFilled">`| `<m-button pattern="successFill">` |
+| `<m-button pattern="warningFilled">`| `<m-button pattern="warningFill">` |
+| `<m-button pattern="infoFilled">`| `<m-button pattern="infoFill">` |
+
+**Note:** If you were using these deprecated patterns in a custom theme and wish to continue using them, you can update them from this:
+
+```js
+button: {
+  patterns: {
+    primary: {
+      /* customizations */
+    },
+    secondary: {
+      /* customizations */
+    },
+    tertiary: {
+      /* customizations */
+    },
+  },
+},
+```
+
+To this:
+
+```js
+button: {
+  patterns: {
+    primary: {
+      variant: 'fill',
+      /* customizations */
+    },
+    secondary: {
+      variant: 'outline',
+      /* customizations */
+    },
+    tertiary: {
+      variant: 'ghost',
+      /* customizations */
+    },
+  },
+},
+```
+
+### MNotice prop `variant` renamed to `display`
+
+MNotice's `variant` prop has been renamed to `display`.
+
+before (14.x) | after (15.x)
+-|-
+`<m-notice>` | `<m-notice>` (no changes)
+`<m-notice variant="inline">` | `<m-notice display="inline">`
+`<m-notice variant="block">` | `<m-notice display="block">`
+
+### Default theme changes
+
+**NOTE:** If you're using MTheme at the root of your app and setting an explicit primary color then these changes won't affect your app. These changes only affect people who are using Maker without MTheme or with MTheme but aren't setting an explicit primary color and have been relying on the implicit primary color being `#000000`.
+
+Within the default theme the primary color has changed from `#000000` to `#006aff`, the derived contextual primary colors have been updated, the overlay color has changed from `rgba(0, 0, 0, 0.3)` to `rgba(0, 0, 0, 0.32)`. The default parameters within the `maker-colors` utility function have also been updated accordingly.
+
+If you weren't using MTheme before and relying on the implicit primary color being `#000000`, e.g.
+
+```vue
+<template>
+  <div id="app">
+    <m-button>
+      i expect this button to be #000000
+      but if i migrate to 15.x it will be #006aff
+    </m-button>
+  </div>
+</template>
+```
+
+You will now have to import MTheme and explicitly set the primary color to `#000000`, e.g.
+
+```vue
+<template>
+  <div id="app">
+    <m-theme :theme="{ colors: { primary: '#000000' }, }">
+      <m-button>
+        now this button is guaranteed to be
+        #000000 in both 14.x and 15.x
+      </m-button>
+    </m-theme>
+  </div>
+</template>
+```
+
+Also, if you were previously using the `maker-colors` utility function and relying on the implicit primary color being `#000000` by calling the function with only the first parameter, e.g. `makerColors(bgColor)`, then you now also have to pass `#000000` as an explicit 2nd argument to maintain the same appearance in your app migrating to 15.x from 14.x, e.g. `makerColors(bgColor, '#000000')`. Again, if you were already using the utility function with an explicit 2nd parameter in 14.x, `makerColors(bgColor, primaryColor)`, then you do not have to make any changes when migrating to 15.x.
+
+## [13.x](https://square.github.io/maker/styleguide/13.0.1/#/) -> [14.x](https://square.github.io/maker/styleguide/14.18.3/#/) ([PR](https://github.com/square/maker/pull/389))
+
+### Transition components moved from `/components` to `/utils`
+
+before (13.x) | after (14.x)
+-|-
+`import { MTouchCapture } from '@square/maker/components/TouchCapture';` | `import { MTouchCapture } from '@square/maker/utils/TouchCapture';`
+`import { MTransitionFadeIn } from '@square/maker/components/TransitionFadeIn';` | `import { MTransitionFadeIn } from '@square/maker/utils/TransitionFadeIn';`
+`import { MTransitionResize } from '@square/maker/components/TransitionResize';` | `import { MTransitionResize } from '@square/maker/utils/TransitionResize';`
+`import { MTransitionSpringLeft } from '@square/maker/components/TransitionSpringLeft';` | `import { MTransitionSpringLeft } from '@square/maker/utils/TransitionSpringLeft';`
+`import { MTransitionSpringUp } from '@square/maker/components/TransitionSpringUp';` | `import { MTransitionSpringUp } from '@square/maker/utils/TransitionSpringUp';`
+`import { MTransitionStaggered } from '@square/maker/components/TransitionStaggered';` | `import { MTransitionStaggered } from '@square/maker/utils/TransitionStaggered';`
+
+Other transition components like MTransition and MTransitionResponsive were already in the `/utils` directory so if you were using those then those imports don't require any updates.
+
+
+## [12.x](https://square.github.io/maker/styleguide/12.5.0/#/) -> [13.x](https://square.github.io/maker/styleguide/13.0.1/#/) ([PR](https://github.com/square/maker/pull/386))
+
+### `profiles` refactored from keyed array into object
+
+The `profiles` field within theme config objects has been changed from a keyed array to an object. You should refactor your code to change `profiles` from a keyed array to an object. Example of what `profiles` looked like before:
+
+```js
+// 12.x (before)
+// keyed array
+[
+  {
+    id: 'light-profile',
+    colors: { /* whatever */ },
+  },
+  {
+    id: 'dark-profile',
+    colors: { /* whatever */ },
+  },
+]
+```
+
+Example of what `profiles` should look like now:
+
+```js
+// 13.x (after)
+// object
+{
+  'light-profile': {
+    colors: { /* whatever */ },
+  },
+  'dark-profile': {
+    colors: { /* whatever */ },
+  },
+}
+```
+
+## [11.x](https://square.github.io/maker/styleguide/11.8.4/#/) -> [12.x](https://square.github.io/maker/styleguide/12.5.0/#/) ([PR](https://github.com/square/maker/pull/351))
+
+### `chroma-js` removed, replaced by `colord`
+
+Maker peer dependencies have changed. `chroma-js` has been replaced by `colord`. In your `package.json`:
+
+11.x (before) | 12.x (after)
+-|-
+`"chroma-js": "^2.1.0"` | `"colord": "^2.9.2"`
+
+
+## [9.x](https://square.github.io/maker/styleguide/9.8.1/#/) -> [11.x](https://square.github.io/maker/styleguide/11.8.4/#/) ([PR](https://github.com/square/maker/pull/302))
+
+10.x was skipped.
+
+### MHeading was removed, replaced with MText
+
+9.x (before) | 11.x (after)
+-|-
+`import { MHeading } from '@square/maker/components/Heading'` | `import { MText } from '@square/maker/components/Text'`
+`<m-heading>` | `<m-text pattern="title">`
+
+### Typography now globally themeable
+
+Any theming configs you had for `heading` and `text` should be moved into the new `fonts` config of the theme object. Take these:
+
+```js
+// in theme object
+heading: {
+  fontFamily: 'headingFontFamily',
+  fontWeight: 'headingFontWeight',
+},
+text: {
+  fontFamily: 'textFontFamily',
+  fontWeight: 'textFontWeight',
+},
+```
+
+And move them here:
+
+```js
+// in theme object
+fonts: {
+  heading: {
+    fontFamily: 'headingFontFamily',
+    fontWeight: 'headingFontWeight',
+  },
+  body: {
+    fontFamily: 'textFontFamily',
+    fontWeight: 'textFontWeight',
+  },
+},
+```
+
+### Public CSS variables renamed
+
+9.x (before) | 11.x (after)
+-|-
+`--neutral-0` | `--maker-color-neutral-0`
+`--neutral-10` | `--maker-color-neutral-10`
+`--neutral-20` | `--maker-color-neutral-20`
+`--neutral-80` | `--maker-color-neutral-80`
+`--neutral-90` | `--maker-color-neutral-90`
+`--neutral-100` | `--maker-color-neutral-100`
+`--color-primary` | `--maker-color-primary`
+`--color-background` | `--maker-color-background`
+`--color-heading` | `--maker-color-heading`
+`--maker-color-title` | `--maker-color-heading`
+`--color-text` | `--maker-color-body`
+`--maker-color-paragraph` | `--maker-color-body`
+`--color-elevation` | `--maker-color-elevation`
+`--color-overlay` | `--maker-color-overlay`
+`--font-family-title` | `--maker-font-heading-font-family`
+`--maker-font-family-title` | `--maker-font-heading-font-family`
+`--font-weight-title` | `--maker-font-heading-font-weight`
+`--maker-font-weight-title` | `--maker-font-heading-font-weight`
+`--font-family-paragraph` | `--maker-font-body-font-family`
+`--maker-font-family-paragraph` | `--maker-font-body-font-family`
+`--font-weight-paragraph` | `--maker-font-body-font-weight`
+`--maker-font-weight-paragraph` | `--maker-font-body-font-weight`
+`--font-family-label` | `--maker-font-label-font-family`
+`--maker-font-family-label` | `--maker-font-label-font-family`
+`--font-weight-label` | `--maker-font-label-font-weight`
+`--maker-font-weight-label` | `--maker-font-label-font-weight`
+
+### Prefer patterns over variants for MButtons
+
+Although the `variant` prop has not been deprecated, it's almost always more correct to use `pattern` for MButtons now.
+
+9.x (before) | 11.x (after)
+-|-
+`<m-button variant="primary">` | `<m-button pattern="primary">`
+`<m-button variant="secondary">` | `<m-button pattern="secondary">`
+`<m-button variant="tertiary">` | `<m-button pattern="tertiary">`
+
+### Miscellaneous
+
+1. If you don't want to set a themeable prop but must pass some null-ish value then `''` (empty string) no longer works for that use-case, you must now explicitly pass `undefined`.
+2. Margin was removed from `<m-text element="p">` (`p` is the default), and if you want to maintain margin on these elements you now need to add it with your own CSS
+
+## [8.x](https://square.github.io/maker/styleguide/8.1.0/#/) -> [9.x](https://square.github.io/maker/styleguide/9.8.1/#/) ([PR](https://github.com/square/maker/pull/205))
+
+### Theme component majorly refactored
+
+Prior to this release MTheme was nonfunctional so nobody should have been using it so although it received major refactors it should not require any code refactors in user code.
+
+### Text component props were renamed
+
+8.x (before) | 9.x (after)
+-|-
+`<m-text text-color="#000">` | `<m-text color="#000">`
+`<m-heading text-color="#000">` | `<m-heading color="#000">`
+
+## [7.x](https://square.github.io/maker/styleguide/7.0.3/#/) -> [8.x](https://square.github.io/maker/styleguide/8.1.0/#/) ([PR](https://github.com/square/maker/pull/256))
+
+### Dropped support for UC Android & Opera Mini browsers
+
+No code refactors necessary.
+
+## [6.x](https://square.github.io/maker/styleguide/6.7.3/#/) -> [7.x](https://square.github.io/maker/styleguide/7.0.3/#/) ([PR](https://github.com/square/maker/pull/249))
+
+### MTextButton moved from `/Button` to `/TextButton`
+
+6.x (before) | 7.x (after)
+-|-
+`import { MTextButton } from '@square/maker/components/Button'` | `import { MTextButton } from '@square/maker/components/TextButton'`
+
+## [5.x](https://square.github.io/maker/styleguide/5.4.0/#/) -> [6.x](https://square.github.io/maker/styleguide/6.7.3/#/) ([PR](https://github.com/square/maker/pull/148))
+
+### MSection removed, replaced with MContainer
+
+5.x (before) | 6.x (after)
+-|-
+`import { MSection } from '@square/maker/components/Section'` | `import { MContainer } from '@square/maker/components/Container'`
+`<m-section>` | `<m-container bg-color="#fff">`
+
+## [4.x](https://square.github.io/maker/styleguide/4.12.0/#/) -> [5.x](https://square.github.io/maker/styleguide/5.4.0/#/) ([PR](https://github.com/square/maker/pull/129))
+
+### MNoticeButton removed, replaced with MTextButton
+
+4.x (before) | 5.x (after)
+-|-
+`import { MNoticeButton } from '@square/maker/components/Notice'` | `import { MTextButton } from '@square/maker/components/Button'`
+`<m-notice-button>` | `<m-text-button>`
+
+## [3.x](https://square.github.io/maker/styleguide/3.0.0/#/) -> [4.x](https://square.github.io/maker/styleguide/4.12.0/#/) ([PR](https://github.com/square/maker/pull/47))
+
+### `lodash` dependency was externalized
+
+No code refactors necessary.
+
+## [2.x](https://square.github.io/maker/styleguide/2.2.4/#/) -> [3.x](https://square.github.io/maker/styleguide/3.0.0/#/) ([PR](https://github.com/square/maker/pull/41))
+
+### `date-fns` dependency was externalized
+
+No code refactors necessary.
+
+## [1.x](https://square.github.io/maker/styleguide/1.3.1/#/) -> [2.x](https://square.github.io/maker/styleguide/2.2.4/#/) ([PR](https://github.com/square/maker/pull/35))
+
+### Peer dependencies changed
+
+- Update peer dep `popmotion` from `8.x` to `^9.3.1`
+- Add new peer dep `stylefire` to `^7.0.3`
+
+### Transition components renamed
+
+1.x (before) | 2.x (after)
+-|-
+`import { MTransitionFade } from '@square/maker/components/TransitionFade'` | `import { MTransitionFadeIn } from '@square/maker/components/TransitionFadeIn'`
+`import { MTransitionSpring } from '@square/maker/utils/TransitionSpring'` | `import { MTransition } from '@square/maker/utils/Transition'`
+`import { MTransitionSpringResponsive } from '@square/maker/utils/TransitionSpringResponsive'` | `import { MTransitionResponsive } from '@square/maker/utils/TransitionResponsive'`
+`<m-transition-fade>` | `<m-transition-fade-in>`
+`<m-transition-spring>` | `<m-transition>`
+`<m-transition-spring-responsive>` | `<m-transition-responsive>`
+
+### Transition props changed
+
+MTransition and MTransitionResponsive now take transition functions instead of `popmotion` config objects.

--- a/.github/WHAT_IS_MAKER.md
+++ b/.github/WHAT_IS_MAKER.md
@@ -1,6 +1,6 @@
 # What is Maker?
 
-Most people contributing to and using Maker will be familiar with [Orbit](https://github.com/square/orbit), but they might have some wrong ideas about Maker's goals, by assuming they're the same as Orbit's. This is incorrect. Maker is not Orbit. Their key high-level differences in a table:
+Most people contributing to and using Maker will be familiar with [Orbit](https://github.com/squareup/orbit-ui), but they might have some wrong ideas about Maker's goals by assuming they're the same as Orbit's. This is incorrect. Maker is not Orbit. Their key high-level differences in a table:
 
 | | Orbit | Maker |
 |-|-------|-------|
@@ -37,7 +37,7 @@ No. Start from first principles. Review the table above. It's okay to look at an
 
 ### When should I update an MCL component vs implementing a one-off in my project?
 
-There is a [Maker Design System Figma file](https://www.figma.com/file/2cgnI0Cb5L7DqdCNiIRrot/%F0%9F%8D%81-Maker-Design-System?node-id=2379%3A19587). To make an engineering-friendly analogy, this Figma file is like the `master` branch of MDS. The `master` branch of MCL should always faithfully represent the designs in the `master` branch of MDS, i.e. [its Figma file](https://www.figma.com/file/2cgnI0Cb5L7DqdCNiIRrot/%F0%9F%8D%81-Maker-Design-System?node-id=2379%3A19587). MDS is the source of truth for MCL.
+There is a [Maker Design System Figma file](https://www.figma.com/file/SHY7Z7PbcVssjIJVuJ3IwU/%F0%9F%8D%81-Maker?node-id=2379%3A19587). To make an engineering-friendly analogy, this Figma file is like the `master` branch of MDS. The `master` branch of MCL should always faithfully represent the designs in the `master` branch of MDS, i.e. [its Figma file](https://www.figma.com/file/SHY7Z7PbcVssjIJVuJ3IwU/%F0%9F%8D%81-Maker?node-id=2379%3A19587). MDS is the source of truth for MCL.
 
 Ideally, when a product designer uses MDS to design a mockup, they design the entire mockup using only MDS. If you're working with such a designer then you'll be able to use MCL as-is to implement the mockup without having to do any hacks, overrides, or opening any PRs to change MCL.
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
-# Square Maker
+# Maker
 
-A mobile-first themeable Vue.js 2.x component library. [View the styleguide here](https://square.github.io/maker/styleguide/latest-stable/#/).
+Maker is a mobile-first themeable Vue.js 2.x component library. [View its docs here](https://square.github.io/maker/styleguide/latest-stable/#/).
 
-## 🚀 Install
+## Install
 
 ```sh
 # install maker
 npm i @square/maker
-```
-
-```sh
 # install peer dependencies
 npx i-peers -a
 ```
 
-## Contributing
+## Quick links
 
-Please read the [contributing docs](.github/CONTRIBUTING.md).
+- Using latest version of Maker? [Read latest-stable docs.](https://square.github.io/maker/styleguide/latest-stable/#/)
+- Using older version of Maker? [Find older version docs here.](https://square.github.io/maker/)
+- Upgrading to a new major version of Maker? [Read the migration docs.](.github/MIGRATION.md)
+- Need to report a bug? [Create an issue.](https://github.com/square/maker/issues/new/choose)
+- Need to request a new feature? [Create an issue.](https://github.com/square/maker/issues/new/choose)
+- Need to ask a question? [Ask here.](https://github.com/square/maker/discussions)
+- Contributing to Maker? [Read the contributing docs.](.github/CONTRIBUTING.md)
+

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ npx i-peers -a
 
 - Using latest version of Maker? [Read latest-stable docs.](https://square.github.io/maker/styleguide/latest-stable/#/)
 - Using older version of Maker? [Find older version docs here.](https://square.github.io/maker/)
-- Upgrading to a new major version of Maker? [Read the migration docs.](.github/MIGRATION.md)
+- Upgrading to a new major version of Maker? [Read the migration docs.](https://github.com/square/maker/blob/master/.github/MIGRATION.md)
 - Need to report a bug? [Create an issue.](https://github.com/square/maker/issues/new/choose)
 - Need to request a new feature? [Create an issue.](https://github.com/square/maker/issues/new/choose)
 - Need to ask a question? [Ask here.](https://github.com/square/maker/discussions)
-- Contributing to Maker? [Read the contributing docs.](.github/CONTRIBUTING.md)
+- Contributing to Maker? [Read the contributing docs.](https://github.com/square/maker/blob/master/.github/CONTRIBUTING.md)
 


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
docs could have used an improvement

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
(1) adds a **Quick links** section to the [main readme](https://github.com/square/maker/blob/more-docs/README.md):
![image](https://user-images.githubusercontent.com/7769424/199759858-6bb2752d-ea82-42a0-8650-688cbd838efa.png)

(2) Adds **Create an issue first** and **Maker Team heirarchy** to the [contributing docs](https://github.com/square/maker/blob/more-docs/.github/CONTRIBUTING.md):
![image](https://user-images.githubusercontent.com/7769424/199760413-3a2fb30e-717b-4e3d-9d36-5200a3576e6c.png)

(3) adds [migration docs](https://github.com/square/maker/blob/more-docs/.github/MIGRATION.md):
![image](https://user-images.githubusercontent.com/7769424/199760643-d4a698ac-935b-49e3-b91e-f84eb4cf0983.png)
