### PR TITLE
feat(image): add hexagon as an image shape

### DIFF
--- a/src/components/Image/README.md
+++ b/src/components/Image/README.md
@@ -58,6 +58,7 @@ export default {
 				'square',
 				'circle',
 				'arch',
+				'hexagon',
 			],
 			fadedInComplete: 'Fade in not completed',
 		};
@@ -246,15 +247,15 @@ Supports attributes from [`<img>`](https://developer.mozilla.org/en-US/docs/Web/
 
 Themable props* can be configured via the [Theme](#/Theme) component using the key `image`.
 
-| Prop            | Type      | Default    | Possible values                                | Description                                                                         |
-| --------------- | --------- | ---------- | ---------------------------------------------- | ----------------------------------------------------------------------------------- |
-| src             | `string`  | —          | -                                              | -                                                                                   |
-| srcset          | `string`  | —          | -                                              | -                                                                                   |
-| sizes           | `string`  | —          | -                                              | -                                                                                   |
-| shape*          | `string`  | —          | `'original'`, `'square'`, `'circle'`, `'arch'` | Original applies theme's border radius, square applies border radius of 0           |
-| lazyload        | `boolean` | `false`    | -                                              | -                                                                                   |
-| object-fit      | `string`  | `'cover'`  | -                                              | [Object fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)           |
-| object-position | `string`  | `'center'` | -                                              | [Object position](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) |
+| Prop            | Type      | Default    | Possible values                                             | Description                                                                         |
+| --------------- | --------- | ---------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| src             | `string`  | —          | -                                                           | -                                                                                   |
+| srcset          | `string`  | —          | -                                                           | -                                                                                   |
+| sizes           | `string`  | —          | -                                                           | -                                                                                   |
+| shape*          | `string`  | —          | `'original'`, `'square'`, `'circle'`, `'arch'`, `'hexagon'` | Original applies theme's border radius, square applies border radius of 0           |
+| lazyload        | `boolean` | `false`    | -                                                           | -                                                                                   |
+| object-fit      | `string`  | `'cover'`  | -                                                           | [Object fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)           |
+| object-position | `string`  | `'center'` | -                                                           | [Object position](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) |
 
 
 ## Events

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -29,6 +29,28 @@
 		<pseudo-window
 			@resize="throttledResizeHandler"
 		/>
+		<div
+			:class="$s.ImageClipPaths"
+		>
+			<svg
+				viewBox="0 0 456 456"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<defs>
+					<clipPath
+						id="mImageHexPath"
+						clipPathUnits="objectBoundingBox"
+						:transform="svgScale"
+					>
+						<path
+							:d="SVG_PATH"
+							fill="white"
+						/>
+					</clipPath>
+				</defs>
+			</svg>
+		</div>
 	</div>
 </template>
 
@@ -39,6 +61,11 @@ import { MTransitionFadeIn } from '@square/maker/components/TransitionFadeIn';
 import { MSkeletonBlock } from '@square/maker/components/Skeleton';
 import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
 import cssValidator from '@square/maker/utils/css-validator';
+
+const SVG_PATH = 'M 228.192 0 L 425.646 114 V 342 L 228.192 456 L 30.738586 342 V 114 L 228.192 0 Z';
+// Calculate scale based on viewbox dimensions
+// eslint-disable-next-line no-magic-numbers
+const SVG_SCALE = 1 / 456;
 
 /** @constructor */
 function SharedIntersectionObserver() {
@@ -104,7 +131,7 @@ export default {
 		shape: {
 			type: String,
 			default: undefined,
-			validator: (shape) => ['original', 'square', 'circle', 'arch'].includes(shape),
+			validator: (shape) => ['original', 'square', 'circle', 'arch', 'hexagon'].includes(shape),
 		},
 		lazyload: {
 			type: Boolean,
@@ -135,6 +162,7 @@ export default {
 			throttledResizeHandler: throttle(this.getImageDimensions, THROTTLE_DELAY),
 			height: 0,
 			width: 0,
+			SVG_PATH,
 		};
 	},
 
@@ -165,6 +193,10 @@ export default {
 
 		isThumbnail() {
 			return this.width < THUMBNAIL_MAX_WIDTH;
+		},
+
+		svgScale() {
+			return `scale(${SVG_SCALE}, ${SVG_SCALE})`;
 		},
 	},
 
@@ -252,5 +284,15 @@ export default {
 		border-top-left-radius: var(--image-height);
 		border-top-right-radius: var(--image-height);
 	}
+
+	&.shape_hexagon {
+		-webkit-clip-path: url(#mImageHexPath);
+		clip-path: url(#mImageHexPath);
+	}
+}
+
+.ImageClipPaths {
+	width: 0;
+	height: 0;
 }
 </style>

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -294,5 +294,6 @@ export default {
 .ImageClipPaths {
 	width: 0;
 	height: 0;
+	overflow: hidden;
 }
 </style>


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Add hexagon as an image `shape` option
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
<img width="1515" alt="Screenshot 2023-10-12 at 12 44 41 PM" src="https://github.com/square/maker/assets/82115556/7f28acd2-0ed7-451e-8b9a-5090112bce0d">

* Implemented using css `clip-path` with an inline svg


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
* Initially tried implementing this using a shared svg file, but the `clip-path` css property only works with a specific id on `clipPath` which made referencing the file difficult. [Documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path) suggests that this can be done with `clip-path: url(hexagon.svg#hexPath)`, but I was not able to get this to work in the same way we would reference `background-image: url(./hexagon.svg)`. I could only get this to work if the referenced svg was visible in the DOM without being conditionally rendered. Referencing svg via file path would also have to add additional webpack loaders.
I also considered appending an svg to the DOM if one is not present, but that didn't quite seem best practice. 
Open to suggestions here