### PR TITLE
feat(modal,dialog,popover)!: add composables for modal/dialog/popover layers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@square/maker-icons": "^3.2.0",
         "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
         "@vue/babel-preset-jsx": "^1.1.2",
+        "@vue/composition-api": "^1.7.1",
         "babel-eslint": "^10.1.0",
         "babel-loader": "^8.1.0",
         "babel-plugin-date-fns": "^2.0.0",
@@ -948,7 +949,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.22.5",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/@babel/parser/-/parser-7.22.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
       "integrity": "sha1-ch/QQvPOGJYjjPGzQcd+t97n2+o=",
       "dev": true,
       "license": "MIT",
@@ -4359,6 +4360,16 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "node_modules/@vue/composition-api": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.7.1.tgz",
+      "integrity": "sha1-qmgxvloSgX2T6J4kdGDDEN16OjI=",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": ">= 2.5 < 2.7"
+      }
     },
     "node_modules/@vue/devtools-api": {
       "version": "6.1.4",
@@ -7817,7 +7828,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.2",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/csstype/-/csstype-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha1-HUv51XLxHBQDHwQ24cELwfVx9Qs=",
       "dev": true,
       "license": "MIT"
@@ -11325,7 +11336,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.12.1",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/is-core-module/-/is-core-module-2.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
       "integrity": "sha1-DAtohbb4ABHHFUHOFcjWbPWk+f0=",
       "dev": true,
       "license": "MIT",
@@ -17049,7 +17060,7 @@
     },
     "node_modules/resolve": {
       "version": "1.22.2",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/resolve/-/resolve-1.22.2.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
       "integrity": "sha1-DtCUPU4wGGeVV2bJ8+GubQHGhF8=",
       "dev": true,
       "license": "MIT",
@@ -20446,7 +20457,7 @@
     },
     "node_modules/vue": {
       "version": "2.7.14",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/vue/-/vue-2.7.14.tgz",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
       "integrity": "sha1-N0Pc0kj9OjTUIa5Fa4ZKAka6+xc=",
       "dev": true,
       "license": "MIT",
@@ -20753,7 +20764,7 @@
     },
     "node_modules/vue-server-renderer": {
       "version": "2.7.14",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/vue-server-renderer/-/vue-server-renderer-2.7.14.tgz",
+      "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.7.14.tgz",
       "integrity": "sha1-mG8/3KY/uzi7aDRpjxHg1qgfGC8=",
       "dev": true,
       "license": "MIT",
@@ -20770,7 +20781,7 @@
     },
     "node_modules/vue-server-renderer/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "dev": true,
       "license": "MIT",
@@ -20786,7 +20797,7 @@
     },
     "node_modules/vue-server-renderer/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
       "dev": true,
       "license": "MIT",
@@ -20803,7 +20814,7 @@
     },
     "node_modules/vue-server-renderer/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
       "dev": true,
       "license": "MIT",
@@ -20816,14 +20827,14 @@
     },
     "node_modules/vue-server-renderer/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vue-server-renderer/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
       "dev": true,
       "license": "MIT",
@@ -20842,7 +20853,7 @@
     },
     "node_modules/vue-server-renderer/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
       "dev": true,
       "license": "MIT",
@@ -20880,7 +20891,7 @@
     },
     "node_modules/vue-template-compiler": {
       "version": "2.7.14",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
       "integrity": "sha1-RUW337iAkHRMFXeuWsP5ZOYWNLE=",
       "dev": true,
       "license": "MIT",
@@ -20915,7 +20926,7 @@
     },
     "node_modules/vue/node_modules/@vue/compiler-sfc": {
       "version": "2.7.14",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
       "integrity": "sha1-NEb9L7tnDXCSd/w/+ojvxeEChP0=",
       "dev": true,
       "dependencies": {
@@ -20926,7 +20937,7 @@
     },
     "node_modules/vue/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -22654,7 +22665,7 @@
     },
     "@babel/parser": {
       "version": "7.22.5",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/@babel/parser/-/parser-7.22.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
       "integrity": "sha1-ch/QQvPOGJYjjPGzQcd+t97n2+o=",
       "dev": true
     },
@@ -25714,6 +25725,12 @@
         }
       }
     },
+    "@vue/composition-api": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.7.1.tgz",
+      "integrity": "sha1-qmgxvloSgX2T6J4kdGDDEN16OjI=",
+      "dev": true
+    },
     "@vue/devtools-api": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.1.4.tgz",
