### PR TITLE
fix(icon): fix default icon color inheritence

### DIFF
--- a/src/components/Icon/src/Icon.vue
+++ b/src/components/Icon/src/Icon.vue
@@ -112,7 +112,7 @@ export default {
 <style module="$s">
 .Icon {
 	--icon-size: 16px;
-	--color: inherit;
+	--color: currentColor;
 	--fill: currentColor;
 
 	width: var(--icon-size);

--- a/src/components/Theme/src/default-components.cjs
+++ b/src/components/Theme/src/default-components.cjs
@@ -451,7 +451,7 @@ module.exports = function defaultComponents() {
 			},
 		},
 		icon: {
-			color: 'inherit',
+			color: 'currentColor',
 			fill: 'currentColor',
 			name: 'info',
 			pattern: undefined,


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
This fixes an icon color bug. Icons with no `color` prop declared are not inheriting the parent color as desired, but inheriting the nearest parent definition of `--color`, which typically happens on the nearest MTheme. This causes a bug on button loaders where instead of applying the button color, it applies the MTheme color instead.

## Describe the changes in this PR
This PR replaces `--color: inherit` with `--color: currentColor`, which fixes the color inheritance bug.
<img width="570" alt="Screenshot 2023-06-23 at 4 12 34 PM" src="https://github.com/square/maker/assets/1486885/3224e233-0a19-4a4e-981d-c90439c865f8">
<img width="568" alt="Screenshot 2023-06-23 at 4 12 14 PM" src="https://github.com/square/maker/assets/1486885/ed8807fa-9fe4-426a-978d-53bde6dbc86e">
<img width="621" alt="Screenshot 2023-06-23 at 4 27 16 PM" src="https://github.com/square/maker/assets/1486885/1f7c9bec-cad5-4905-b4d3-00eba123afa1">



## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
