### PR TITLE
fix(pininput): fix safari autofill styles

### DIFF
--- a/src/components/PinInput/src/PinInputControl.vue
+++ b/src/components/PinInput/src/PinInputControl.vue
@@ -298,7 +298,7 @@ export default {
 	font-size: 16px;
 	font-family: inherit;
 	text-align: center;
-	background: $maker-color-background;
+	background: transparent;
 	border: 1px solid $maker-color-neutral-20;
 	border-radius: $maker-shape-default-border-radius;
 	outline: none;

--- a/src/components/PinInput/src/PinInputControl.vue
+++ b/src/components/PinInput/src/PinInputControl.vue
@@ -3,6 +3,23 @@
 		:class="$s.PinInputContainer"
 		:style="computedStyles"
 	>
+		<input
+			ref="input"
+			:class="$s.PinInput"
+			:maxlength="pinLength"
+			:value="inputValue"
+			type="text"
+			inputmode="numeric"
+			pattern="[0-9]*"
+			:disabled="disabled || isShaking"
+			@keydown="handleKeyDown"
+			@keypress="sanitizePinInput"
+			@input="onInputPin"
+			@keyup="updateCaretPosition"
+			@click="updateCaretPosition"
+			@focus="setFocus(true)"
+			@blur="setFocus(false)"
+		>
 		<div
 			:class="{
 				[$s.PinInputCells]: true,
@@ -22,24 +39,6 @@
 				{{ inputValue[pinPosition - 1] }}
 			</div>
 		</div>
-
-		<input
-			ref="input"
-			:class="$s.PinInput"
-			:maxlength="pinLength"
-			:value="inputValue"
-			type="text"
-			inputmode="numeric"
-			pattern="[0-9]*"
-			:disabled="disabled || isShaking"
-			@keydown="handleKeyDown"
-			@keypress="sanitizePinInput"
-			@input="onInputPin"
-			@keyup="updateCaretPosition"
-			@click="updateCaretPosition"
-			@focus="setFocus(true)"
-			@blur="setFocus(false)"
-		>
 	</div>
 </template>
 
@@ -267,12 +266,22 @@ export default {
 	background: transparent;
 	border: 0;
 	outline: 0;
+
+	/* Prevents Safari styles */
+	&:-webkit-autofill-and-obscured,
+	&:-webkit-autofill-strong-password,
+	&:-webkit-autofill-strong-password-viewable,
+	&:-webkit-autofill {
+		color: transparent !important;
+		box-shadow: 0 0 0 1000px $maker-color-background inset;
+	}
 }
 
 .PinInputCells {
 	position: relative;
 	display: flex;
 	gap: 8px;
+	pointer-events: none;
 }
 
 .PinInputCell {


### PR DESCRIPTION
## Describe the problem this PR addresses
Closes #535
Updates the styling of the pininput `input` element to hide the safari yellow background and text colour, which was causing the text to appear twice on iOS browsers.

## Describe the changes in this PR
- Set webkit autofill background to maker bg color
- Set webkit autofill color to transparent
- Rearranged cell to be above input instead of the other way around

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
