### PR TITLE
feat(image): add object-position property to image

### DIFF
--- a/src/components/Image/README.md
+++ b/src/components/Image/README.md
@@ -176,6 +176,66 @@ export default {
 </style>
 ```
 
+### Object Position
+
+```vue
+<template>
+	<div>
+		<m-image
+			class="image"
+			src="https://source.unsplash.com/random/400x400"
+			:object-fit="objectFit"
+			:object-position="objectPosition"
+		/>
+		<br>
+		<label>
+			Object Position
+			<select
+				v-model="objectPosition"
+			>
+				<option
+					v-for="(value, index) in objectPositionOptions"
+					:key="index"
+					:value="value"
+				>
+					{{ value }}
+				</option>
+			</select>
+		</label>
+	</div>
+</template>
+
+<script>
+import { MImage } from '@square/maker/components/Image';
+
+export default {
+	components: {
+		MImage,
+	},
+
+	data() {
+		return {
+			objectFit: 'contain',
+			objectPosition: 'center',
+			objectPositionOptions: [
+				'center',
+				'top',
+				'bottom',
+			],
+		};
+	},
+};
+</script>
+
+<style scoped>
+.image {
+	display: inline-block;
+	width: 400px;
+	height: 600px;
+}
+</style>
+```
+
 ## Props
 Supports all `<img>` attributes
 

--- a/src/components/Image/README.md
+++ b/src/components/Image/README.md
@@ -186,14 +186,15 @@ Supports attributes from [`<img>`](https://developer.mozilla.org/en-US/docs/Web/
 
 Themable props* can be configured via the [Theme](#/Theme) component using the key `image`.
 
-| Prop       | Type      | Default   | Possible values                                | Description                                                               |
-| ---------- | --------- | --------- | ---------------------------------------------- | ------------------------------------------------------------------------- |
-| src        | `string`  | —         | -                                              | -                                                                         |
-| srcset     | `string`  | —         | -                                              | -                                                                         |
-| sizes      | `string`  | —         | -                                              | -                                                                         |
-| shape*     | `string`  | —         | `'original'`, `'square'`, `'circle'`, `'arch'` | Original applies theme's border radius, square applies border radius of 0 |
-| lazyload   | `boolean` | `false`   | -                                              | -                                                                         |
-| object-fit | `string`  | `'cover'` | -                                              | [Object fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) |
+| Prop            | Type      | Default    | Possible values                                | Description                                                                         |
+| --------------- | --------- | ---------- | ---------------------------------------------- | ----------------------------------------------------------------------------------- |
+| src             | `string`  | —          | -                                              | -                                                                                   |
+| srcset          | `string`  | —          | -                                              | -                                                                                   |
+| sizes           | `string`  | —          | -                                              | -                                                                                   |
+| shape*          | `string`  | —          | `'original'`, `'square'`, `'circle'`, `'arch'` | Original applies theme's border radius, square applies border radius of 0           |
+| lazyload        | `boolean` | `false`    | -                                              | -                                                                                   |
+| object-fit      | `string`  | `'cover'`  | -                                              | [Object fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)           |
+| object-position | `string`  | `'center'` | -                                              | [Object position](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) |
 
 
 ## Events

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -118,6 +118,14 @@ export default {
 			validator: cssValidator('object-fit'),
 			default: 'cover',
 		},
+		/**
+		 * [Object position](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position)
+		 */
+		objectPosition: {
+			type: String,
+			validator: cssValidator('object-position'),
+			default: 'center',
+		},
 	},
 
 	data() {
@@ -151,6 +159,7 @@ export default {
 			return {
 				'--image-height': `${this.height}px`,
 				'--image-object-fit': this.objectFit,
+				'--image-object-position': this.objectPosition,
 			};
 		},
 
@@ -224,7 +233,7 @@ export default {
 	width: 100%;
 	height: 100%;
 	object-fit: var(--image-object-fit);
-	object-position: center;
+	object-position: var(--image-object-position);
 	border-radius: $maker-shape-image-border-radius;
 
 	&.thumbnail {


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
* `object-position` is currently set to `center`, regardless of `object-fit`

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
* add `objectPosition` property to adjust image `object-position`

## Screen Capture
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->

https://user-images.githubusercontent.com/82115556/215611988-078fa337-8b09-4dcb-bdaf-9e4385d748e7.mov

