### PR TITLE
fix(Checkbox): show outline on `focus`

### DIFF
--- a/src/components/Checkbox/src/CheckboxControl.vue
+++ b/src/components/Checkbox/src/CheckboxControl.vue
@@ -114,12 +114,15 @@ export default {
 	background-color: $maker-color-background;
 	border: 1px solid var(--color-border);
 	border-radius: 4px;
-	outline: none;
 	cursor: inherit;
 	transition:
 		border 0.2s ease,
 		background-color 0.2s ease;
 	appearance: none;
+
+	&:not(:focus) {
+		outline: none;
+	}
 
 	&:invalid {
 		border-color: var(--color-error);


### PR DESCRIPTION
## Describe the problem this PR addresses
When using keyboard-only to navigate the page, tab controls rely on the outline to show the user where they are focused on the page. `outline: none` on Checkbox essentially removed the `focus` state, making it look like you could not interact with the Checkbox via keyboard controls.

(checkboxes stay the exact same while tabbing through)
<img width="310" alt="Screenshot 2023-05-24 at 10 41 44 AM" src="https://github.com/square/maker/assets/20190589/c1985c5a-dc3d-43b0-a5c1-3ec2ae6e19c5">


## Describe the changes in this PR

Improved accessibility via adding back in outline on checkbox `focus` state.

https://github.com/square/maker/assets/20190589/976b4936-b672-40a6-a27b-91ac9ac1a551

## Other information

Test the existing experience on the [18.0.5 styleguide](https://square.github.io/maker/styleguide/18.0.5/#/Checkbox):

- click on the description under 'Checkbox' title
- press 'tab' to focus on the links within the description ('Choice', 'Radio', etc.)
- keep pressing 'tab' until you're past the links and should be onto the the checkboxes (observe no `focus` outline)
- try pressing 'space' to select the checkbox you're currently focused on
