### PR TITLE
feat(thumbnails)!: allows any valid css size for size prop

### DIFF
--- a/.github/MIGRATION.md
+++ b/.github/MIGRATION.md
@@ -45,6 +45,13 @@ We've been using `critical` and `error` interchangeably internally within the li
 `<m-progress-circle icon-name="critical">` | `<m-progress-circle icon-name="error">`
 `<m-toast icon-name="critical">` | `<m-toast icon-name="error">`
 
+### MThumbnails `size` prop now takes Strings instead of Numbers
+
+Before the MThumbnails `size` prop only took a Number, and converted it to pixels, to set the thumbnail size. Now it takes a String, which can be any valid CSS width/height value. This is now more similar to how most props on most components work.
+
+15.x (before) | 16.x (after)
+-|-
+`<m-thumbnails :size="100">` | `<m-thumbnails size="100px">`
 
 
 ## [14.x](https://square.github.io/maker/styleguide/14.18.3/#/) -> [15.x](https://square.github.io/maker/styleguide/15.9.0/#/) ([PR](https://github.com/square/maker/pull/441))

--- a/src/components/Thumbnails/README.md
+++ b/src/components/Thumbnails/README.md
@@ -3,82 +3,77 @@
 Use Thumbnails to display a list of images.
 
 ## Examples
+
 ```vue
 <template>
 	<div class="container">
-		Thumbnails - click on thumbnails / overflow-text to view emitted event
-		<m-thumbnails
-			:thumbnails="thumbnails"
-			:max-thumbnails="3"
-			@thumbnail:click="clickThumbnail"
-			@overflow:click="clickOverflow"
-		/>
-		<m-divider />
 		Thumbnails with no overflow
 		<m-thumbnails
 			:thumbnails="thumbnails"
 			:max-thumbnails="10"
-			@thumbnail:click="clickThumbnail"
-			@overflow:click="clickOverflow"
 		/>
 		<m-divider />
-		Thumbnails with specified image size and overflow with specified text size
+		Thumbnails with overflow
 		<m-thumbnails
 			:thumbnails="thumbnails"
 			:max-thumbnails="3"
-			:size="100"
-			:overflow-text-size="5"
+		/>
+		<m-divider />
+		Thumbnails with click events
+		<m-thumbnails
+			:thumbnails="thumbnails"
+			:max-thumbnails="5"
 			@thumbnail:click="clickThumbnail"
 			@overflow:click="clickOverflow"
 		/>
-		<m-toast-layer />
+		clicked: {{ lastClicked }}
+		<m-divider />
+		Thumbnails with custom sizes
+		<m-thumbnails
+			:thumbnails="thumbnails"
+			:max-thumbnails="3"
+			size="100px"
+			:overflow-text-size="5"
+		/>
 	</div>
 </template>
 
 <script>
-import { MToastLayer, MToast } from '@square/maker/components/Toast';
 import { MDivider } from '@square/maker/components/Divider';
 import { MThumbnails } from '@square/maker/components/Thumbnails';
 
 export default {
 	components: {
-		MToastLayer,
 		MDivider,
 		MThumbnails,
 	},
 
-	mixins: [
-		MToastLayer.apiMixin,
-	],
-
 	data() {
 		return {
 			thumbnails: [
-				'https://source.unsplash.com/random/100x100',
-				'https://source.unsplash.com/random/200x200',
-				'https://source.unsplash.com/random/300x300',
-				'https://source.unsplash.com/random/400x400',
-				'https://source.unsplash.com/random/500x500',
-				'https://source.unsplash.com/random/600x600',
+				'https://source.unsplash.com/random/100x100?1',
+				'https://source.unsplash.com/random/100x100?2',
+				'https://source.unsplash.com/random/100x100?3',
+				'https://source.unsplash.com/random/100x100?4',
+				'https://source.unsplash.com/random/100x100?5',
+				'https://source.unsplash.com/random/100x100?6',
 			],
+			lastClicked: '',
 		};
 	},
 
 	methods: {
 		clickThumbnail(thumbnail) {
-			this.toastApi.open(() => <MToast
-					text={`Hello. Thumbnail (${thumbnail}) clicked.`}
-			/>);
+			this.lastClicked = thumbnail;
 		},
 
 		clickOverflow() {
-			this.toastApi.open(() => <MToast
-					text={'Hello. Overflow clicked.'}
-			/>);
+			this.lastClicked = 'overflow';
 		},
 	},
 };
 </script>
+
 <style scoped>
 .container {
 	width: 500px;
@@ -93,12 +88,12 @@ export default {
 <!-- api-tables:start -->
 ## Props
 
-| Prop               | Type     | Default                   | Possible values | Description                                                        |
-| ------------------ | -------- | ------------------------- | --------------- | ------------------------------------------------------------------ |
-| thumbnails         | `array`  | —                         | -               | Image urls to display for thumbnails                               |
-| size               | `number` | `32`                      | -               | Size to display thumbnail images (in px)                           |
-| max-thumbnails     | `number` | `DEFAULT_THUMBNAIL_COUNT` | -               | Maximum number of thumbnails to display                            |
-| overflow-text-size | `number` | —                         | -               | Overflow text size. Size of text as step in fluid scale (-2 to 7). |
+| Prop               | Type     | Default  | Possible values | Description                                                        |
+| ------------------ | -------- | -------- | --------------- | ------------------------------------------------------------------ |
+| thumbnails         | `array`  | —        | -               | Image urls to display for thumbnails                               |
+| size               | `string` | `'32px'` | -               | Size to display thumbnail images                                   |
+| max-thumbnails     | `number` | `5`      | -               | Maximum number of thumbnails to display                            |
+| overflow-text-size | `number` | `0`      | -               | Overflow text size. Size of text as step in fluid scale (-2 to 7). |
 
 
 ## Events


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
before thumbnails `size` prop only accepted a Number, and converted it to pixels, for setting the thumbnail size... now it accepts any valid CSS string (similar to most props on most Maker components)

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
`size` prop now accepts any valid css value for width/height

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
https://square.github.io/maker/styleguide/css-sizes-for-thumbnails/#/Thumbnails