### PR TITLE
feat(cards): add glass variant for cards, rename default to outline

### DIFF
--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -22,15 +22,61 @@ Use Card to provide a stylized container of information.
 				here is my card content. there is a fixed width of 400px applied directly to the card.
 			</m-card>
 		</div>
+		<m-theme
+			class="glass-demo"
+			:theme="themeDark"
+		>
+			<m-image
+				class="image"
+				src="https://source.unsplash.com/600x400/?night+sky"
+			/>
+			<m-card
+				variant="glass"
+				style="width:400px;"
+			>
+				here is my card content. there is a fixed width of 400px applied directly to the card.
+			</m-card>
+		</m-theme>
+		<m-theme
+			class="glass-demo"
+			:theme="themeLight"
+		>
+			<m-image
+				class="image"
+				src="https://source.unsplash.com/600x400/?snow+blind"
+			/>
+			<m-card
+				variant="glass"
+				style="width:400px;"
+			>
+				here is my card content. there is a fixed width of 400px applied directly to the card.
+			</m-card>
+		</m-theme>
 	</div>
 </template>
 
 <script>
 import { MCard } from '@square/maker/components/Card';
+import { MImage } from '@square/maker/components/Image';
+import { MTheme } from '@square/maker/components/Theme';
+import makerColors from '@square/maker/utils/maker-colors';
 
 export default {
 	components: {
 		MCard,
+		MImage,
+		MTheme,
+	},
+
+	data() {
+		return {
+			themeLight: {
+				colors: makerColors('#ffffff', '#000000'),
+			},
+			themeDark: {
+				colors: makerColors('#000000', '#ffffff'),
+			},
+		};
 	},
 };
 </script>
