### PR TITLE
docs: group components in styleguide sidenav

### DIFF
--- a/styleguide/COMPONENTS.md
+++ b/styleguide/COMPONENTS.md
@@ -1,3 +1,0 @@
-# Components
-
-Browse component documentation by clicking on the links in the side navigation. All of the components can be used standalone. If you would like to theme components for a whole app you need to wrap them using the [Theme](#/Theme) component.

--- a/styleguide/SideNav.vue
+++ b/styleguide/SideNav.vue
@@ -2,7 +2,7 @@
 	<div>
 		<nav class="nav">
 			<template
-				v-for="group in groups"
+				v-for="group in groupsWithLinks"
 			>
 				<a
 					:key="group.name"
@@ -48,6 +48,9 @@ export default {
 		groups() {
 			const defaultGroup = {
 				name: 'general',
+				set: new Set([
+					'starrating',
+				]),
 				links: [],
 			};
 			const groups = [
@@ -57,6 +60,12 @@ export default {
 						'accordion',
 						'card',
 						'container',
+						'theme',
+						'blade',
+						'dialog',
+						'modal',
+						'popover',
+						'toast',
 					]),
 					links: [],
 				},
@@ -76,6 +85,19 @@ export default {
 						'stepper',
 						'textarea',
 						'toggle',
+						'menu',
+					]),
+					links: [],
+				},
+				{
+					name: 'notify',
+					set: new Set([
+						'notice',
+						'pill',
+						'badge',
+						'toast',
+						'progressbar',
+						'progresscircle',
 					]),
 					links: [],
 				},
@@ -89,6 +111,7 @@ export default {
 						'popover',
 						'menu',
 						'toast',
+						'select',
 					]),
 					links: [],
 				},
@@ -103,6 +126,7 @@ export default {
 				{
 					name: 'layout',
 					set: new Set([
+						'container',
 						'blockformcontrollayout',
 						'inlineformcontrollayout',
 						'row',
@@ -133,20 +157,23 @@ export default {
 				},
 			];
 			for (const navLink of this.navLinks) {
+				const navLinkLabel = navLink.label.toLowerCase();
 				let hasGroup = false;
 				for (const group of groups) {
-					if (group.set.has(navLink.label.toLowerCase())) {
+					if (group.set.has(navLinkLabel)) {
 						group.links.push(navLink);
 						hasGroup = true;
-						break;
 					}
 				}
-				if (!hasGroup) {
+				if (!hasGroup || defaultGroup.set.has(navLinkLabel)) {
 					defaultGroup.links.push(navLink);
 				}
 			}
 			groups.unshift(defaultGroup);
 			return groups;
+		},
+		groupsWithLinks() {
+			return this.groups.filter((group) => group.links.length > 0);
 		},
 	},
 };

--- a/styleguide/SideNav.vue
+++ b/styleguide/SideNav.vue
@@ -1,22 +1,25 @@
 <template>
 	<div>
 		<nav class="nav">
-			<router-link
-				to="/components"
-				class="header-link link"
-				@click.native="$emit('route:click')"
+			<template
+				v-for="group in groups"
 			>
-				components
-			</router-link>
-			<router-link
-				v-for="componentLink in navLinks"
-				:key="componentLink.path.name"
-				:to="componentLink.path"
-				class="link"
-				@click.native="$emit('route:click')"
-			>
-				{{ componentLink.label }}
-			</router-link>
+				<a
+					:key="group.name"
+					class="link header-link"
+				>
+					{{ group.name }}
+				</a>
+				<router-link
+					v-for="link in group.links"
+					:key="link.path.name"
+					:to="link.path"
+					class="link"
+					@click.native="$emit('route:click')"
+				>
+					{{ link.label }}
+				</router-link>
+			</template>
 			<router-link
 				to="/utils"
 				class="header-link link"
@@ -29,7 +32,6 @@
 </template>
 
 <script>
-
 export default {
 	computed: {
 		navLinks() {
@@ -42,6 +44,109 @@ export default {
 					},
 					category: route.category,
 				}));
+		},
+		groups() {
+			const defaultGroup = {
+				name: 'general',
+				links: [],
+			};
+			const groups = [
+				{
+					name: 'container',
+					set: new Set([
+						'accordion',
+						'card',
+						'container',
+					]),
+					links: [],
+				},
+				{
+					name: 'form',
+					set: new Set([
+						'calendar',
+						'checkbox',
+						'choice',
+						'imageuploader',
+						'input',
+						'pininput',
+						'radio',
+						'segmentedcontrol',
+						'select',
+						'starrating',
+						'stepper',
+						'textarea',
+						'toggle',
+					]),
+					links: [],
+				},
+				{
+					name: 'popout',
+					set: new Set([
+						'actionbar',
+						'blade',
+						'dialog',
+						'modal',
+						'popover',
+						'menu',
+						'toast',
+					]),
+					links: [],
+				},
+				{
+					name: 'loading',
+					set: new Set([
+						'loading',
+						'skeleton',
+					]),
+					links: [],
+				},
+				{
+					name: 'layout',
+					set: new Set([
+						'blockformcontrollayout',
+						'inlineformcontrollayout',
+						'row',
+					]),
+					links: [],
+				},
+				{
+					name: 'transition',
+					set: new Set([
+						'transition',
+						'transitioncollapse',
+						'transitionfadein',
+						'transitionresize',
+						'transitionresponsive',
+						'transitionspringleft',
+						'transitionspringup',
+						'transitionstack',
+						'transitionstaggered',
+					]),
+					links: [],
+				},
+				{
+					name: 'functional',
+					set: new Set([
+						'touchcapture',
+					]),
+					links: [],
+				},
+			];
+			for (const navLink of this.navLinks) {
+				let hasGroup = false;
+				for (const group of groups) {
+					if (group.set.has(navLink.label.toLowerCase())) {
+						group.links.push(navLink);
+						hasGroup = true;
+						break;
+					}
+				}
+				if (!hasGroup) {
+					defaultGroup.links.push(navLink);
+				}
+			}
+			groups.unshift(defaultGroup);
+			return groups;
 		},
 	},
 };
@@ -63,8 +168,8 @@ export default {
 .nav .header-link {
 	font-weight: 600;
 	font-size: 14px;
-	line-height: 2.5;
-	letter-spacing: 1px;
+	line-height: 3;
+	letter-spacing: 2px;
 	text-transform: uppercase;
 }
 </style>

--- a/styleguide/create-router.js
+++ b/styleguide/create-router.js
@@ -4,7 +4,6 @@ import Router from 'vue-router';
 import Meta from 'vue-meta';
 import VuePortal from '@linusborg/vue-simple-portal';
 import IndexPage from './INDEX.md';
-import ComponentsPage from './COMPONENTS.md';
 import UtilsPage from './UTILS.md';
 
 Vue.use(Router);
@@ -22,11 +21,6 @@ function createRouter() {
 				name: 'index',
 				path: '/',
 				component: IndexPage,
-			},
-			{
-				name: 'components',
-				path: '/components',
-				component: ComponentsPage,
 			},
 			{
 				name: 'utils',


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
components in styleguide sidenav aren't grouped/categorized/organized in any way

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
adds groups/categories for components

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
https://square.github.io/maker/styleguide/sidenav-groupings/#/