### PR TITLE
fix(pininput): undo safari-specific fixes, set input to opacity 0

### DIFF
--- a/src/components/PinInput/src/PinInputControl.vue
+++ b/src/components/PinInput/src/PinInputControl.vue
@@ -34,6 +34,7 @@
 					[$s.isFocused]: isCellFocused(pinPosition - 1),
 					[$s.fill]: variant === 'fill',
 					[$s.error]: invalid,
+					[$s.disabled]: disabled || isShaking
 				}"
 			>
 				{{ inputValue[pinPosition - 1] }}
@@ -267,18 +268,8 @@ export default {
 	border: 0;
 	outline: 0;
 
-	/* Prevents Safari styles */
-	&:-webkit-autofill-and-obscured,
-	&:-webkit-autofill-strong-password,
-	&:-webkit-autofill-strong-password-viewable,
-	&:-webkit-autofill {
-		color: var(--bg-color, #fff) !important;
-		background-color: var(--bg-color, #fff) !important;
-		background-clip: content-box !important;
-		-webkit-box-shadow: 0 0 0 1000px var(--bg-color, #fff) inset !important;
-		box-shadow: 0 0 0 1000px var(--bg-color, #fff) inset !important;
-		-webkit-text-fill-color: var(--bg-color, #fff);
-	}
+	/* This makes the input clickable but not actually visible */
+	opacity: 0 !important;
 }
 
 .PinInputCells {
@@ -318,6 +309,11 @@ export default {
 
 	&.error {
 		border-color: $maker-color-error-fill;
+	}
+
+	&.disabled {
+		border: 1px solid $maker-color-neutral-20;
+		opacity: 0.9;
 	}
 }
 


### PR DESCRIPTION
## Describe the problem this PR addresses
This PR is a follow up to #545 and removes the safari-specific changes. Instead, we will now set the opacity of the input to `0`, which makes it interact-able but any browser-applied styles will not appear.

## Describe the changes in this PR
https://user-images.githubusercontent.com/3402466/234887815-ff6b7931-c192-402e-91da-93a60952d461.mov