### PR TITLE
fix(button): don't change a custom button hover color

### DIFF
--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -75,8 +75,8 @@ function setColorVariables(tokens, variant) {
 	const hoverStateAdjust = 0.08;
 	const activeStateAdjust = 0.16;
 	const focusAlphaAdjust = 0.3;
-	const colorHover = colorMainHover === colorMain
-		? colorMainHover[stateAdjustment](hoverStateAdjust).toHex() : colorMainHover.toHex();
+	const colorHover = tokens.colorHover
+		? tokens.colorHover : colorMainHover[stateAdjustment](hoverStateAdjust).toHex();
 	const colorActive = colorMainHover[stateAdjustment](activeStateAdjust).toHex();
 	const colorFocus = colorMainHover.alpha(focusAlphaAdjust).toHex();
 

--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -75,7 +75,8 @@ function setColorVariables(tokens, variant) {
 	const hoverStateAdjust = 0.08;
 	const activeStateAdjust = 0.16;
 	const focusAlphaAdjust = 0.3;
-	const colorHover = colorMainHover[stateAdjustment](hoverStateAdjust).toHex();
+	const colorHover = colorMainHover === colorMain
+		? colorMainHover[stateAdjustment](hoverStateAdjust).toHex() : colorMainHover.toHex();
 	const colorActive = colorMainHover[stateAdjustment](activeStateAdjust).toHex();
 	const colorFocus = colorMainHover.alpha(focusAlphaAdjust).toHex();
 


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Button hover color get's lightened or darkened slightly even it's a custom value.
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
No longer lighten/darken hover color if it's different than the main button fill color.
<img width="235" alt="Screen Shot 2022-12-22 at 5 24 07 PM" src="https://user-images.githubusercontent.com/1486885/209236087-6ac6f92a-a921-4fb6-b781-9e07d20a0474.png">
<img width="226" alt="Screen Shot 2022-12-22 at 5 23 44 PM" src="https://user-images.githubusercontent.com/1486885/209236088-09fc3c5a-416c-40bc-9075-51ff45404d88.png">


<!--
  📸 Inline screenshots to better communicate the changes
-->

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