@@ -28278,7 +28295,7 @@
     },
     "csstype": {
       "version": "3.1.2",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/csstype/-/csstype-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha1-HUv51XLxHBQDHwQ24cELwfVx9Qs=",
       "dev": true
     },
@@ -30966,7 +30983,7 @@
     },
     "is-core-module": {
       "version": "2.12.1",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/is-core-module/-/is-core-module-2.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
       "integrity": "sha1-DAtohbb4ABHHFUHOFcjWbPWk+f0=",
       "dev": true,
       "requires": {
@@ -35329,7 +35346,7 @@
     },
     "resolve": {
       "version": "1.22.2",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/resolve/-/resolve-1.22.2.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
       "integrity": "sha1-DtCUPU4wGGeVV2bJ8+GubQHGhF8=",
       "dev": true,
       "requires": {
@@ -38023,7 +38040,7 @@
     },
     "vue": {
       "version": "2.7.14",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/vue/-/vue-2.7.14.tgz",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
       "integrity": "sha1-N0Pc0kj9OjTUIa5Fa4ZKAka6+xc=",
       "dev": true,
       "requires": {
@@ -38033,7 +38050,7 @@
       "dependencies": {
         "@vue/compiler-sfc": {
           "version": "2.7.14",
-          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
           "integrity": "sha1-NEb9L7tnDXCSd/w/+ojvxeEChP0=",
           "dev": true,
           "requires": {
@@ -38044,7 +38061,7 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -38279,7 +38296,7 @@
     },
     "vue-server-renderer": {
       "version": "2.7.14",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/vue-server-renderer/-/vue-server-renderer-2.7.14.tgz",
+      "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.7.14.tgz",
       "integrity": "sha1-mG8/3KY/uzi7aDRpjxHg1qgfGC8=",
       "dev": true,
       "requires": {
@@ -38295,7 +38312,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -38304,7 +38321,7 @@
         },
         "chalk": {
           "version": "4.1.2",
-          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/chalk/-/chalk-4.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
           "dev": true,
           "requires": {
@@ -38314,7 +38331,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -38323,13 +38340,13 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
@@ -38341,7 +38358,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/supports-color/-/supports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -38376,7 +38393,7 @@
     },
     "vue-template-compiler": {
       "version": "2.7.14",
-      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
       "integrity": "sha1-RUW337iAkHRMFXeuWsP5ZOYWNLE=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@square/maker-icons": "^3.2.0",
         "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
         "@vue/babel-preset-jsx": "^1.1.2",
-        "@vue/composition-api": "^1.4.9",
         "babel-eslint": "^10.1.0",
         "babel-loader": "^8.1.0",
         "babel-plugin-date-fns": "^2.0.0",
@@ -71,7 +70,7 @@
         "terser-webpack-plugin": "^5.1.4",
         "tiny-glob": "^0.2.9",
         "tippy.js": "^6.2.6",
-        "vue": "^2.6.14",
+        "vue": "^2.7.14",
         "vue-demo-collapse": "0.0.2",
         "vue-docgen-api": "^4.34.2",
         "vue-frag": "^1.1.2",
@@ -80,9 +79,9 @@
         "vue-meta": "^2.4.0",
         "vue-pseudo-window": "^0.4.0",
         "vue-router": "^3.4.5",
-        "vue-server-renderer": "^2.6.14",
+        "vue-server-renderer": "^2.7.14",
         "vue-subslot": "^1.2.3",
-        "vue-template-compiler": "^2.6.14",
+        "vue-template-compiler": "^2.7.14",
         "vue-v": "^1.2.0",
         "vue-vnode-syringe": "^3.1.0",
         "webfontloader": "^1.6.28",
@@ -98,7 +97,7 @@
         "lodash": "^4.17.20",
         "popmotion": "^9.3.1",
         "stylefire": "^7.0.3",
-        "vue": "^2.6.14"
+        "vue": "^2.7.14"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -352,18 +351,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "node_modules/@babel/helper-create-class-features-plugin/node_modules/@babel/parser": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/helper-create-class-features-plugin/node_modules/@babel/template": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
@@ -507,18 +494,6 @@
         "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
-      }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/@babel/parser": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/@babel/template": {
@@ -676,18 +651,6 @@
         "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables/node_modules/@babel/parser": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables/node_modules/@babel/template": {
@@ -923,18 +886,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "node_modules/@babel/helper-wrap-function/node_modules/@babel/parser": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/helper-wrap-function/node_modules/@babel/template": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
@@ -996,10 +947,11 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-      "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+      "version": "7.22.5",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/@babel/parser/-/parser-7.22.5.tgz",
+      "integrity": "sha1-ch/QQvPOGJYjjPGzQcd+t97n2+o=",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1658,18 +1610,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "node_modules/@babel/plugin-transform-classes/node_modules/@babel/parser": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-classes/node_modules/@babel/template": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
@@ -1877,18 +1817,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "node_modules/@babel/plugin-transform-function-name/node_modules/@babel/parser": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-function-name/node_modules/@babel/template": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
@@ -2091,18 +2019,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "node_modules/@babel/plugin-transform-modules-amd/node_modules/@babel/parser": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-modules-amd/node_modules/@babel/template": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
@@ -2284,18 +2200,6 @@
         "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-commonjs/node_modules/@babel/parser": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs/node_modules/@babel/template": {
@@ -2482,18 +2386,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "node_modules/@babel/plugin-transform-modules-systemjs/node_modules/@babel/parser": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-modules-systemjs/node_modules/@babel/template": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
@@ -2675,18 +2567,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "node_modules/@babel/plugin-transform-modules-umd/node_modules/@babel/parser": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-modules-umd/node_modules/@babel/template": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
@@ -2862,18 +2742,6 @@
         "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-object-super/node_modules/@babel/parser": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-object-super/node_modules/@babel/template": {
@@ -4320,18 +4188,6 @@
         "source-map": "^0.6.1"
       }
     },
-    "node_modules/@vue/compiler-sfc/node_modules/@babel/parser": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-core": {
       "version": "3.2.31",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.31.tgz",
@@ -4504,15 +4360,6 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
-    "node_modules/@vue/composition-api": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.4.9.tgz",
-      "integrity": "sha512-l6YOeg5LEXmfPqyxAnBaCv1FMRw0OGKJ4m6nOWRm6ngt5TuHcj5ZoBRN+LXh3J0u6Ur3C4VA+RiKT+M0eItr/g==",
-      "dev": true,
-      "peerDependencies": {
-        "vue": ">= 2.5 < 3"
-      }
-    },
     "node_modules/@vue/devtools-api": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.1.4.tgz",
@@ -4539,18 +4386,6 @@
         "@vue/shared": "3.2.31",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7"
-      }
-    },
-    "node_modules/@vue/reactivity-transform/node_modules/@babel/parser": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@vue/reactivity-transform/node_modules/@vue/compiler-core": {
@@ -7980,6 +7815,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha1-HUv51XLxHBQDHwQ24cELwfVx9Qs=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -8656,35 +8498,6 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-import-resolver-node/node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-      "dev": true,
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/eslint-import-resolver-node/node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.8.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/eslint-import-resolver-webpack": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.1.tgz",
@@ -8759,18 +8572,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/eslint-import-resolver-webpack/node_modules/is-core-module": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-      "dev": true,
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/eslint-import-resolver-webpack/node_modules/is-regex": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
@@ -8792,19 +8593,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "node_modules/eslint-import-resolver-webpack/node_modules/resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/eslint-import-resolver-webpack/node_modules/semver": {
       "version": "5.7.1",
@@ -8952,18 +8740,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-      "dev": true,
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/eslint-plugin-import/node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -8981,23 +8757,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
-    },
-    "node_modules/eslint-plugin-import/node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.8.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/eslint-plugin-markdown": {
       "version": "2.2.1",
@@ -10628,27 +10387,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-ansi/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/has-bigints": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
@@ -11586,10 +11324,11 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.12.1",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha1-DAtohbb4ABHHFUHOFcjWbPWk+f0=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -17309,13 +17048,18 @@
       "dev": true
     },
     "node_modules/resolve": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "version": "1.22.2",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha1-DtCUPU4wGGeVV2bJ8+GubQHGhF8=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.1.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.11.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -20701,10 +20445,15 @@
       }
     },
     "node_modules/vue": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
-      "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==",
-      "dev": true
+      "version": "2.7.14",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/vue/-/vue-2.7.14.tgz",
+      "integrity": "sha1-N0Pc0kj9OjTUIa5Fa4ZKAka6+xc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-sfc": "2.7.14",
+        "csstype": "^3.1.0"
+      }
     },
     "node_modules/vue-demi": {
       "version": "0.12.5",
@@ -21003,68 +20752,83 @@
       "dev": true
     },
     "node_modules/vue-server-renderer": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.14.tgz",
