### PR TITLE
feat: add `shape` property to `MPill`

### DIFF
--- a/build/webpack-base-config.js
+++ b/build/webpack-base-config.js
@@ -45,7 +45,7 @@ const webpackBaseConfig = {
 				loader: 'babel-loader',
 			},
 			{
-				test: /\.(post)?css$/,
+				test: /\.css$/,
 				oneOf: [
 					// Matches `<style module>`
 					{

--- a/build/webpack-base-config.js
+++ b/build/webpack-base-config.js
@@ -45,7 +45,7 @@ const webpackBaseConfig = {
 				loader: 'babel-loader',
 			},
 			{
-				test: /\.css$/,
+				test: /\.(post)?css$/,
 				oneOf: [
 					// Matches `<style module>`
 					{

--- a/src/components/Pill/README.md
+++ b/src/components/Pill/README.md
@@ -53,7 +53,7 @@ Pill can also take on a variety of shapes, optionally with a different shape on 
 			:shape="shape.shape"
 			:pattern="shape.pattern || 'info'"
 		>
-			shape: {{ shape.key }}
+			shape: {{ shape.shape }}
 		</m-pill>
 	</div>
 </template>
@@ -70,16 +70,16 @@ Pill can also take on a variety of shapes, optionally with a different shape on 
 			return {
 				shapes: [
 					{ key: 'pill', shape: 'pill' },
-					{ key: 'pill', shape: 'pill', pattern: 'infoOutline' },
+					{ key: 'pill-outline', shape: 'pill', pattern: 'infoOutline' },
 					{ key: 'rounded', shape: 'rounded' },
-					{ key: 'rounded', shape: 'rounded', pattern: 'infoOutline' },
-					{ key: 'sharp', shape: 'sharp' },
-					{ key: 'sharp', shape: 'sharp', pattern: 'infoOutline' },
+					{ key: 'rounded-outline', shape: 'rounded', pattern: 'infoOutline' },
+					{ key: 'squared', shape: 'squared' },
+					{ key: 'squared-outline', shape: 'squared', pattern: 'infoOutline' },
 					{ key: 'point', shape: 'point' },
-					{ key: 'point', shape: 'point', pattern: 'infoOutline' },
+					{ key: 'point-outline', shape: 'point', pattern: 'infoOutline' },
 					{ key: 'ribbon', shape: 'ribbon' },
-					{ key: 'ribbon', shape: 'ribbon', pattern: 'infoOutline' },
-					{ key: 'sharp, point', shape: ['sharp', 'point'] },
+					{ key: 'ribbon-outline', shape: 'ribbon', pattern: 'infoOutline' },
+					{ key: 'squared, point', shape: ['squared', 'point'] },
 					{ key: 'rounded, ribbon', shape: ['rounded', 'ribbon'], pattern: 'infoOutline' },
 				],
 			};
@@ -109,7 +109,7 @@ Themable props* can be configured via the [Theme](#/Theme) component using the k
 | pattern*    | `string`       | `'info'`    | `'primary'`, `'error'`, `'success'`, `'warning'`, `'info'`, `'primaryOutline'`, `'errorOutline'`, `'successOutline'`, `'warningOutline'`, `'infoOutline'`, `'primarySubtle'`, `'errorSubtle'`, `'successSubtle'`, `'warningSubtle'`, `'infoSubtle'`, any custom pattern defined within the theme | pattern defined at theme level                                        |
 | text-color* | `string`       | `'#ffffff'` | -                                                                                                                                                                                                                                                                                                | text color, also border color if no bg color                          |
 | bg-color*   | `string`       | `'#1b1b1b'` | -                                                                                                                                                                                                                                                                                                | bg & border color                                                     |
-| shape       | `string|array` | `'pill'`    | `'pill'`, `'sharp'`, `'rounded'`, `'point'`, `'ribbon'`                                                                                                                                                                                                                                          | The shape the pill should take, or a tuple of shapes for each endcap. |
+| shape       | `string|array` | `'pill'`    | `'pill'`, `'squared'`, `'rounded'`, `'point'`, `'ribbon'`                                                                                                                                                                                                                                        | The shape the pill should take, or a tuple of shapes for each endcap. |
 
 
 ## Slots

--- a/src/components/Pill/README.md
+++ b/src/components/Pill/README.md
@@ -42,6 +42,60 @@ export default {
 </style>
 ```
 
+Pill can also take on a variety of shapes, optionally with a different shape on each endcap:
+
+```vue
+<template>
+	<div class="spaceout">
+		<m-pill
+			v-for="shape in shapes"
+			:key="shape.key"
+			:shape="shape.shape"
+			:pattern="shape.pattern || 'info'"
+		>
+			shape: {{ shape.key }}
+		</m-pill>
+	</div>
+</template>
+
+<script>
+	import { MPill } from '@square/maker/components/Pill';
+
+	export default {
+		components: {
+			MPill,
+		},
+
+		data() {
+			return {
+				shapes: [
+					{ key: 'pill', shape: 'pill' },
+					{ key: 'pill', shape: 'pill', pattern: 'infoOutline' },
+					{ key: 'rounded', shape: 'rounded' },
+					{ key: 'rounded', shape: 'rounded', pattern: 'infoOutline' },
+					{ key: 'sharp', shape: 'sharp' },
+					{ key: 'sharp', shape: 'sharp', pattern: 'infoOutline' },
+					{ key: 'point', shape: 'point' },
+					{ key: 'point', shape: 'point', pattern: 'infoOutline' },
+					{ key: 'ribbon', shape: 'ribbon' },
+					{ key: 'ribbon', shape: 'ribbon', pattern: 'infoOutline' },
+					{ key: 'sharp, point', shape: ['sharp', 'point'] },
+					{ key: 'rounded, ribbon', shape: ['rounded', 'ribbon'], pattern: 'infoOutline' },
+				],
+			};
+		},
+	};
+</script>
+
+<style scoped>
+.spaceout {
+	display: flex;
+	gap: 4px;
+	flex-wrap: wrap;
+}
+</style>
+```
+
 
 <!-- api-tables:start -->
 ## Props
@@ -50,11 +104,12 @@ Supports attributes from [`<span>`](https://developer.mozilla.org/en-US/docs/Web
 
 Themable props* can be configured via the [Theme](#/Theme) component using the key `pill`.
 
-| Prop        | Type     | Default     | Possible values                                                                                                                                                                                                                                                                                  | Description                                  |
-| ----------- | -------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
-| pattern*    | `string` | `'info'`    | `'primary'`, `'error'`, `'success'`, `'warning'`, `'info'`, `'primaryOutline'`, `'errorOutline'`, `'successOutline'`, `'warningOutline'`, `'infoOutline'`, `'primarySubtle'`, `'errorSubtle'`, `'successSubtle'`, `'warningSubtle'`, `'infoSubtle'`, any custom pattern defined within the theme | pattern defined at theme level               |
-| text-color* | `string` | `'#ffffff'` | -                                                                                                                                                                                                                                                                                                | text color, also border color if no bg color |
-| bg-color*   | `string` | `'#1b1b1b'` | -                                                                                                                                                                                                                                                                                                | bg & border color                            |
+| Prop        | Type           | Default     | Possible values                                                                                                                                                                                                                                                                                  | Description                                                           |
+| ----------- | -------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| pattern*    | `string`       | `'info'`    | `'primary'`, `'error'`, `'success'`, `'warning'`, `'info'`, `'primaryOutline'`, `'errorOutline'`, `'successOutline'`, `'warningOutline'`, `'infoOutline'`, `'primarySubtle'`, `'errorSubtle'`, `'successSubtle'`, `'warningSubtle'`, `'infoSubtle'`, any custom pattern defined within the theme | pattern defined at theme level                                        |
+| text-color* | `string`       | `'#ffffff'` | -                                                                                                                                                                                                                                                                                                | text color, also border color if no bg color                          |
+| bg-color*   | `string`       | `'#1b1b1b'` | -                                                                                                                                                                                                                                                                                                | bg & border color                                                     |
+| shape       | `string|array` | `'pill'`    | `'pill'`, `'sharp'`, `'rounded'`, `'point'`, `'ribbon'`                                                                                                                                                                                                                                          | The shape the pill should take, or a tuple of shapes for each endcap. |
 
 
 ## Slots

--- a/src/components/Pill/src/Pill.vue
+++ b/src/components/Pill/src/Pill.vue
@@ -71,7 +71,7 @@ export default {
 		shape: {
 			type: [String, Array],
 			default: 'pill',
-			validator: function validatePillShape(input) {
+			validator(input) {
 				if (Array.isArray(input)) {
 					return input.length === MAXIMUM_ALLOWED_SHAPES
 						&& input.every((value) => ALLOWED_SHAPES.has(value));

--- a/src/components/Pill/src/Pill.vue
+++ b/src/components/Pill/src/Pill.vue
@@ -1,6 +1,6 @@
 <template>
 	<span
-		:class="$s.Pill"
+		:class="[$s.Pill, shapeClass]"
 		:style="style"
 		v-bind="$attrs"
 		v-on="$listeners"
@@ -13,6 +13,15 @@
 <script>
 import cssValidator from '@square/maker/utils/css-validator';
 import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
+
+const MAXIMUM_ALLOWED_SHAPES = 2;
+const ALLOWED_SHAPES = new Set([
+	'sharp',
+	'rounded',
+	'pill',
+	'point',
+	'ribbon',
+]);
 
 /**
  * @inheritAttrs span
@@ -36,6 +45,7 @@ export default {
 			type: String,
 			default: undefined,
 		},
+
 		/**
 		 * text color, also border color if no bg color
 		 */
@@ -44,6 +54,7 @@ export default {
 			default: undefined,
 			validator: cssValidator('color'),
 		},
+
 		/**
 		 * bg & border color
 		 */
@@ -51,6 +62,23 @@ export default {
 			type: String,
 			default: undefined,
 			validator: cssValidator('color'),
+		},
+
+		/**
+		 * The shape the pill should take, or a tuple of shapes for each endcap.
+		 * @values pill, sharp, rounded, point, ribbon
+		 */
+		shape: {
+			type: [String, Array],
+			default: 'pill',
+			validator: function validatePillShape(input) {
+				if (Array.isArray(input)) {
+					return input.length === MAXIMUM_ALLOWED_SHAPES
+						&& input.every((value) => ALLOWED_SHAPES.has(value));
+				}
+
+				return ALLOWED_SHAPES.has(input);
+			},
 		},
 	},
 
@@ -60,22 +88,39 @@ export default {
 			'textColor',
 			'bgColor',
 		]),
+
 		style() {
 			const textColor = this.resolvedTextColor || 'var(--maker-color-neutral-90, #1b1b1b)';
 			const bgColor = this.resolvedBgColor || 'transparent';
 			const borderColor = bgColor === 'transparent' ? textColor : bgColor;
+
 			return {
 				'--text-color': textColor,
 				'--bg-color': bgColor,
 				'--border-color': borderColor,
 			};
 		},
+
+		shapeClass() {
+			const { '--bg-color': bgColor } = this.style;
+
+			const selectors = Array.isArray(this.shape)
+				? [`start--${this.shape[0]}`, `end--${this.shape[1]}`]
+				: [`start--${this.shape}`, `end--${this.shape}`];
+
+			if (bgColor === 'transparent') {
+				selectors.push('outlined');
+			}
+
+			return selectors.map((style) => this.$s[style]);
+		},
 	},
 };
 </script>
 
-<style module="$s">
+<style module="$s" lang="postcss">
 .Pill {
+	position: relative;
 	display: inline-block;
 	padding: 4px 8px;
 	color: var(--text-color, #1b1b1b);
@@ -85,6 +130,194 @@ export default {
 	line-height: 16px; /* TODO: refactor to line-height step -2 later? */
 	background-color: var(--bg-color);
 	border: 1px solid var(--border-color);
-	border-radius: 100px;
+
+	&.start--pill {
+		border-top-left-radius: 100px;
+		border-bottom-left-radius: 100px;
+	}
+
+	&.start--rounded {
+		border-top-left-radius: 4px;
+		border-bottom-left-radius: 4px;
+	}
+
+	&.start--sharp,
+	&.start--point,
+	&.start--ribbon {
+		border-top-left-radius: unset;
+		border-bottom-left-radius: unset;
+	}
+
+	&.start--point,
+	&.start--ribbon {
+		/* Absolute position doesn't make space in layouts for the decoration, so we force it here */
+		margin-left: 15px;
+		border-left: none;
+
+		&::before {
+			position: absolute;
+			top: -1px; /* align to border */
+			bottom: -1px; /* align to border */
+			left: -15px;
+			width: 15px;
+			background-color: inherit;
+			content: '';
+		}
+
+		&.outlined::before {
+			background-color: var(--border-color);
+		}
+	}
+
+	&.start--point {
+		&::before {
+			clip-path:
+				polygon(
+					100% 0%,
+					0% 50%,
+					100% 100%,
+					100% 0%
+				);
+		}
+
+		&.outlined::before {
+			clip-path:
+				polygon(
+					100% 0%,
+					0% 50%,
+					100% 100%,
+					100% calc(100% - 1px),
+					calc(0% + 1px) 50%,
+					100% calc(0% + 1px),
+					100% 0%
+				);
+		}
+	}
+
+	&.start--ribbon {
+		&::before {
+			clip-path:
+				polygon(
+					100% 0%,
+					0% 0%,
+					80% 50%,
+					0% 100%,
+					100% 100%,
+					100% 0%
+				);
+		}
+
+		&.outlined::before {
+			clip-path:
+				polygon(
+					100% 0%,
+					0% 0%,
+					80% 50%,
+					0% 100%,
+					100% 100%,
+					100% calc(100% - 1px),
+					calc(0% + 2px) calc(100% - 1px),
+					calc(80% + 1px) 50%,
+					calc(0% + 2px) calc(0% + 1px),
+					100% calc(0% + 1px),
+					100% 0%
+				);
+		}
+	}
+
+	&.end--pill {
+		border-top-right-radius: 100px;
+		border-bottom-right-radius: 100px;
+	}
+
+	&.end--rounded {
+		border-top-right-radius: 4px;
+		border-bottom-right-radius: 4px;
+	}
+
+	&.end--sharp,
+	&.end--point,
+	&.end--ribbon {
+		border-top-right-radius: unset;
+		border-bottom-right-radius: unset;
+	}
+
+	&.end--point,
+	&.end--ribbon {
+		/* Absolute position doesn't make space in layouts for the decoration, so we force it here */
+		margin-right: 15px;
+		border-right: none;
+
+		&::after {
+			position: absolute;
+			top: -1px;  /* align to border */
+			bottom: -1px; /* align to border */
+			left: 100%;
+			width: 15px;
+			background-color: var(--bg-color);
+			content: '';
+		}
+
+		&.outlined::after {
+			background-color: var(--border-color);
+		}
+	}
+
+	&.end--point {
+		&::after {
+			clip-path:
+				polygon(
+					0% 0%,
+					100% 50%,
+					0% 100%,
+					0% 0%
+				);
+		}
+
+		&.outlined::after {
+			clip-path:
+				polygon(
+					0% 0%,
+					100% 50%,
+					0% 100%,
+					0% calc(100% - 1px),
+					calc(100% - 1px) 50%,
+					0% calc(0% + 1px),
+					0% 0%
+				);
+		}
+	}
+
+	&.end--ribbon {
+		&.outlined::after {
+			background-color: var(--border-color);
+			clip-path:
+				polygon(
+					0% 0%,
+					100% 0%,
+					20% 50%,
+					100% 100%,
+					0% 100%,
+					0% calc(100% - 1px),
+					calc(100% - 2px) calc(100% - 1px),
+					calc(20% - 1px) 50%,
+					calc(100% - 2px) calc(0% + 1px),
+					0% calc(0% + 1px),
+					0% 0%
+				);
+		}
+
+		&::after {
+			clip-path:
+				polygon(
+					0% 0%,
+					100% 0%,
+					20% 50%,
+					100% 100%,
+					0% 100%,
+					0% 0%
+				);
+		}
+	}
 }
 </style>

--- a/src/components/Pill/src/Pill.vue
+++ b/src/components/Pill/src/Pill.vue
@@ -118,7 +118,7 @@ export default {
 };
 </script>
 
-<style module="$s" lang="postcss">
+<style module="$s">
 .Pill {
 	position: relative;
 	display: inline-block;

--- a/src/components/Pill/src/Pill.vue
+++ b/src/components/Pill/src/Pill.vue
@@ -16,7 +16,7 @@ import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/co
 
 const MAXIMUM_ALLOWED_SHAPES = 2;
 const ALLOWED_SHAPES = new Set([
-	'sharp',
+	'squared',
 	'rounded',
 	'pill',
 	'point',
@@ -66,7 +66,7 @@ export default {
 
 		/**
 		 * The shape the pill should take, or a tuple of shapes for each endcap.
-		 * @values pill, sharp, rounded, point, ribbon
+		 * @values pill, squared, rounded, point, ribbon
 		 */
 		shape: {
 			type: [String, Array],
@@ -141,7 +141,7 @@ export default {
 		border-bottom-left-radius: 4px;
 	}
 
-	&.start--sharp,
+	&.start--squared,
 	&.start--point,
 	&.start--ribbon {
 		border-top-left-radius: unset;
@@ -160,7 +160,7 @@ export default {
 			bottom: -1px; /* align to border */
 			left: -15px;
 			width: 15px;
-			background-color: inherit;
+			background-color: var(--bg-color);
 			content: '';
 		}
 
@@ -235,7 +235,7 @@ export default {
 		border-bottom-right-radius: 4px;
 	}
 
-	&.end--sharp,
+	&.end--squared,
 	&.end--point,
 	&.end--ribbon {
 		border-top-right-radius: unset;
@@ -289,8 +289,19 @@ export default {
 	}
 
 	&.end--ribbon {
+		&::after {
+			clip-path:
+				polygon(
+					0% 0%,
+					100% 0%,
+					20% 50%,
+					100% 100%,
+					0% 100%,
+					0% 0%
+				);
+		}
+
 		&.outlined::after {
-			background-color: var(--border-color);
 			clip-path:
 				polygon(
 					0% 0%,
@@ -303,18 +314,6 @@ export default {
 					calc(20% - 1px) 50%,
 					calc(100% - 2px) calc(0% + 1px),
 					0% calc(0% + 1px),
-					0% 0%
-				);
-		}
-
-		&::after {
-			clip-path:
-				polygon(
-					0% 0%,
-					100% 0%,
-					20% 50%,
-					100% 100%,
-					0% 100%,
 					0% 0%
 				);
 		}


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

We have a project where we'd like to use `MPill` to present informational items, however we'd like to be able to customise the shape of the pill.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->

This PR adds the `shape` property, accepting either a single shape or a tuple of two shapes to use on each endcap.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
I've implemented this with the `::before` and `::after` pseudo-elements but I'm not overly fond of this implementation. That being said, I couldn't think of a better way to do it without manually `clip-path`ing the entire capsule uniquely for every pair of shapes.

There's also an ancillary change to let Webpack process `style` tags with the `lang` explicitly set to `postcss`. This doesn't have any actual changes on the build, but fixes syntax highlighting and context-aware tools in editors like VSCode using Volar.