### PR TITLE
fix(input): suffix icons getting cut off

### DIFF
--- a/src/components/Input/src/InputControl.vue
+++ b/src/components/Input/src/InputControl.vue
@@ -205,6 +205,7 @@ export default {
 	flex-grow: 1;
 	order: 2;
 	box-sizing: inherit;
+	width: 100%;
 	color: inherit;
 	font-weight: inherit;
 	font-size: inherit;


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

when minputs are very narrow (< 200px width) and had a suffix (text or icon) the suffix would get cut off.

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
stops suffix from getting cut off with minput is < 200px width

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
nope