### PR TITLE
feat(text): balance letter-spacing when centered

### DIFF
--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -58,6 +58,69 @@ export default {
 </script>
 ```
 
+## Letter spacing alignment
+CSS applies letter spacing to the right side of the letter. This is problematic when the text is centered because it adds more space to the right side. To counter act this, we add a left-padding to the text that is equal to the letter spacing. This ensures that the text is centered correctly.
+
+```vue
+<template>
+	<div>
+		<div class="container">
+			<div class="line" />
+			<m-text
+				class="text"
+				letter-spacing="2em"
+			>
+				Text
+			</m-text>
+		</div>
+		<div class="container">
+			<div class="line" />
+			<m-text
+				class="text"
+				letter-spacing="1.5em"
+			>
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam euismod, nisl eget
+			</m-text>
+		</div>
+	</div>
+</template>
+
+<script>
+import { MText } from '@square/maker/components/Text';
+
+export default {
+	components: {
+		MText,
+	},
+};
+</script>
+
+<style scoped>
+.container {
+	position: relative;
+	width: 600px;
+	margin: 0 auto;
+	background-color: #eee;
+	overflow: hidden;
+	padding: 16px;
+	text-align: center;
+}
+
+.line {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	width: 1px;
+	left: 50%;
+	background-color: #000;
+}
+
+.text {
+	border: 1px solid #000;
+}
+</style>
+```
+
 <!-- api-tables:start -->
 ## Props
 

--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -121,6 +121,12 @@ export default {
 		},
 	},
 
+	data() {
+		return {
+			isCentered: false,
+		};
+	},
+
 	computed: {
 		...resolveThemeableProps('text', [
 			'pattern',
@@ -198,7 +204,33 @@ export default {
 			if (this.resolvedLetterSpacing !== 'inherit') {
 				styles.letterSpacing = this.resolvedLetterSpacing;
 			}
+			if (this.isCentered) {
+				styles.paddingLeft = this.letterSpacing;
+			}
 			return styles;
+		},
+	},
+
+	mounted() {
+		this.detectAlignCenter();
+	},
+
+	updated() {
+		this.detectAlignCenter();
+	},
+
+	methods: {
+		/**
+		 * Letter spacing is applied to the right-side of the letter
+		 * so when the text is centered, it becomes misaligned
+		 *
+		 * Detect if the text is center aligned and add left padding
+		 * to balance out the letter spacing
+		 */
+		detectAlignCenter() {
+			const computedStyle = window.getComputedStyle(this.$el);
+			const textAlign = computedStyle.getPropertyValue('text-align');
+			this.isCentered = textAlign === 'center';
 		},
 	},
 


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->


When the text is centered with letter spacing, it isn't center aligned:

<img width="1083" alt="Screenshot 2023-08-18 at 12 34 13 AM" src="https://github.com/square/maker/assets/1075694/31f85b6b-1300-4eb0-b37a-a795f1802fbb">


## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->

Add padding left to balance it out:

<img width="1166" alt="Screenshot 2023-08-18 at 12 34 02 AM" src="https://github.com/square/maker/assets/1075694/15ea9fa6-6270-4ea8-86ae-44783eda9fd0">


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
