### PR TITLE
feat(button): add hover text pattern support

### DIFF
--- a/lab/experiments/ButtonCustomization.vue
+++ b/lab/experiments/ButtonCustomization.vue
@@ -53,6 +53,45 @@
 				Font size: {{ fontSize }}
 			</label>
 			<label>
+				<select
+					v-model="fontFamilyHover"
+				>
+					<option>
+						Georgia
+					</option>
+					<option>
+						Verdana
+					</option>
+					<option>
+						Monospace
+					</option>
+				</select>
+				Font family hover
+			</label>
+			<label>
+				<select
+					v-model="fontWeightHover"
+				>
+					<option>
+						normal
+					</option>
+					<option>
+						bold
+					</option>
+				</select>
+				Font weight hover
+			</label>
+			<label>
+				<input
+					v-model="fontSizeHover"
+					type="range"
+					min="12"
+					max="32"
+					step="2"
+				>
+				Font size hover: {{ fontSizeHover }}
+			</label>
+			<label>
 				<input
 					v-model="color"
 					type="color"
@@ -534,9 +573,12 @@ import makerColors from '@square/maker/utils/maker-colors';
 const defaultButtonProps = {
 	color: '#9142ff',
 	colorHover: undefined,
-	fontFamily: undefined,
-	fontWeight: undefined,
+	fontFamily: 'Verdana',
+	fontWeight: 'normal',
 	fontSize: undefined,
+	fontFamilyHover: 'Monospace',
+	fontWeightHover: 'bold',
+	fontSizeHover: undefined,
 	textColor: '#ffffff',
 	textColorHover: undefined,
 	borderRadius: undefined,
@@ -578,11 +620,23 @@ export default {
 	},
 	computed: {
 		theme() {
-			const { fontSize, fontFamily, fontWeight } = this;
+			const {
+				fontSize,
+				fontFamily,
+				fontWeight,
+				fontSizeHover,
+				fontFamilyHover,
+				fontWeightHover,
+			} = this;
 			const buttonTextPattern = {
 				...(fontFamily && { fontFamily }),
 				...(fontWeight && { fontWeight }),
 				...(fontSize && { fontSize: `${fontSize}px` }),
+			};
+			const buttonTextPatternHover = {
+				...(fontFamilyHover && { fontFamily: fontFamilyHover }),
+				...(fontWeightHover && { fontWeight: fontWeightHover }),
+				...(fontSizeHover && { fontSize: `${fontSizeHover}px` }),
 			};
 			return {
 				colors: {
@@ -592,7 +646,11 @@ export default {
 				text: {
 					patterns: {
 						buttonLabel: buttonTextPattern,
+						buttonLabelHover: buttonTextPatternHover,
 					},
+				},
+				button: {
+					textPatternHover: 'buttonLabelHover',
 				},
 			};
 		},

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -783,7 +783,8 @@ Themable props* can be configured via the [Theme](#/Theme) component using the k
 
 | Prop                 | Type     | Default         | Possible values | Description                                                 |
 | -------------------- | -------- | --------------- | --------------- | ----------------------------------------------------------- |
-| text-pattern*        | `string` | `'buttonLabel'` | -               | MText pattern in button label                               |
+| text-pattern*        | `string` | `'buttonLabel'` | -               | Text pattern in button label                                |
+| text-pattern-hover*  | `string` | —               | -               | Text hover pattern in button label                          |
 | color-hover*         | `string` | —               | -               | Main hover color of button                                  |
 | text-color-hover*    | `string` | —               | -               | Text hover color of button (only applied on fill buttons)   |
 | border-radius*       | `string` | —               | -               | button's border radius                                      |

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -48,6 +48,7 @@
 </template>
 
 <script>
+import { kebabCase } from 'lodash';
 import cssValidator from '@square/maker/utils/css-validator';
 import { colord } from 'colord';
 import { getContrast } from '@square/maker/utils/get-contrast';
@@ -106,19 +107,19 @@ const TEXT_STYLES = new Set([
 	'textDecoration',
 ]);
 
-function kebabCase(string) {
-	return string.replace(/([\da-z])([A-Z])/g, '$1-$2').toLowerCase();
+function isValidCss(style, value) {
+	if (global.CSS) {
+		return global.CSS.supports(style, value);
+	}
+	return true;
 }
 
 function formatCssStyles(theme, styles, suffix) {
 	const formattedStyles = {};
 	for (const [style, value] of Object.entries(styles)) {
-		if (TEXT_STYLES.has(style) && cssValidator(style, value)) {
-			if (value.startsWith('@')) {
-				formattedStyles[`--${kebabCase(style)}${suffix}`] = theme.resolve(value);
-			} else {
-				formattedStyles[`--${kebabCase(style)}${suffix}`] = value;
-			}
+		const cssStyle = kebabCase(style);
+		if (TEXT_STYLES.has(style) && isValidCss(cssStyle, value)) {
+			formattedStyles[`--${cssStyle}${suffix}`] = theme.resolve(value);
 		}
 	}
 	return formattedStyles;
@@ -383,10 +384,8 @@ export default {
 			};
 
 			const { resolvedTextPattern, resolvedTextPatternHover, theme } = this;
-			const textPattern = resolvedTextPattern
-				? theme?.text?.patterns?.[resolvedTextPattern] || {} : {};
-			const textPatternHover = resolvedTextPatternHover
-				? theme.text.patterns?.[resolvedTextPatternHover] || {} : {};
+			const textPattern = theme?.text?.patterns?.[resolvedTextPattern] || {};
+			const textPatternHover = theme.text.patterns?.[resolvedTextPatternHover] || {};
 			const textPatternStyles = formatCssStyles(theme, textPattern, '');
 			const textPatternHoverStyles = formatCssStyles(theme, textPatternHover, '-hover');
 
@@ -400,7 +399,7 @@ export default {
 			return this.disabled || this.loading;
 		},
 		fontSize() {
-			return this.theme.text.patterns[this.resolvedTextPattern]?.fontSize || 'inherit';
+			return this.theme.text.patterns[this.resolvedTextPattern]?.fontSize;
 		},
 		adjustedSize() {
 			// Scale button size to fontSize if one is set
@@ -449,8 +448,9 @@ export default {
 	min-width: 0;
 	color: var(--color-contrast, #fff);
 	font-weight: var(--font-weight, var(--maker-font-label-font-weight, 500));
+	font-size: var(--font-size);
 	font-family: var(--font-family, var(--maker-font-label-font-family, inherit));
-	font-style: var(--font-size);
+	font-style: var(--font-style);
 	text-transform: var(--text-transform);
 	text-decoration: var(--text-decoration);
 	vertical-align: middle;
@@ -468,7 +468,8 @@ export default {
 		background-color 0.2s ease-in,
 		filter 0.2s ease-in,
 		box-shadow 0.2s ease-in,
-		border-radius 0.2s ease-in;
+		border-radius 0.2s ease-in,
+		font-size 0.2s ease-in;
 	user-select: none;
 	touch-action: manipulation;
 	fill: currentColor;
@@ -493,9 +494,10 @@ export default {
 	}
 
 	&.size_small {
+		--font-size: 12px;
+
 		height: 32px;
 		padding: var(--small-padding);
-		font-size: 12px;
 
 		& > * {
 			line-height: 1.4;
@@ -508,9 +510,10 @@ export default {
 	}
 
 	&.size_medium {
+		--font-size: 14px;
+
 		height: 48px;
 		padding: var(--medium-padding);
-		font-size: 14px;
 
 		& > * {
 			line-height: 1.77;
@@ -523,9 +526,10 @@ export default {
 	}
 
 	&.size_large {
+		--font-size: 16px;
+
 		height: 64px;
 		padding: var(--large-padding);
-		font-size: 16px;
 
 		& > * {
 			line-height: 1.5;
@@ -577,8 +581,9 @@ export default {
 	&:hover:not(:disabled) {
 		color: var(--color-contrast-hover, var(--color-contrast));
 		font-weight: var(--font-weight-hover, var(--font-weight));
+		font-size: var(--font-size-hover, var(--font-size));
 		font-family: var(--font-family-hover, var(--font-family));
-		font-style: var(--font-size-hover, var(--font-size));
+		font-style: var(--font-style-hover, var(--font-style));
 		text-transform: var(--text-transform-hover, var(--text-transform));
 		text-decoration: var(--text-decoration-hover, var(--text-decoration));
 		background-color: var(--color-hover);

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -23,33 +23,27 @@
 			v-if="loading"
 			:class="$s.Loading"
 		/>
-		<m-text
+		<span
 			:class="[
 				$s.MainText,
 				{
 					[$s.TruncateText]: !isSingleChild(),
 				}
 			]"
-			:pattern="resolvedTextPattern"
-			element="span"
-			color="inherit"
 		>
 			<!-- @slot Button label -->
 			<slot />
-		</m-text>
+		</span>
 
-		<m-text
+		<span
 			v-if="$scopedSlots.information"
 			:class="[$s.InformationText, $s.TruncateText]"
-			:pattern="resolvedTextPattern"
-			element="span"
-			color="inherit"
 		>
 			<!-- @slot Information label -->
 			<slot
 				name="information"
 			/>
-		</m-text>
+		</span>
 	</component>
 </template>
 
@@ -60,7 +54,6 @@ import { getContrast } from '@square/maker/utils/get-contrast';
 import { BASE_TEN } from '@square/maker/utils/constants';
 import { MLoading } from '@square/maker/components/Loading';
 import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
-import { MText } from '@square/maker/components/Text';
 
 function setColorVariables(tokens, variant) {
 	const colorMain = colord(tokens.color);
@@ -104,6 +97,33 @@ function setColorVariables(tokens, variant) {
 	};
 }
 
+const TEXT_STYLES = new Set([
+	'fontFamily',
+	'fontWeight',
+	'fontSize',
+	'fontStyle',
+	'textTransform',
+	'textDecoration',
+]);
+
+function kebabCase(string) {
+	return string.replace(/([\da-z])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+function formatCssStyles(theme, styles, suffix) {
+	const formattedStyles = {};
+	for (const [style, value] of Object.entries(styles)) {
+		if (TEXT_STYLES.has(style) && cssValidator(style, value)) {
+			if (value.startsWith('@')) {
+				formattedStyles[`--${kebabCase(style)}${suffix}`] = theme.resolve(value);
+			} else {
+				formattedStyles[`--${kebabCase(style)}${suffix}`] = value;
+			}
+		}
+	}
+	return formattedStyles;
+}
+
 /**
  * Button component
  * @inheritAttrs button
@@ -112,7 +132,6 @@ function setColorVariables(tokens, variant) {
 export default {
 	components: {
 		MLoading,
-		MText,
 	},
 
 	inject: {
@@ -217,10 +236,18 @@ export default {
 			default: false,
 		},
 		/**
-		 * MText pattern in button label
+		 * Text pattern in button label
 		 * @advanced
 		 */
 		textPattern: {
+			type: String,
+			default: undefined,
+		},
+		/**
+		 * Text hover pattern in button label
+		 * @advanced
+		 */
+		textPatternHover: {
 			type: String,
 			default: undefined,
 		},
@@ -324,6 +351,7 @@ export default {
 			'textColor',
 			'textColorHover',
 			'textPattern',
+			'textPatternHover',
 			'variant',
 			'shape',
 			'borderRadius',
@@ -353,8 +381,19 @@ export default {
 				boxShadow: this.resolvedBoxShadow,
 				boxShadowHover: this.resolvedBoxShadowHover,
 			};
+
+			const { resolvedTextPattern, resolvedTextPatternHover, theme } = this;
+			const textPattern = resolvedTextPattern
+				? theme?.text?.patterns?.[resolvedTextPattern] || {} : {};
+			const textPatternHover = resolvedTextPatternHover
+				? theme.text.patterns?.[resolvedTextPatternHover] || {} : {};
+			const textPatternStyles = formatCssStyles(theme, textPattern, '');
+			const textPatternHoverStyles = formatCssStyles(theme, textPatternHover, '-hover');
+
 			return {
 				...setColorVariables(tokens, this.resolvedVariant),
+				...textPatternStyles,
+				...textPatternHoverStyles,
 			};
 		},
 		isDisabled() {
@@ -409,8 +448,11 @@ export default {
 	box-sizing: border-box;
 	min-width: 0;
 	color: var(--color-contrast, #fff);
-	font-weight: var(--maker-font-label-font-weight, 500);
-	font-family: var(--maker-font-label-font-family, inherit);
+	font-weight: var(--font-weight, var(--maker-font-label-font-weight, 500));
+	font-family: var(--font-family, var(--maker-font-label-font-family, inherit));
+	font-style: var(--font-size);
+	text-transform: var(--text-transform);
+	text-decoration: var(--text-decoration);
 	vertical-align: middle;
 	background-color: var(--color-main, $maker-color-primary);
 	border: none;
@@ -534,6 +576,11 @@ export default {
 
 	&:hover:not(:disabled) {
 		color: var(--color-contrast-hover, var(--color-contrast));
+		font-weight: var(--font-weight-hover, var(--font-weight));
+		font-family: var(--font-family-hover, var(--font-family));
+		font-style: var(--font-size-hover, var(--font-size));
+		text-transform: var(--text-transform-hover, var(--text-transform));
+		text-decoration: var(--text-decoration-hover, var(--text-decoration));
 		background-color: var(--color-hover);
 		border-radius: var(--border-radius-hover, $maker-shape-button-border-radius);
 		box-shadow:

--- a/src/components/Theme/src/default-components.cjs
+++ b/src/components/Theme/src/default-components.cjs
@@ -9,6 +9,7 @@ module.exports = function defaultComponents() {
 			variant: 'fill',
 			shape: undefined,
 			textPattern: 'buttonLabel',
+			textPatternHover: undefined,
 			color: '@colors.primary',
 			textColor: undefined,
 			fullWidth: false,

--- a/src/components/Theme/src/default-components.cjs
+++ b/src/components/Theme/src/default-components.cjs
@@ -185,7 +185,6 @@ module.exports = function defaultComponents() {
 				buttonLabel: {
 					fontFamily: '@fonts.label.fontFamily',
 					fontWeight: '@fonts.label.fontWeight',
-					fontSize: 'inherit',
 				},
 			},
 		},


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Button currently does not support hover text styles.

<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
Adds a `textPatternHover` prop to Button, removes MText from inside button in favor of directly applying text pattern styles.
<!--
  📸 Inline screenshots to better communicate the changes
-->

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