-      "integrity": "sha512-HifYRa/LW7cKywg9gd4ZtvtRuBlstQBao5ZCWlg40fyB4OPoGfEXAzxb0emSLv4pBDOHYx0UjpqvxpiQFEuoLA==",
+      "version": "2.7.14",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/vue-server-renderer/-/vue-server-renderer-2.7.14.tgz",
+      "integrity": "sha1-mG8/3KY/uzi7aDRpjxHg1qgfGC8=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "chalk": "^1.1.3",
-        "hash-sum": "^1.0.2",
-        "he": "^1.1.0",
+        "chalk": "^4.1.2",
+        "hash-sum": "^2.0.0",
+        "he": "^1.2.0",
         "lodash.template": "^4.5.0",
         "lodash.uniq": "^4.5.0",
-        "resolve": "^1.2.0",
-        "serialize-javascript": "^3.1.0",
+        "resolve": "^1.22.0",
+        "serialize-javascript": "^6.0.0",
         "source-map": "0.5.6"
       }
     },
-    "node_modules/vue-server-renderer/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/vue-server-renderer/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "version": "4.3.0",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/vue-server-renderer/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "4.1.2",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/vue-server-renderer/node_modules/hash-sum": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
-      "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
-      "dev": true
-    },
-    "node_modules/vue-server-renderer/node_modules/serialize-javascript": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-      "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+    "node_modules/vue-server-renderer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "randombytes": "^2.1.0"
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/vue-server-renderer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue-server-renderer/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/vue-server-renderer/node_modules/source-map": {
@@ -21076,25 +20840,17 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/vue-server-renderer/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+    "node_modules/vue-server-renderer/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^2.0.0"
+        "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/vue-server-renderer/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
+        "node": ">=8"
       }
     },
     "node_modules/vue-style-loader": {
@@ -21123,13 +20879,14 @@
       }
     },
     "node_modules/vue-template-compiler": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz",
