### PR TITLE
fix(textbutton): fix cursor css for disabled state

### DIFF
--- a/src/components/TextButton/src/TextButton.vue
+++ b/src/components/TextButton/src/TextButton.vue
@@ -176,7 +176,7 @@ export default {
 	}
 
 	&:disabled {
-		cursor: initial;
+		cursor: not-allowed;
 
 		& > * {
 			opacity: 0.5;


### PR DESCRIPTION
## Describe the problem this PR addresses
Properly set the CSS for the disabled state to `not-allowed`