### PR TITLE
fix(modal,dialog): prevent unintended close for modals/dialogs when selecting text

### DIFF
--- a/src/components/Dialog/README.md
+++ b/src/components/Dialog/README.md
@@ -35,7 +35,7 @@ export default {
 
 	methods: {
 		openDialog() {
-			this.dialogApi.open(() => <DemoDialog />);
+			this.dialogApi.open(() => <DemoDialog />, { closeOnClickOutside: true });
 		},
 	},
 };

--- a/src/components/Dialog/src/DialogLayer.vue
+++ b/src/components/Dialog/src/DialogLayer.vue
@@ -10,7 +10,7 @@
 			<div
 				v-if="dialogApi.state.renderFn"
 				:class="$s.DialogLayer"
-				@click.capture="closeOnClickOutside"
+				@mousedown.capture="closeOnClickOutside"
 			>
 				<pseudo-window
 					body

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -33,7 +33,7 @@ export default {
 
 	methods: {
 		openModal() {
-			this.modalApi.open(() => <DemoModal />);
+			this.modalApi.open(() => <DemoModal />, { closeOnClickOutside: true });
 		},
 	},
 };

--- a/src/components/Modal/src/ModalLayer.vue
+++ b/src/components/Modal/src/ModalLayer.vue
@@ -19,7 +19,7 @@
 				v-if="parentModalApi.state.renderFn"
 				ref="baseModalLayer"
 				:class="$s.ModalLayer"
-				@click.capture="closeOnClickOutside"
+				@mousedown.capture="closeOnClickOutside"
 			>
 				<pseudo-window
 					body


### PR DESCRIPTION
## Describe the problem this PR addresses
When clicking and dragging to select text, if the user releases their cursor outside the modal/dialog window, the modal/dialog will close (specifically on Chrome). This is because the `click` event uses the hovered target on `mouseup`, which trips the `closeOnClickOutside` logic. On other browsers like Firefox, the target is the element hovered on `mousedown`.

## Describe the changes in this PR
- Update `@click.capture` to `@mousedown.capture` for the modal/dialog layer components to trigger the `closeOnClickOutside` logic.

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