-      "integrity": "sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==",
+      "version": "2.7.14",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+      "integrity": "sha1-RUW337iAkHRMFXeuWsP5ZOYWNLE=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "de-indent": "^1.0.2",
-        "he": "^1.1.0"
+        "he": "^1.2.0"
       }
     },
     "node_modules/vue-template-es2015-compiler": {
@@ -21154,6 +20911,27 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/vue-vnode-syringe?sponsor=1"
+      }
+    },
+    "node_modules/vue/node_modules/@vue/compiler-sfc": {
+      "version": "2.7.14",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
+      "integrity": "sha1-NEb9L7tnDXCSd/w/+ojvxeEChP0=",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.18.4",
+        "postcss": "^8.4.14",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/vue/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/watchpack": {
@@ -22276,12 +22054,6 @@
             "js-tokens": "^4.0.0"
           }
         },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
         "@babel/template": {
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
@@ -22422,12 +22194,6 @@
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
-        },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -22586,12 +22352,6 @@
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
-        },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -22830,12 +22590,6 @@
             "js-tokens": "^4.0.0"
           }
         },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
         "@babel/template": {
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
@@ -22899,9 +22653,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-      "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+      "version": "7.22.5",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/@babel/parser/-/parser-7.22.5.tgz",
+      "integrity": "sha1-ch/QQvPOGJYjjPGzQcd+t97n2+o=",
       "dev": true
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
@@ -23496,12 +23250,6 @@
             "js-tokens": "^4.0.0"
           }
         },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
         "@babel/template": {
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
@@ -23702,12 +23450,6 @@
             "js-tokens": "^4.0.0"
           }
         },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
         "@babel/template": {
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
@@ -23907,12 +23649,6 @@
             "js-tokens": "^4.0.0"
           }
         },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
         "@babel/template": {
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
@@ -24094,12 +23830,6 @@
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
-        },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -24284,12 +24014,6 @@
             "js-tokens": "^4.0.0"
           }
         },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
         "@babel/template": {
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
@@ -24470,12 +24194,6 @@
             "js-tokens": "^4.0.0"
           }
         },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
