### PR TITLE
feat(dialog,modal): allow blocking swipe-to-close

### DIFF
--- a/src/components/Dialog/README.md
+++ b/src/components/Dialog/README.md
@@ -286,9 +286,6 @@ type OpenOptions = {
 	// Dialog will close when clicked outside of it - default false
 	closeOnClickOutside?: boolean;
 
-	// Dialog will closed when a user swipes down
-	closeOnSwipeDown?: boolean;
-
 	// Dialog will close when esc key is pressed - default false
 	closeOnEsc?: boolean;
 
@@ -804,10 +801,11 @@ export default {
 
 Themable props* can be configured via the [Theme](#/Theme) component using the key `dialog`.
 
-| Prop      | Type     | Default     | Possible values | Description                |
-| --------- | -------- | ----------- | --------------- | -------------------------- |
-| bg-color* | `string` | `'#ffffff'` | -               | Background color of dialog |
-| color*    | `string` | `'#000000'` | -               | Text color of dialog       |
+| Prop                | Type      | Default     | Possible values | Description                             |
+| ------------------- | --------- | ----------- | --------------- | --------------------------------------- |
+| bg-color*           | `string`  | `'#ffffff'` | -               | Background color of dialog              |
+| color*              | `string`  | `'#000000'` | -               | Text color of dialog                    |
+| close-on-swipe-down | `boolean` | `true`      | -               | Toggle to allow swiping the dialog away |
 
 
 ## Dialog Slots

--- a/src/components/Dialog/README.md
+++ b/src/components/Dialog/README.md
@@ -286,6 +286,9 @@ type OpenOptions = {
 	// Dialog will close when clicked outside of it - default false
 	closeOnClickOutside?: boolean;
 
+	// Dialog will closed when a user swipes down
+	closeOnSwipeDown?: boolean;
+
 	// Dialog will close when esc key is pressed - default false
 	closeOnEsc?: boolean;
 

--- a/src/components/Dialog/src/Dialog.vue
+++ b/src/components/Dialog/src/Dialog.vue
@@ -78,15 +78,31 @@ export default {
 				...this.dialogStyles,
 			};
 		},
+
+		closeOnSwipeDown() {
+			const { closeOnSwipeDown } = this.dialogApi.state.options;
+
+			// Nullish values are true, else respect value given
+			// eslint-disable-next-line unicorn/no-null
+			return closeOnSwipeDown == null || Boolean(closeOnSwipeDown);
+		},
 	},
 
 	methods: {
 		setScrollTop() {
+			if (!this.closeOnSwipeDown) {
+				return;
+			}
+
 			const scrollTop = this.$refs?.dialog?.$el?.scrollTop || 0;
 			this.isScrolledToTop = scrollTop <= 0;
 		},
 
 		onSwipeDown() {
+			if (!this.closeOnSwipeDown) {
+				return;
+			}
+
 			if (this.isScrolledToTop) {
 				this.preventDefault = true;
 				this.dialogApi.close();
@@ -94,6 +110,10 @@ export default {
 		},
 
 		onDragDown(gesture) {
+			if (!this.closeOnSwipeDown) {
+				return;
+			}
+
 			if (this.isScrolledToTop) {
 				this.preventDefault = true;
 				this.dialogStyles = {
@@ -106,6 +126,10 @@ export default {
 		},
 
 		onDragEnd(gesture) {
+			if (!this.closeOnSwipeDown) {
+				return;
+			}
+
 			// Pixels dialog must be dragged to close on release
 			const minDragCloseDistance = 50;
 			if (this.isScrolledToTop

--- a/src/components/Dialog/src/Dialog.vue
+++ b/src/components/Dialog/src/Dialog.vue
@@ -53,6 +53,14 @@ export default {
 			default: undefined,
 			validator: cssValidator('color'),
 		},
+
+		/**
+		 * Toggle to allow swiping the dialog away
+		 */
+		closeOnSwipeDown: {
+			type: Boolean,
+			default: true,
+		},
 	},
 
 	data() {
@@ -77,14 +85,6 @@ export default {
 				'--color': this.resolvedColor,
 				...this.dialogStyles,
 			};
-		},
-
-		closeOnSwipeDown() {
-			const { closeOnSwipeDown } = this.dialogApi.state.options;
-
-			// Nullish values are true, else respect value given
-			// eslint-disable-next-line unicorn/no-null
-			return closeOnSwipeDown == null || Boolean(closeOnSwipeDown);
 		},
 	},
 

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -768,11 +768,12 @@ export default {
 
 Themable props* can be configured via the [Theme](#/Theme) component using the key `modal`.
 
-| Prop         | Type     | Default     | Possible values | Description                          |
-| ------------ | -------- | ----------- | --------------- | ------------------------------------ |
-| before-close | `func`   | —           | -               | Before close hook, can block closing |
-| bg-color*    | `string` | `'#ffffff'` | -               | Background color of modal            |
-| color*       | `string` | `'#000000'` | -               | Text color of modal                  |
+| Prop                | Type      | Default     | Possible values | Description                             |
+| ------------------- | --------- | ----------- | --------------- | --------------------------------------- |
+| before-close        | `func`    | —           | -               | Before close hook, can block closing    |
+| bg-color*           | `string`  | `'#ffffff'` | -               | Background color of modal               |
+| color*              | `string`  | `'#000000'` | -               | Text color of modal                     |
+| close-on-swipe-down | `boolean` | `true`      | -               | Toggle to allow swiping the dialog away |
 
 
 ## Modal Slots

--- a/src/components/Modal/src/Modal.vue
+++ b/src/components/Modal/src/Modal.vue
@@ -60,6 +60,14 @@ export default {
 			default: undefined,
 			validator: cssValidator('color'),
 		},
+
+		/**
+		 * Toggle to allow swiping the dialog away
+		 */
+		closeOnSwipeDown: {
+			type: Boolean,
+			default: true,
+		},
 	},
 
 	data() {
@@ -98,11 +106,19 @@ export default {
 
 	methods: {
 		setScrollTop() {
+			if (!this.closeOnSwipeDown) {
+				return;
+			}
+
 			const scrollTop = this.$refs?.modal?.$el?.scrollTop || 0;
 			this.isScrolledToTop = scrollTop <= 0;
 		},
 
 		onSwipeDown() {
+			if (!this.closeOnSwipeDown) {
+				return;
+			}
+
 			if (this.isScrolledToTop) {
 				this.preventDefault = true;
 				this.modalApi.close();
@@ -110,6 +126,10 @@ export default {
 		},
 
 		onDragDown(gesture) {
+			if (!this.closeOnSwipeDown) {
+				return;
+			}
+
 			if (this.isScrolledToTop) {
 				this.preventDefault = true;
 				const transform = `translateY(${gesture.changeY}px)`;
@@ -123,6 +143,10 @@ export default {
 		},
 
 		onDragEnd(gesture) {
+			if (!this.closeOnSwipeDown) {
+				return;
+			}
+
 			// percent of window height modal must be dragged to close on release
 			const minDragCloseDistance = 0.3;
 			const minDragThreshold = window.innerHeight * minDragCloseDistance;


### PR DESCRIPTION
## Describe the problem this PR addresses
Closes #565 
Provides a prop to block swiping away dialogs and modals on touch-enabled devices. `closeOnSwipeDown` is enabled by default to maintain current functionality.

## Describe the changes in this PR
- Add `closeOnSwipeDown` as a prop on `MDialog` and `MModal` components
- Update `MDialog`/`MModal` to check the value of `closeOnSwipeDown` to enable/disable swipe (nullish values evaluate to enabled)