### PR TITLE
docs: provide unique keys for side nav

### DIFF
--- a/styleguide/SideNav.vue
+++ b/styleguide/SideNav.vue
@@ -12,7 +12,7 @@
 				</a>
 				<router-link
 					v-for="link in group.links"
-					:key="link.path.name"
+					:key="group.name + '-' + link.path.name"
 					:to="link.path"
 					class="link"
 					@click.native="$emit('route:click')"


### PR DESCRIPTION
## Describe the problem this PR addresses
Some components are under multiple groups, which when run locally causes these vue warns to occur
![image](https://user-images.githubusercontent.com/18740390/230244178-8d859c12-d291-4b25-81e4-2e5e86f00290.png)

## Describe the changes in this PR
Prepend group to the key name to make them unique
