### PR TITLE
fix(button): fix custom hover color style on outline/ghost buttons

### DIFF
--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -75,7 +75,7 @@ function setColorVariables(tokens, variant) {
 	const hoverStateAdjust = 0.08;
 	const activeStateAdjust = 0.16;
 	const focusAlphaAdjust = 0.3;
-	const colorHover = tokens.colorHover
+	const colorHover = tokens.colorHover && variant === 'fill'
 		? tokens.colorHover : colorMainHover[stateAdjustment](hoverStateAdjust).toHex();
 	const colorActive = colorMainHover[stateAdjustment](activeStateAdjust).toHex();
 	const colorFocus = colorMainHover.alpha(focusAlphaAdjust).toHex();

--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -170,7 +170,7 @@ Themable props* can be configured via the [Theme](#/Theme) component using the k
 | pattern* | `string` | —                | `'info'`, `'warning'`, `'error'`, `'success'`, `'primary'`, any custom pattern defined within the theme | pattern defined in theme                                       |
 | name*    | `string` | `'info'`         | -                                                                                                       | name of icon, defined in theme                                 |
 | size     | `string` | `'small'`        | `'small'`, `'medium'`, `'large'`, `'xlarge'`, `'xxlarge'`                                               | size of icon, can be named value or any valid CSS width/height |
-| color*   | `string` | `'inherit'`      | -                                                                                                       | color of icon                                                  |
+| color*   | `string` | `'currentColor'` | -                                                                                                       | color of icon                                                  |
 | fill*    | `string` | `'currentColor'` | -                                                                                                       | fill of icon                                                   |
 
 


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Custom hover color on outline and ghost buttons incorrectly applying to the fill color.

https://github.com/square/maker/assets/1486885/a407ce43-2352-43ce-9eaa-07f7f1121a3f

## Describe the changes in this PR
Fixes the hover state for custom hover colors on outline/ghost buttons.

https://github.com/square/maker/assets/1486885/40929af3-db68-4d7a-bec7-23e64afc4463


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
