### PR TITLE
fix(Image): shape not working without explicit image height

### DIFF
--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -247,7 +247,9 @@ export default {
 
 		onLoaded() {
 			this.loaded = true;
-			this.getImageDimensions();
+			// We can't get the proper height of the image until after the DOM has been updated
+			// The image will otherwise be hidden, and the offsetHeight will be 0
+			this.$nextTick(() => this.getImageDimensions());
 		},
 	},
 };


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
* Image shape `circle` and `arch` were not working without defining an explicit height for the image. This was because the `onLoaded` method being used to set the image `height` and `width` was being triggered in the same update cycle as `loaded`. Because we are using `v-show="loaded"` the element has not yet appeared in the DOM so the `offsetHeight` will always be 0. You can see in the screenshot that the shape is actually applied, once the resize method has been triggered and the element is actually visible.

https://github.com/square/maker/assets/82115556/0d93cbb3-323a-4af5-94c6-04551b95ca4a


## Describe the changes in this PR
* This PR ensures that `offsetHeight` is only retrieved after the DOM has had a chance to update and the image is actually visible
<!--
  📸 Inline screenshots to better communicate the changes
-->





## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
