### PR TITLE
fix(modal)!: removes broken parentModal from internal modalApi state

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -1,6 +1,16 @@
 # Migration guides for Maker major releases
 
-## [14.x](https://square.github.io/maker/styleguide/14.18.3/#/) -> [15.x](https://square.github.io/maker/styleguide/latest-stable/#/) ([PR](https://github.com/square/maker/pull/441))
+## [15.x](https://square.github.io/maker/styleguide/15.9.0/#/) -> [16.x](https://square.github.io/maker/styleguide/latest-stable/#/) ([PR](not yet made))
+
+### `parentModal` removed from `modalApi`, use `closeAll` instead
+
+Before, if a user wanted to close a stack of modals simultaneously, they would write `this.modalApi.parentModal.close()`, which worked at some point in time, but has been broken for a while, and even while it "worked" it would force close both modals without running their `beforeClose` hooks. For these reasons `parentModal` has been removed and replaced with a `closeAll` method which solves all of these problems.
+
+15.x (before) | 16.x (after)
+-|-
+`this.modalApi.parentModal.close()` | `this.modalApi.closeAll()`
+
+## [14.x](https://square.github.io/maker/styleguide/14.18.3/#/) -> [15.x](https://square.github.io/maker/styleguide/15.9.0/#/) ([PR](https://github.com/square/maker/pull/441))
 
 ### MButton pattern & variant renames
 

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -185,10 +185,6 @@ const apiMixin = {
 				options: {},
 				// true if this modal has a modal beneath it
 				isStacked: !!vm.parentModalApi,
-				// although parentModal is not used within Maker it's used
-				// by some of our users so removing it would be a breaking
-				// change and require a major release
-				parentModal: vm.parentModalApi,
 			}),
 
 			// only called from parent


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
Before, if a user wanted to close a stack of modals simultaneously, they would write `this.modalApi.parentModal.close()`, which worked at some point in time, but has been broken for a while, and even while it "worked" it would force close both modals without running their `beforeClose` hooks. For these reasons `parentModal` has been removed and replaced with a `closeAll` method which solves all of these problems.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
removes `parentModal`

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
