### PR TITLE
fix(imageuploader): close button now responsive to shape theming

### DIFF
--- a/src/components/ImageUploader/src/ImageSelection.vue
+++ b/src/components/ImageUploader/src/ImageSelection.vue
@@ -38,27 +38,30 @@
 			size="xsmall"
 		/>
 
-		<button
+		<m-button
 			v-if="!isUploading"
-			type="button"
-			:class="$s.ImageSelectionRemoveButton"
+			size="small"
+			color="#ffffff"
+			:class="$s.TopRight"
 			@click="$emit('removeImage')"
 		>
 			<m-icon
 				:class="$s.ImageSelectionRemoveIcon"
 				name="close"
 			/>
-		</button>
+		</m-button>
 	</div>
 </template>
 
 <script>
+import { MButton } from '@square/maker/components/Button';
 import { MLoading } from '@square/maker/components/Loading';
 import { MProgressBar } from '@square/maker/components/ProgressBar';
 import { MIcon } from '@square/maker/components/Icon';
 
 export default {
 	components: {
+		MButton,
 		MLoading,
 		MProgressBar,
 		MIcon,
@@ -148,19 +151,10 @@ export default {
 	border: 1px solid var(--color-error);
 }
 
-.ImageSelectionRemoveButton {
+.TopRight {
 	position: absolute;
 	top: 8px;
 	right: 8px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 32px;
-	height: 32px;
-	background-color: #fff;
-	border: 0;
-	border-radius: 50%;
-	cursor: pointer;
 }
 
 .ImageSelectionRemoveIcon {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
close button in imageuploader component wasn't an mbutton

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
it's now an mbutton, and will respond to shape theming

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
https://square.github.io/maker/styleguide/themable-button-in-imageuploader/#/ImageUploader