### PR TITLE
fix(pininput): fix safari autofill styles on mobile

### DIFF
--- a/src/components/PinInput/src/PinInputControl.vue
+++ b/src/components/PinInput/src/PinInputControl.vue
@@ -272,8 +272,12 @@ export default {
 	&:-webkit-autofill-strong-password,
 	&:-webkit-autofill-strong-password-viewable,
 	&:-webkit-autofill {
-		color: transparent !important;
-		box-shadow: 0 0 0 1000px $maker-color-background inset;
+		color: var(--bg-color, #fff) !important;
+		background-color: var(--bg-color, #fff) !important;
+		background-clip: content-box !important;
+		-webkit-box-shadow: 0 0 0 1000px var(--bg-color, #fff) inset !important;
+		box-shadow: 0 0 0 1000px var(--bg-color, #fff) inset !important;
+		-webkit-text-fill-color: var(--bg-color, #fff);
 	}
 }
 


### PR DESCRIPTION
## Describe the problem this PR addresses
Closes #544
This PR updates the safari autofill styles to hide the yellow background and input text on iOS devices.

## Describe the changes in this PR
![image](https://user-images.githubusercontent.com/3402466/232814886-d6e227e7-4381-4360-9d08-db3ce5d0d203.png)
