### PR TITLE
feat(container): add padding prop to container component

### DIFF
--- a/src/components/Container/README.md
+++ b/src/components/Container/README.md
@@ -158,6 +158,48 @@ export default {
 </script>
 ```
 
+## Other customizations
+
+Containers can be customized further with: bg-color, color, padding.
+
+```vue
+<template>
+	<div>
+		<m-container
+			label="background color customized label"
+			size="small"
+			bg-color="#ffe800"
+		>
+			background color customized
+		</m-container>
+		<m-container
+			label="text color customized label"
+			size="small"
+			color="#ffe800"
+		>
+			text color customized
+		</m-container>
+		<m-container
+			label="padding customized label"
+			size="small"
+			padding="50px"
+		>
+			padding customized
+		</m-container>
+	</div>
+</template>
+
+<script>
+import { MContainer } from '@square/maker/components/Container';
+
+export default {
+	components: {
+		MContainer,
+	},
+};
+</script>
+```
+
 <!-- api-tables:start -->
 ## Props
 

--- a/src/components/Container/README.md
+++ b/src/components/Container/README.md
@@ -144,15 +144,6 @@ Containers can be small, medium, or large, which affects the default typography 
 		>
 			large container content
 		</m-container>
-		<m-container
-			label="container with custom padding label"
-			sublabel="container with custom padding sublabel"
-			requirement-label="container with custom padding requirement label"
-			size="small"
-			padding="50px"
-		>
-			container with custom padding
-		</m-container>
 	</div>
 </template>
 

--- a/src/components/Container/README.md
+++ b/src/components/Container/README.md
@@ -144,6 +144,15 @@ Containers can be small, medium, or large, which affects the default typography 
 		>
 			large container content
 		</m-container>
+		<m-container
+			label="container with custom padding label"
+			sublabel="container with custom padding sublabel"
+			requirement-label="container with custom padding requirement label"
+			size="small"
+			padding="50px"
+		>
+			container with custom padding
+		</m-container>
 	</div>
 </template>
 
@@ -163,14 +172,15 @@ export default {
 
 Supports attributes from [`<section>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section).
 
-| Prop              | Type     | Default    | Possible values            | Description                   |
-| ----------------- | -------- | ---------- | -------------------------- | ----------------------------- |
-| label             | `string` | —          | —                          | Container label               |
-| sublabel          | `string` | —          | —                          | Container sublabel            |
-| requirement-label | `string` | —          | —                          | Container requirement label   |
-| size              | `string` | `'medium'` | `small`, `medium`, `large` | Container size                |
-| bg-color          | `string` | —          | —                          | Background color of container |
-| color             | `string` | —          | —                          | Text color of container       |
+| Prop              | Type     | Default       | Possible values            | Description                   |
+| ----------------- | -------- | ------------- | -------------------------- | ----------------------------- |
+| label             | `string` | —             | —                          | Container label               |
+| sublabel          | `string` | —             | —                          | Container sublabel            |
+| requirement-label | `string` | —             | —                          | Container requirement label   |
+| size              | `string` | `'medium'`    | `small`, `medium`, `large` | Container size                |
+| bg-color          | `string` | —             | —                          | Background color of container |
+| color             | `string` | —             | —                          | Text color of container       |
+| padding           | `string` | `'16px 24px'` | —                          | Padding of the container      |
 
 
 ## Slots

--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -51,6 +51,7 @@
 import { colord } from 'colord';
 import assert from '@square/maker/utils/assert';
 import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
+import cssValidator from '@square/maker/utils/css-validator';
 
 /**
  * @inheritAttrs section
@@ -118,13 +119,7 @@ export default {
 		padding: {
 			type: String,
 			default: '16px 24px',
-			validator: (padding) => {
-				// CSS not defined when rendering server-side
-				if (global.CSS) {
-					return global.CSS.supports('padding', padding);
-				}
-				return true;
-			},
+			validator: cssValidator('padding'),
 		},
 	},
 

--- a/src/components/Container/src/Container.vue
+++ b/src/components/Container/src/Container.vue
@@ -112,6 +112,20 @@ export default {
 			default: undefined,
 			validator: (color) => colord(color).isValid(),
 		},
+		/**
+		 * Padding of the container
+		 */
+		padding: {
+			type: String,
+			default: '16px 24px',
+			validator: (padding) => {
+				// CSS not defined when rendering server-side
+				if (global.CSS) {
+					return global.CSS.supports('padding', padding);
+				}
+				return true;
+			},
+		},
 	},
 
 	computed: {
@@ -120,6 +134,7 @@ export default {
 			return {
 				'--bg-color': this.resolvedBgColor,
 				'--color': this.resolvedColor,
+				'--padding': this.padding,
 			};
 		},
 		hasLabel() {
@@ -146,7 +161,7 @@ export default {
 
 <style module="$s">
 .Container {
-	padding: 16px 24px;
+	padding: var(--padding);
 	background-color: var(--bg-color, inherit);
 }
 


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

Container padding cannot be customized

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->

Added new padding prop to Container component. Updated docs.
