### PR TITLE
fix(touchcapture): stop generating noisy console error

### DIFF
--- a/src/components/TouchCapture/src/TouchCapture.vue
+++ b/src/components/TouchCapture/src/TouchCapture.vue
@@ -111,7 +111,7 @@ export default {
 
 	methods: {
 		handleTouchEvent(event) {
-			if (this.preventDefault) {
+			if (this.preventDefault && event.cancelable) { // Some things are not cancelable like scrolling - https://www.uriports.com/blog/easy-fix-for-intervention-ignored-attempt-to-cancel-a-touchmove-event-with-cancelable-false/
 				event.preventDefault();
 			}
 			switch (event.type) {


### PR DESCRIPTION

<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Some events are not cancelable such as scrolling. We try to cancel theses events even though browser's wont' let us leading to an error in the console which is picked up by error monitoring.

To replicate go to: 
https://www.justonemoreplantco.com/events-and-workshops
Click "Philadelphia Flower Show Bus Trip" to bring up the modal scroll down a bit then try to drag all the way down

https://user-images.githubusercontent.com/16027039/223269826-6500fc2b-e74f-4dd8-a660-e7a5c59e1b56.mov



## Describe the changes in this PR
No UI changes only we should check if an event is cancelable before we actually try to cancel it.



## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