@@ -44,6 +90,19 @@ export default {
 .container {
 	width: 300px;
 }
+
+.glass-demo {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 600px;
+	height: 400px;
+}
+
+.image {
+	position: absolute;
+}
 </style>
 ```
 
@@ -54,9 +113,10 @@ Supports attributes from [`<div>`](https://developer.mozilla.org/en-US/docs/Web/
 
 Themable props* can be configured via the [Theme](#/Theme) component using the key `card`.
 
-| Prop   | Type     | Default | Possible values                    | Description |
-| ------ | -------- | ------- | ---------------------------------- | ----------- |
-| shape* | `string` | —       | `'squared'`, `'rounded'`, `'pill'` | card shape  |
+| Prop     | Type     | Default     | Possible values                    | Description  |
+| -------- | -------- | ----------- | ---------------------------------- | ------------ |
+| shape*   | `string` | —           | `'squared'`, `'rounded'`, `'pill'` | card shape   |
+| variant* | `string` | `'outline'` | `'outline'`, `'glass'`             | card variant |
 
 
 ## Slots

--- a/src/components/Card/src/Card.vue
+++ b/src/components/Card/src/Card.vue
@@ -1,25 +1,40 @@
 <template>
-	<div
+	<m-theme
 		:class="[
 			$s.Card,
 			$s[`shape_${resolvedShape}`],
+			$s[`variant_${resolvedVariant}`],
 		]"
 		v-bind="$attrs"
+		:style="style"
+		:theme="cardTheme"
 		v-on="$listeners"
 	>
 		<!-- @slot card content -->
 		<slot />
-	</div>
+	</m-theme>
 </template>
 
 <script>
-import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
+import {
+	MTheme,
+	MThemeKey,
+	defaultTheme,
+	resolveThemeableProps,
+} from '@square/maker/components/Theme';
+import { getContrast } from '@square/maker/utils/get-contrast';
+import makerColors from '@square/maker/utils/maker-colors';
+import { colord } from 'colord';
 
 /**
  * @inheritAttrs div
  * @inheritListeners div
  */
 export default {
+	components: {
+		MTheme,
+	},
+
 	inject: {
 		theme: {
 			default: defaultTheme(),
@@ -38,12 +53,47 @@ export default {
 			default: undefined,
 			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
 		},
+		/**
+		 * card variant
+		 */
+		variant: {
+			type: String,
+			default: undefined,
+			validator: (variant) => ['outline', 'glass'].includes(variant),
+		},
 	},
 
 	computed: {
 		...resolveThemeableProps('card', [
 			'shape',
+			'variant',
 		]),
+
+		style() {
+			if (this.variant !== 'glass') {
+				return {};
+			}
+
+			const alpha = 0.8;
+			return {
+				'--bg-color-glass': colord(this.theme.colors['neutral-100']).alpha(alpha).toRgbString(),
+			};
+		},
+
+		cardTheme() {
+			if (this.variant !== 'glass') {
+				return {};
+			}
+
+			const cardBg = this.theme.colors['neutral-100'];
+			return {
+				colors: {
+					...makerColors(cardBg, this.theme.colors.primary),
+					heading: getContrast(cardBg, this.theme.colors.heading),
+					body: getContrast(cardBg, this.theme.colors.body),
+				},
+			};
+		},
 	},
 };
 </script>
@@ -54,9 +104,17 @@ export default {
 	--radius-pill-default: 4px;
 
 	padding: 16px 24px;
-	background-color: $maker-color-background;
-	border: 1px solid $maker-color-neutral-20;
 	border-radius: $maker-shape-card-border-radius;
+
+	&.variant_outline {
+		background-color: $maker-color-background;
+		border: 1px solid $maker-color-neutral-20;
+	}
+
+	&.variant_glass {
+		background-color: var(--bg-color-glass);
+		backdrop-filter: blur(2px);
+	}
 
 	&.shape_squared {
 		border-radius: 0;

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -220,6 +220,7 @@ export default {
 }
 
 .Image {
+	display: block;
 	width: 100%;
 	height: 100%;
 	object-fit: var(--image-object-fit);

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -256,6 +256,89 @@ export default {
 }
 </style>
 ```
+### Custom popover component
+
+Using Popover to toggle a component besides PopoverContent (e.g. Card)
+
+```vue
+<template>
+	<m-theme
+		class="wrapper"
+		:theme="theme"
+	>
+		<m-popover-layer />
+		<m-image
+			class="image"
+			src="https://source.unsplash.com/600x400/?night+sky"
+		/>
+		<m-popover>
+			<template #action="popover">
+				<m-button
+					size="small"
+					@click="popover.toggle()"
+				>
+					Toggle popover
+				</m-button>
+			</template>
+
+			<template #content>
+				<m-card
+					variant="glass"
+				>
+					Content for a basic popover
+				</m-card>
+			</template>
+		</m-popover>
+	</m-theme>
+</template>
+
+<script>
+import { MPopoverLayer, MPopover } from '@square/maker/components/Popover';
+import { MButton } from '@square/maker/components/Button';
+import { MCard } from '@square/maker/components/Card';
+import { MImage } from '@square/maker/components/Image';
+import { MTheme } from '@square/maker/components/Theme';
+import makerColors from '@square/maker/utils/maker-colors';
+
+export default {
+	components: {
+		MPopoverLayer,
+		MPopover,
+		MButton,
+		MCard,
+		MImage,
+		MTheme,
+	},
+
+	mixins: [
+		MPopoverLayer.popoverMixin,
+	],
+
+	computed: {
+		theme() {
+			return {
+				colors: makerColors('#000000', '#ffffff'),
+			};
+		},
+	},
+};
+</script>
+
+<style scoped>
+.wrapper {
+	position: relative;
+	width: 600px;
+	height: 400px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.image {
+	position: absolute;
+}
+</style>
+```
 
 ### External triggers
 

--- a/src/components/Popover/src/PopoverContent.vue
+++ b/src/components/Popover/src/PopoverContent.vue
@@ -72,6 +72,7 @@ export default {
 				colors = makerColors(this.bgColor);
 			}
 			if (this.color) {
+				colors.heading = getContrast(colors.background, this.color);
 				colors.body = getContrast(colors.background, this.color, WCAG_CONTRAST_TEXT);
 			}
 

--- a/src/components/Theme/src/default-components.cjs
+++ b/src/components/Theme/src/default-components.cjs
@@ -149,6 +149,7 @@ module.exports = function defaultComponents() {
 		},
 		card: {
 			shape: undefined,
+			variant: 'outline',
 		},
 		text: {
 			size: 0,


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
No cards with glass backdrop.
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR

Adds the `variant` prop to Cards, and styles for the `glass` variant. Renames current default card style to `outline` and makes it the theme default. Adds examples for usage to style guides.

<img width="614" alt="Screenshot 2023-01-25 at 11 56 18 AM" src="https://user-images.githubusercontent.com/1486885/214696600-fe0054ee-9b66-4660-b8c2-928c67ca2138.png">


<!--
  📸 Inline screenshots to better communicate the changes
-->

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
