### PR TITLE
fix(theme): allow webpack to properly treeshake lodash

### DIFF
--- a/src/components/Theme/src/utils.cjs
+++ b/src/components/Theme/src/utils.cjs
@@ -1,4 +1,7 @@
-const { isString, isNil, get } = require('lodash');
+const isString = require('lodash/isString');
+const isNil = require('lodash/isNil');
+const get = require('lodash/get');
+// Can't import via require('lodash') as it will bring in the entire lodash lib
 
 /**
  * Check if passed in value is a pointer, if so resolve the pointer to its value,


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
We noticed that in our app that the entire lodash lib was being pulled into our main script which seemed curious because we use the "babel-plugin-lodash". Some digging revealed this dependency was coming from Maker.
![image](https://user-images.githubusercontent.com/18740390/205157482-a82799db-ffae-4044-942c-c0a56df9236e.png)

In the .cjs file if you import via `require('lodash')` it imports the entire lib, as the `babel-plugin-lodash` appears to only only handles ES. Have to import via the individual functions and now we longer have the entire lodash lib.
![image](https://user-images.githubusercontent.com/18740390/205157898-c7697ad1-6518-4f66-a48b-a1ebffedffdb.png)