-        },
         "@babel/template": {
           "version": "7.12.13",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
@@ -24647,12 +24365,6 @@
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
-        },
-        "@babel/parser": {
-          "version": "7.13.13",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-          "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
-          "dev": true
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -25863,12 +25575,6 @@
         "source-map": "^0.6.1"
       },
       "dependencies": {
-        "@babel/parser": {
-          "version": "7.17.8",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-          "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
-          "dev": true
-        },
         "@vue/compiler-core": {
           "version": "3.2.31",
           "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.31.tgz",
@@ -26008,12 +25714,6 @@
         }
       }
     },
-    "@vue/composition-api": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.4.9.tgz",
-      "integrity": "sha512-l6YOeg5LEXmfPqyxAnBaCv1FMRw0OGKJ4m6nOWRm6ngt5TuHcj5ZoBRN+LXh3J0u6Ur3C4VA+RiKT+M0eItr/g==",
-      "dev": true
-    },
     "@vue/devtools-api": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.1.4.tgz",
@@ -26050,12 +25750,6 @@
         "magic-string": "^0.25.7"
       },
       "dependencies": {
-        "@babel/parser": {
-          "version": "7.17.8",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-          "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
-          "dev": true
-        },
         "@vue/compiler-core": {
           "version": "3.2.31",
           "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.31.tgz",
@@ -28582,6 +28276,12 @@
         }
       }
     },
+    "csstype": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha1-HUv51XLxHBQDHwQ24cELwfVx9Qs=",
+      "dev": true
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -29238,26 +28938,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "is-core-module": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-          "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.3"
-          }
-        },
-        "resolve": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-          "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.8.1",
-            "path-parse": "^1.0.7",
-            "supports-preserve-symlinks-flag": "^1.0.0"
-          }
         }
       }
     },
@@ -29316,15 +28996,6 @@
           "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
           "dev": true
         },
-        "is-core-module": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-          "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.3"
-          }
-        },
         "is-regex": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
@@ -29340,16 +29011,6 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
-        },
-        "resolve": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
-          }
         },
         "semver": {
           "version": "5.7.1",
@@ -29468,15 +29129,6 @@
             "esutils": "^2.0.2"
           }
         },
-        "is-core-module": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-          "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.3"
-          }
-        },
         "is-glob": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -29491,17 +29143,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
-        },
-        "resolve": {
-          "version": "1.22.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-          "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.8.1",
-            "path-parse": "^1.0.7",
-            "supports-preserve-symlinks-flag": "^1.0.0"
-          }
         }
       }
     },
@@ -30620,23 +30261,6 @@
         "function-bind": "^1.1.1"
       }
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        }
-      }
-    },
     "has-bigints": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
@@ -31341,9 +30965,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.12.1",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha1-DAtohbb4ABHHFUHOFcjWbPWk+f0=",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -35704,13 +35328,14 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "version": "1.22.2",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha1-DtCUPU4wGGeVV2bJ8+GubQHGhF8=",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.1.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.11.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
     "resolve-cwd": {
@@ -38397,10 +38022,33 @@
       "dev": true
     },
     "vue": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
-      "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==",
-      "dev": true
+      "version": "2.7.14",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/vue/-/vue-2.7.14.tgz",
+      "integrity": "sha1-N0Pc0kj9OjTUIa5Fa4ZKAka6+xc=",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-sfc": "2.7.14",
+        "csstype": "^3.1.0"
+      },
+      "dependencies": {
+        "@vue/compiler-sfc": {
+          "version": "2.7.14",
+          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
+          "integrity": "sha1-NEb9L7tnDXCSd/w/+ojvxeEChP0=",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.18.4",
+            "postcss": "^8.4.14",
+            "source-map": "^0.6.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
     },
     "vue-demi": {
       "version": "0.12.5",
@@ -38630,60 +38278,60 @@
       "dev": true
     },
     "vue-server-renderer": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.14.tgz",
-      "integrity": "sha512-HifYRa/LW7cKywg9gd4ZtvtRuBlstQBao5ZCWlg40fyB4OPoGfEXAzxb0emSLv4pBDOHYx0UjpqvxpiQFEuoLA==",
+      "version": "2.7.14",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/vue-server-renderer/-/vue-server-renderer-2.7.14.tgz",
+      "integrity": "sha1-mG8/3KY/uzi7aDRpjxHg1qgfGC8=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "hash-sum": "^1.0.2",
-        "he": "^1.1.0",
+        "chalk": "^4.1.2",
+        "hash-sum": "^2.0.0",
+        "he": "^1.2.0",
         "lodash.template": "^4.5.0",
         "lodash.uniq": "^4.5.0",
-        "resolve": "^1.2.0",
-        "serialize-javascript": "^3.1.0",
+        "resolve": "^1.22.0",
+        "serialize-javascript": "^6.0.0",
         "source-map": "0.5.6"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
         "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "version": "4.3.0",
+          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
         },
         "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "version": "4.1.2",
