### PR TITLE
fix(textarea): properly disable textarea

### DIFF
--- a/src/components/Textarea/src/TextareaControl.vue
+++ b/src/components/Textarea/src/TextareaControl.vue
@@ -11,6 +11,7 @@
 				[$s.invalid]: invalid,
 			},
 		]"
+		:disabled="disabled"
 		v-bind="$attrs"
 		v-on="$listeners"
 	/>


### PR DESCRIPTION
## Describe the problem this PR addresses
Currently the disabled textarea allows a user to still type inside
![image](https://user-images.githubusercontent.com/18740390/228059176-25eec49c-c6c7-4c99-b62d-3d4d448e9a61.png)

## Describe the changes in this PR
Because `disabled` is a prop on the `TextareaControl` it's not included in the `$attrs` and thus not passed into the `textarea` element
