### PR TITLE
feat(image): add object-fit property to image component

### DIFF
--- a/src/components/Image/README.md
+++ b/src/components/Image/README.md
@@ -143,16 +143,11 @@ export default {
 
 	data() {
 		return {
-			shape: 'square',
-			shapeOptions: [
-				'square',
-				'circle',
-				'arch',
-			],
 			objectFit: 'cover',
 			objectFitOptions: [
 				'cover',
 				'contain',
+				'scale-down',
 			],
 		};
 	},
@@ -198,7 +193,7 @@ Themable props* can be configured via the [Theme](#/Theme) component using the k
 | sizes      | `string`  | —         | -                                              | -                                                                         |
 | shape*     | `string`  | —         | `'original'`, `'square'`, `'circle'`, `'arch'` | Original applies theme's border radius, square applies border radius of 0 |
 | lazyload   | `boolean` | `false`   | -                                              | -                                                                         |
-| object-fit | `string`  | `'cover'` | `'cover'`, `'contain'`                         | `cover` - image will be clipped to fit, `contain` - image will be scaled to fit dimensions                                                                         |
+| object-fit | `string`  | `'cover'` | `'cover'`, `'contain'`, `'scale-down'`                         | `cover` - image will be clipped to fit, `contain` - image will be scaled to fit dimensions                                                                         |
 
 
 ## Events

--- a/src/components/Image/README.md
+++ b/src/components/Image/README.md
@@ -193,7 +193,7 @@ Themable props* can be configured via the [Theme](#/Theme) component using the k
 | sizes      | `string`  | —         | -                                              | -                                                                         |
 | shape*     | `string`  | —         | `'original'`, `'square'`, `'circle'`, `'arch'` | Original applies theme's border radius, square applies border radius of 0 |
 | lazyload   | `boolean` | `false`   | -                                              | -                                                                         |
-| object-fit | `string`  | `'cover'` | `'cover'`, `'contain'`, `'scale-down'`                         | `cover` - image will be clipped to fit, `contain` - image will be scaled to fit dimensions                                                                         |
+| object-fit | `string`  | `'cover'` | `'cover'`, `'contain'`, `'scale-down'`         | `cover` - image will be clipped to fit, `contain` - image will be scaled to fit dimensions |
 
 
 ## Events

--- a/src/components/Image/README.md
+++ b/src/components/Image/README.md
@@ -1,9 +1,12 @@
 # Image
 
+
+## Examples
+
+### Shape
 ```vue
 <template>
 	<div>
-		<h4>image</h4>
 		<m-image
 			class="image"
 			src="https://source.unsplash.com/random/400x600"
@@ -90,6 +93,94 @@ export default {
 </style>
 ```
 
+### Object Fit
+
+object-fit: `contain` works best when shape: `original`
+
+```vue
+<template>
+	<div>
+		<m-image
+			class="image"
+			src="https://source.unsplash.com/random/400x600"
+			:object-fit="objectFit"
+		/>
+		<m-image
+			class="image image-tall"
+			src="https://source.unsplash.com/random/400x600"
+			:object-fit="objectFit"
+		/>
+		<m-image
+			class="image image-wide"
+			src="https://source.unsplash.com/random/400x600"
+			:object-fit="objectFit"
+		/>
+		<br>
+		<label>
+			Object Fit
+			<select
+				v-model="objectFit"
+			>
+				<option
+					v-for="(value, index) in objectFitOptions"
+					:key="index"
+					:value="value"
+				>
+					{{ value }}
+				</option>
+			</select>
+		</label>
+	</div>
+</template>
+
+<script>
+import { MImage } from '@square/maker/components/Image';
+
+export default {
+	components: {
+		MImage,
+	},
+
+	data() {
+		return {
+			shape: 'square',
+			shapeOptions: [
+				'square',
+				'circle',
+				'arch',
+			],
+			objectFit: 'cover',
+			objectFitOptions: [
+				'cover',
+				'contain',
+			],
+		};
+	},
+};
+</script>
+
+<style scoped>
+.image {
+	display: inline-block;
+	width: 400px;
+	height: 400px;
+	margin-right: 25px;
+}
+
+.image-tall {
+	display: inline-block;
+	width: 400px;
+	height: 500px;
+}
+
+.image-wide {
+	display: inline-block;
+	width: 600px;
+	height: 400px;
+}
+</style>
+```
+
 ## Props
 Supports all `<img>` attributes
 
@@ -100,13 +191,14 @@ Supports attributes from [`<img>`](https://developer.mozilla.org/en-US/docs/Web/
 
 Themable props* can be configured via the [Theme](#/Theme) component using the key `image`.
 
-| Prop     | Type      | Default | Possible values                                | Description                                                               |
-| -------- | --------- | ------- | ---------------------------------------------- | ------------------------------------------------------------------------- |
-| src      | `string`  | —       | -                                              | -                                                                         |
-| srcset   | `string`  | —       | -                                              | -                                                                         |
-| sizes    | `string`  | —       | -                                              | -                                                                         |
-| shape*   | `string`  | —       | `'original'`, `'square'`, `'circle'`, `'arch'` | Original applies theme's border radius, square applies border radius of 0 |
-| lazyload | `boolean` | `false` | -                                              | -                                                                         |
+| Prop       | Type      | Default   | Possible values                                | Description                                                               |
+| ---------- | --------- | --------- | ---------------------------------------------- | ------------------------------------------------------------------------- |
+| src        | `string`  | —         | -                                              | -                                                                         |
+| srcset     | `string`  | —         | -                                              | -                                                                         |
+| sizes      | `string`  | —         | -                                              | -                                                                         |
+| shape*     | `string`  | —         | `'original'`, `'square'`, `'circle'`, `'arch'` | Original applies theme's border radius, square applies border radius of 0 |
+| lazyload   | `boolean` | `false`   | -                                              | -                                                                         |
+| object-fit | `string`  | `'cover'` | `'cover'`, `'contain'`                         | `cover` - image will be clipped to fit, `contain` - image will be scaled to fit dimensions                                                                         |
 
 
 ## Events

--- a/src/components/Image/README.md
+++ b/src/components/Image/README.md
@@ -193,7 +193,7 @@ Themable props* can be configured via the [Theme](#/Theme) component using the k
 | sizes      | `string`  | —         | -                                              | -                                                                         |
 | shape*     | `string`  | —         | `'original'`, `'square'`, `'circle'`, `'arch'` | Original applies theme's border radius, square applies border radius of 0 |
 | lazyload   | `boolean` | `false`   | -                                              | -                                                                         |
-| object-fit | `string`  | `'cover'` | `'cover'`, `'contain'`, `'scale-down'`         | `cover` - image will be clipped to fit, `contain` - image will be scaled to fit dimensions |
+| object-fit | `string`  | `'cover'` | -                                              | [Object fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) |
 
 
 ## Events

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -111,7 +111,7 @@ export default {
 		},
 		objectFit: {
 			type: String,
-			validator: (fit) => ['cover', 'contain'].includes(fit),
+			validator: (fit) => ['cover', 'contain', 'scale-down'].includes(fit),
 			default: 'cover',
 		},
 	},

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -146,7 +146,7 @@ export default {
 		style() {
 			return {
 				'--image-height': `${this.height}px`,
-				'object-fit': this.objectFit,
+				'--image-object-fit': this.objectFit,
 			};
 		},
 
@@ -218,7 +218,7 @@ export default {
 .Image {
 	width: 100%;
 	height: 100%;
-	object-fit: cover;
+	object-fit: var(--image-object-fit);
 	object-position: center;
 	border-radius: $maker-shape-image-border-radius;
 

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -109,6 +109,11 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		objectFit: {
+			type: String,
+			validator: (fit) => ['cover', 'contain'].includes(fit),
+			default: 'cover',
+		},
 	},
 
 	data() {
@@ -141,6 +146,7 @@ export default {
 		style() {
 			return {
 				'--image-height': `${this.height}px`,
+				'object-fit': this.objectFit,
 			};
 		},
 

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -38,6 +38,7 @@ import { throttle } from 'lodash';
 import { MTransitionFadeIn } from '@square/maker/components/TransitionFadeIn';
 import { MSkeletonBlock } from '@square/maker/components/Skeleton';
 import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
+import cssValidator from '@square/maker/utils/css-validator';
 
 /** @constructor */
 function SharedIntersectionObserver() {
@@ -109,9 +110,12 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		/**
+		 * [Object fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)
+		 */
 		objectFit: {
 			type: String,
-			validator: (fit) => ['cover', 'contain', 'scale-down'].includes(fit),
+			validator: cssValidator('object-fit'),
 			default: 'cover',
 		},
 	},


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
* `object-fit` style is originally set to `cover` which will clip the provided image to the specified image dimensions. This allows the image to be scaled to the given dimensions in addition

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
* Specify `object-fit` property on the image
* Adds `contain` and `scale-down` object fit properties. `cover` is treated as the default

https://user-images.githubusercontent.com/82115556/212120973-382c6c62-4613-49bf-b6ec-febae3f3dfec.mov

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->