+          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
-        "hash-sum": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
-          "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
           "dev": true
         },
-        "serialize-javascript": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-          "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
-          "dev": true,
-          "requires": {
-            "randombytes": "^2.1.0"
-          }
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
         },
         "source-map": {
           "version": "0.5.6",
@@ -38691,20 +38339,14 @@
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "has-flag": "^4.0.0"
           }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         }
       }
     },
@@ -38733,13 +38375,13 @@
       "dev": true
     },
     "vue-template-compiler": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz",
-      "integrity": "sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==",
+      "version": "2.7.14",
+      "resolved": "https://artifactory.intern.weebly.net/artifactory/api/npm/weebly-npm/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+      "integrity": "sha1-RUW337iAkHRMFXeuWsP5ZOYWNLE=",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",
-        "he": "^1.1.0"
+        "he": "^1.2.0"
       }
     },
     "vue-template-es2015-compiler": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@square/maker-icons": "^3.2.0",
     "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
     "@vue/babel-preset-jsx": "^1.1.2",
+    "@vue/composition-api": "^1.7.1",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
     "babel-plugin-date-fns": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lodash": "^4.17.20",
     "popmotion": "^9.3.1",
     "stylefire": "^7.0.3",
-    "vue": "^2.6.14"
+    "vue": "^2.7.14"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.13.10",
@@ -62,7 +62,6 @@
     "@square/maker-icons": "^3.2.0",
     "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
     "@vue/babel-preset-jsx": "^1.1.2",
-    "@vue/composition-api": "^1.4.9",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
     "babel-plugin-date-fns": "^2.0.0",
@@ -116,7 +115,7 @@
     "terser-webpack-plugin": "^5.1.4",
     "tiny-glob": "^0.2.9",
     "tippy.js": "^6.2.6",
-    "vue": "^2.6.14",
+    "vue": "^2.7.14",
     "vue-demo-collapse": "0.0.2",
     "vue-docgen-api": "^4.34.2",
     "vue-frag": "^1.1.2",
@@ -125,9 +124,9 @@
     "vue-meta": "^2.4.0",
     "vue-pseudo-window": "^0.4.0",
     "vue-router": "^3.4.5",
-    "vue-server-renderer": "^2.6.14",
+    "vue-server-renderer": "^2.7.14",
     "vue-subslot": "^1.2.3",
-    "vue-template-compiler": "^2.6.14",
+    "vue-template-compiler": "^2.7.14",
     "vue-v": "^1.2.0",
     "vue-vnode-syringe": "^3.1.0",
     "webfontloader": "^1.6.28",

