### PR TITLE
fix(Stepper): add "+, -" aria-labels 

### DIFF
--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -9,6 +9,7 @@
 			:text-color="resolvedTextColor"
 			:shape="resolvedShape"
 			:disabled="value === minVal"
+			aria-label="−"
 			@click="decrement"
 		>
 			<m-icon
@@ -49,6 +50,7 @@
 			:text-color="resolvedTextColor"
 			:shape="resolvedShape"
 			:disabled="value === maxVal"
+			aria-label="+"
 			@click="increment"
 		>
 			<m-icon


### PR DESCRIPTION
## Describe the problem this PR addresses
Stepper's plus and minus buttons are only described as "button" on screenreader, making it difficult to distinguish between the two and know what they do.

## Describe the changes in this PR
Added `aria-label` to the plus and minus buttons on the Stepper.


Mac VoiceOver reads out as "plus, minus":

https://github.com/square/maker/assets/20190589/1fde59dd-1dbc-4add-8c7f-d30206a7ef27

## Considered alternatives
1. adding screenreader labels on the icon level
While this is something that could be considered in the future to optionally be included by screenreaders, I don't think that all icons, being used as just icons, need to be read out. However, in this case, the icon was being used as the _label_ for a button on the stepper, not just a decorative icon. It's also a much lower-effort addition, since the icon usage here is hard-coded.
2. using the words "plus, minus" vs "+, -"
I decided to just use the characters to allow the label to be read in other languages. They're also the most accurate to what the icons are.
