### PR TITLE
fix(image): Change implementation of clip-path for images

### DIFF
--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -267,10 +267,4 @@ export default {
 		clip-path: var(--maker-image-hexagon);
 	}
 }
-
-.ImageClipPaths {
-	width: 0;
-	height: 0;
-	overflow: hidden;
-}
 </style>

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -1,6 +1,7 @@
 <template>
 	<div
 		:class="$s.ImageWrapper"
+		:style="imageWrapperStyles"
 	>
 		<m-skeleton-block
 			v-if="!loaded"
@@ -29,28 +30,6 @@
 		<pseudo-window
 			@resize="throttledResizeHandler"
 		/>
-		<div
-			:class="$s.ImageClipPaths"
-		>
-			<svg
-				viewBox="0 0 456 456"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<defs>
-					<clipPath
-						id="mImageHexPath"
-						clipPathUnits="objectBoundingBox"
-						:transform="svgScale"
-					>
-						<path
-							:d="SVG_PATH"
-							fill="white"
-						/>
-					</clipPath>
-				</defs>
-			</svg>
-		</div>
 	</div>
 </template>
 
@@ -62,10 +41,7 @@ import { MSkeletonBlock } from '@square/maker/components/Skeleton';
 import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
 import cssValidator from '@square/maker/utils/css-validator';
 
-const SVG_PATH = 'M 228.192 0 L 425.646 114 V 342 L 228.192 456 L 30.738586 342 V 114 L 228.192 0 Z';
-// Calculate scale based on viewbox dimensions
-// eslint-disable-next-line no-magic-numbers
-const SVG_SCALE = 1 / 456;
+const hexagon = 'polygon(50% 0, 93.3012701892219% 25%, 93.3012701892219% 75%, 50% 100%, 6.69872981077807% 75%, 6.69872981077807% 25%)';
 
 /** @constructor */
 function SharedIntersectionObserver() {
@@ -162,7 +138,6 @@ export default {
 			throttledResizeHandler: throttle(this.getImageDimensions, THROTTLE_DELAY),
 			height: 0,
 			width: 0,
-			SVG_PATH,
 		};
 	},
 
@@ -183,6 +158,12 @@ export default {
 				: '';
 		},
 
+		imageWrapperStyles() {
+			return {
+				'--maker-image-hexagon': hexagon,
+			};
+		},
+
 		style() {
 			return {
 				'--image-height': `${this.height}px`,
@@ -193,10 +174,6 @@ export default {
 
 		isThumbnail() {
 			return this.width < THUMBNAIL_MAX_WIDTH;
-		},
-
-		svgScale() {
-			return `scale(${SVG_SCALE}, ${SVG_SCALE})`;
 		},
 	},
 
@@ -286,8 +263,8 @@ export default {
 	}
 
 	&.shape_hexagon {
-		-webkit-clip-path: url(#mImageHexPath);
-		clip-path: url(#mImageHexPath);
+		-webkit-clip-path: var(--maker-image-hexagon);
+		clip-path: var(--maker-image-hexagon);
 	}
 }
 


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
* `clip-path` was being inconsistently applied when there were a lot of images on the page. This was possibly due to the implementation, which was relying on an id attached to the svg to identify the shape. There was likely id collision happening, but utilizing clip path only appeared to work if the id was static, so this PR changes the implementation of `clip-path`
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
* Switch from using `clip-path: url(#id);` to `clip-path: polygon()`, which consistently applies shape to the image

![Screenshot 2023-11-03 at 3 18 49 PM](https://github.com/square/maker/assets/82115556/813a7a18-67bc-4cf1-987d-c160448770a0)

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
