### PR TITLE
fix(textarea): fix invalid state style

### DIFF
--- a/src/components/Textarea/README.md
+++ b/src/components/Textarea/README.md
@@ -187,6 +187,7 @@ Supports attributes from [`<textarea>`](https://developer.mozilla.org/en-US/docs
 | --------- | --------- | -------- | --------------------- | ------------------------------------- |
 | variant   | `string`  | `'fill'` | `'fill'`, `'outline'` | textarea variant                      |
 | v-model   | `string`  | `''`     | -                     | textarea's current value              |
+| disabled  | `boolean` | `false`  | -                     | Toggles textarea's disabled state     |
 | invalid   | `boolean` | `false`  | -                     | Toggle textarea's invalid state       |
 | resizable | `boolean` | `false`  | -                     | Toggles whether textarea is resizable |
 

--- a/src/components/Textarea/src/TextareaControl.vue
+++ b/src/components/Textarea/src/TextareaControl.vue
@@ -7,6 +7,8 @@
 			$s[`variant_${variant}`],
 			{
 				[$s.resizable]: resizable,
+				[$s.disabled]: disabled,
+				[$s.invalid]: invalid,
 			},
 		]"
 		v-bind="$attrs"
@@ -41,6 +43,13 @@ export default {
 		value: {
 			type: String,
 			default: '',
+		},
+		/**
+		 * Toggles textarea's disabled state
+		 */
+		disabled: {
+			type: Boolean,
+			default: false,
 		},
 		/**
 		 * Toggle textarea's invalid state
@@ -138,12 +147,12 @@ export default {
 		color: var(--color-placeholder);
 	}
 
-	&:disabled {
+	&.disabled {
 		cursor: not-allowed;
 		opacity: 0.5;
 	}
 
-	&:invalid {
+	&.invalid {
 		border-color: var(--color-error);
 	}
 
@@ -155,12 +164,12 @@ export default {
 		-webkit-text-fill-color: var(--color-background);
 	}
 
-	&:hover:not(:disabled, :invalid) {
+	&:hover:not(.disabled, .invalid) {
 		border-color: var(--color-border-active);
 	}
 
-	&:active:not(:disabled, :invalid),
-	&:focus:not(:disabled, :invalid) {
+	&:active:not(.disabled, .invalid),
+	&:focus:not(.disabled, .invalid) {
 		border-color: var(--color-border-active);
 	}
 


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Browsers automatically apply the `:invalid` pseudoclass to empty textareas that are `required`. This goes against our styling for text inputs where `:invalid` is only triggered when the prop is explicitly set to true, such as when errors are returned for an attempted form submission.

<img width="757" alt="Screen Shot 2023-01-04 at 2 02 32 PM" src="https://user-images.githubusercontent.com/1486885/210630342-c84da044-d56c-44d3-80bc-a1274357c002.png">


<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
Aligns invalid textarea behavior with text inputs. Red border only applies when `invalid` prop/attribute is set to true.

<img width="715" alt="Screen Shot 2023-01-04 at 2 01 12 PM" src="https://user-images.githubusercontent.com/1486885/210630481-ac9fd94c-ce30-4a77-87d9-a4e68e0217d1.png">


<!--
  📸 Inline screenshots to better communicate the changes
-->

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
