### PR TITLE
refactor: adjust sizing of MButton info slot

### DIFF
--- a/src/components/Button/src/Button.vue
+++ b/src/components/Button/src/Button.vue
@@ -681,7 +681,7 @@ export default {
 }
 
 .InformationText {
-	width: min-content;
+	flex: 0 0 fit-content;
 	padding-left: var(--letter-spacing);
 	opacity: 0.6;
 }


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->
The `information` slot in `MButton` currently uses a `width` property inside a flex container, which causes the text to be cut off in situations where the main slot runs long.

<img width="322" alt="image" src="https://github.com/square/maker/assets/1403744/0795d5e4-66f0-4470-85d2-0b4fac5173bd">


## Describe the changes in this PR
<!--
  📸 Inline screenshots to better communicate the changes
-->
This PR changes the slot to be sized with `flex` properties, specifically setting the `flex-basis` so that contents aren't elided.

<img width="329" alt="image" src="https://github.com/square/maker/assets/1403744/982f7845-2b80-4fd3-a028-a267120e8e6f">


## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