--- a/src/components/Dialog/README.md
+++ b/src/components/Dialog/README.md
@@ -128,6 +128,46 @@ export default {
 </script>
 ```
 
+### Composition API
+
+When using the composition API, you can use the `useDialogLayer` composable instead of the mixin:
+
+```html
+<template>
+	<div>
+		<button @click="openMyDialog">
+			Open MyDialog
+		</button>
+
+		<m-dialog-layer />
+	</div>
+</template>
+
+<script>
+import { inject } from 'vue';
+import { MDialogLayer, dialogApi } from '@square/maker/components/Dialog';
+import MyDialog from './MyDialog.vue';
+
+export default {
+	components: {
+		MDialogLayer,
+	},
+
+	setup() {
+		MDialogLayer.useDialogLayer();
+		const modal = inject(modalApi)
+
+		const openMyDialog = () => this.modalApi.open((h) => h(MyDialog));
+
+		return {
+			openMyDialog,
+		};
+	}
+}
+
+</script>
+```
+
 ## Usage
 
 Dialogs must always be created in their own Single File Component (SFC) file to separate concerns because it introduces a new mode or context to your app. Use the `MDialog` component at the root of your Dialog SFC which signifies the component is a Maker Dialog and allows it to communicate with the Dialog Layer.
@@ -273,6 +313,91 @@ type dialogApi = {
 ```
 
 ## Examples
+
+### Composition API
+
+```vue
+<template>
+	<div>
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="openMyDialog"
+		>
+			Open Modal From Root
+		</m-button>
+
+		<nested-component />
+
+		<m-dialog-layer />
+	</div>
+</template>
+
+<script>
+import { MButton } from '@square/maker/components/Button';
+import { MDialogLayer } from '@square/maker/components/Dialog';
+import DemoDialog from 'doc/DemoDialog.vue';
+import NestedComponent from 'doc/NestedComponent.vue';
+
+export default {
+	components: {
+		MDialogLayer,
+		MButton,
+		NestedComponent,
+	},
+
+	setup() {
+		const { dialogApi } = MDialogLayer.useDialogLayer();
+
+		// eslint-disable-next-line no-unused-vars
+		const openMyDialog = () => dialogApi.open((h) => h(DemoDialog));
+
+		return {
+			openMyDialog,
+		};
+	},
+};
+</script>
+```
+
+_NestedComponent.vue_
+```vue
+<template>
+	<m-button
+		size="small"
+		pattern="primaryOutline"
+		@click="openMyDialog"
+	>
+		Open Modal From Nested Component
+	</m-button>
+</template>
+
+<script>
+import { inject } from 'vue';
+import { dialogApi as dialogKey } from '@square/maker/components/Dialog';
+import { MButton } from '@square/maker/components/Button';
+import DemoDialog from 'doc/DemoDialog.vue';
+
+export default {
+	components: {
+		MButton,
+	},
+
+	setup() {
+		const dialogApi = inject(dialogKey);
+		const openMyDialog = () => dialogApi.open((h) => h(DemoDialog), {
+			// eslint-disable-next-line no-restricted-globals, no-alert
+			beforeCloseHook: () => confirm('Are you sure???'),
+		});
+
+		return {
+			openMyDialog,
+		};
+	},
+};
+</script>
+```
+
 
 ### beforeClose & afterClose hooks
 

--- a/src/components/Dialog/index.js
+++ b/src/components/Dialog/index.js
@@ -2,3 +2,4 @@ export { default as dialogApi } from './src/dialog-api';
 export { default as MDialog } from './src/Dialog.vue';
 export { default as MDialogContent } from './src/DialogContent.vue';
 export { default as MDialogLayer } from './src/DialogLayer.vue';
+export { useDialogLayer } from './src/DialogLayer.vue';

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -136,6 +136,42 @@ export default {
 </script>
 ```
 
+### Composition API
+
+When using the composition API, you can use the `useModalLayer` composable instead of the mixin:
+
+```html
+<template>
+	<div>
+		<button @click="openMyModal">
+			Open MyModal
+		</button>
+
+		<m-modal-layer />
+	</div>
+</template>
+
+<script>
+import { inject } from 'vue';
+import { MModalLayer, modalApi } from '@square/maker/components/Modal';
+import MyModal from './MyModal.vue';
+
+export default {
+	setup() {
+		MModalLayer.useModalLayer();
+		const modal = inject(modalApi)
+
+		const openMyModal = () => this.modalApi.open(() => <MyModal />);
+
+		return {
+			openMyModal,
+		};
+	}
+}
+
+</script>
+```
+
 ## Usage
 
 Modals must always be created in their own Single File Component (SFC) file to separate concerns because it introduces a new mode or context to your app. Use the `MModal` component at the root of your Modal SFC to signify the modal and to communicate with the Modal Layer.
@@ -257,6 +293,90 @@ type modalApi = {
 ```
 
 ## Examples
+
+### Composition API
+
+```vue
+<template>
+	<div>
+		<m-button
+			size="small"
+			pattern="primaryOutline"
+			@click="openMyModal"
+		>
+			Open Modal From Root
+		</m-button>
+
+		<nested-component />
+
+		<m-modal-layer />
+	</div>
+</template>
+
+<script>
+import { MButton } from '@square/maker/components/Button';
+import { MModalLayer } from '@square/maker/components/Modal';
+import DemoModal from 'doc/DemoModal.vue';
+import NestedComponent from 'doc/NestedComponent.vue';
+
+export default {
+	components: {
+		MModalLayer,
+		MButton,
+		NestedComponent,
+	},
+
+	setup() {
+		const { modalApi } = MModalLayer.useModalLayer();
+
+		// eslint-disable-next-line no-unused-vars
+		const openMyModal = () => modalApi.open((h) => h(DemoModal));
+
+		return {
+			openMyModal,
+		};
+	},
+};
+</script>
+```
+
+_NestedComponent.vue_
+```vue
+<template>
+	<m-button
+		size="small"
+		pattern="primaryOutline"
+		@click="openMyModal"
+	>
+		Open Modal From Nested Component
+	</m-button>
+</template>
+
+<script>
+import { inject } from 'vue';
+import { modalApi as modalKey } from '@square/maker/components/Modal';
+import { MButton } from '@square/maker/components/Button';
+import DemoModal from 'doc/DemoModal.vue';
+
+export default {
+	components: {
+		MButton,
+	},
+
+	setup() {
+		const modalApi = inject(modalKey);
+		const openMyModal = () => modalApi.open((h) => h(DemoModal), {
+			// eslint-disable-next-line no-restricted-globals, no-alert
+			beforeCloseHook: () => confirm('Are you sure???'),
+		});
+
+		return {
+			openMyModal,
+		};
+	},
+};
+</script>
+```
 
 ### beforeCloseHook
 

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -153,15 +153,17 @@ When using the composition API, you can use the `useModalLayer` composable inste
 
 <script>
 import { inject } from 'vue';
-import { MModalLayer, modalApi } from '@square/maker/components/Modal';
+import { MModalLayer, modalApi as modalKey } from '@square/maker/components/Modal';
 import MyModal from './MyModal.vue';
 
 export default {
-	setup() {
-		MModalLayer.useModalLayer();
-		const modal = inject(modalApi)
+	components: {
+		MModalLayer,
+	},
 
-		const openMyModal = () => this.modalApi.open(() => <MyModal />);
+	setup() {
+		const { modalApi } = ModalLayer.useModalLayer();
+		const openMyModal = () => this.modalApi.open((h) => h(MyModal));
 
 		return {
 			openMyModal,

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -2,3 +2,4 @@ export { default as modalApi } from './src/modal-api';
 export { default as MModal } from './src/Modal.vue';
 export { default as MModalContent } from './src/ModalContent.vue';
 export { default as MModalLayer } from './src/ModalLayer.vue';
+export { useModalLayer } from './src/ModalLayer.vue';

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -20,7 +20,7 @@ Use the popover to provide the user with more context or options. The Popover La
 
 			<template #content>
 				<m-popover-content>
-					Content for a basic popover
+					Content for a basic composition API popover
 				</m-popover-content>
 			</template>
 		</m-popover>
@@ -47,6 +47,51 @@ export default {
 ```
 
 ## Examples
+
+### Composition API
+```vue
+<template>
+	<div>
+		<m-popover-layer />
+
+		<m-popover>
+			<template #action="popover">
+				<m-button
+					size="small"
+					pattern="primaryOutline"
+					@click="popover.toggle()"
+				>
+					Toggle popover
+				</m-button>
+			</template>
+
+			<template #content>
+				<m-popover-content>
+					Content for a basic composition API popover
+				</m-popover-content>
+			</template>
+		</m-popover>
+	</div>
+</template>
+
+<script>
+import { MButton } from '@square/maker/components/Button';
+import { MPopoverLayer, MPopover, MPopoverContent } from '@square/maker/components/Popover';
+
+export default {
+	components: {
+		MButton,
+		MPopoverLayer,
+		MPopover,
+		MPopoverContent,
+	},
+
+	setup() {
+		MPopoverLayer.usePopoverLayer();
+	},
+};
+</script>
+```
 
 ### Theming
 


### PR DESCRIPTION
## Describe the problem this PR addresses
This PR makes some changes to the modal, dialog, and popover layers to allow initialization of the layers to be done via composables instead of mixins. This is to support components that use the composition API in Vue 2.7.14 (and eventually Vue 3.x).

## Describe the changes in this PR
- Convert modal, dialog, and popover APIs to be able to be initialized by either mixin or composable
- Add documentation for changes
- Require Vue 2.7.14