### PR TITLE
fix(popover): fix destroy logic

### DIFF
--- a/src/components/Popover/src/Popover.vue
+++ b/src/components/Popover/src/Popover.vue
@@ -123,7 +123,9 @@ export default {
 			popperToDestroy: undefined,
 			actionAPI: {
 				open(...ignoreElements) {
-					if (vm.isOpen) {
+					// Even though popover may be closed, need to wait for
+					// the popper to be destroyed before re-opening
+					if (vm.isOpen || Boolean(vm.popperToDestroy)) {
 						return;
 					}
 

--- a/src/components/Popover/src/Popover.vue
+++ b/src/components/Popover/src/Popover.vue
@@ -16,7 +16,7 @@
 						v-if="isOpen"
 						:action-el="actionEl"
 						:popper-config="popperConfig"
-						@popover-instance:new-popper="setPopper"
+						@popover-instance:new-popper="setPopperToDestroy"
 					>
 						<!-- @slot Content that will appear in the floating popover -->
 						<slot name="content" />
@@ -120,7 +120,6 @@ export default {
 			 * will be pushed into the popoverApi state as the opened popover.
 			 */
 			id: getPopoverId(),
-			currentPopper: undefined,
 			popperToDestroy: undefined,
 			actionAPI: {
 				open(...ignoreElements) {
@@ -136,8 +135,6 @@ export default {
 				},
 
 				close() {
-					this.popperToDestroy = this.currentPopper;
-					this.currentPopper = undefined;
 					vm.popoverApi.closePopover();
 				},
 
@@ -214,8 +211,8 @@ export default {
 			this.actionAPI.toggle(...ignoreElements);
 		},
 
-		setPopper(popper) {
-			this.currentPopper = popper;
+		setPopperToDestroy(popper) {
+			this.popperToDestroy = popper;
 		},
 
 		destroyPopper() {


### PR DESCRIPTION
## Describe the problem this PR addresses
Doing some memory leak testing and looks like popover poppers weren't being properly destroyed resulting in detached HTML elements.

Digging in there were 2 core issues:
1) `currentPopper` was being accessed in `close` in the actionApi scope instead of the vm scope, so `.destroy()` was never being called on the popper instance.
2) Even if 1) was working correctly, the `close` logic in the actionApi is only triggered if the user clicks the action element (e.g. a button). However, if the user clicks outside to close the popover, the `close` logic was never called and thus the `destroy` logic never called (as `popperToDestroy` is never set)

## Describe the changes in this PR
I don't think there was any need for the logic in `close` for destroying. We can just rely on `m-transition-fade-in @after-leave="destroyPopper"`, because leaving the transition indicates the popover is being closed, whether it's a click on the action element, or an outside click. So get rid of the `currentPopper` variable and just use `popperToDestroy`, setting it as before and using it to destroy when the popover fades away.
