### PR TITLE
fix(skeleton): use opacity instead of background-color

### DIFF
--- a/src/components/Skeleton/src/SkeletonBlock.vue
+++ b/src/components/Skeleton/src/SkeletonBlock.vue
@@ -42,6 +42,7 @@ export default {
 .SkeletonBlock {
 	width: 100%;
 	height: 100%;
+	background-color: $maker-color-neutral-20;
 
 	&.loading {
 		animation: pulsing 0.5s ease-in-out infinite alternate;
@@ -49,7 +50,7 @@ export default {
 }
 
 @keyframes pulsing {
-	0% { background-color: $maker-color-neutral-10; }
-	100% { background-color: $maker-color-neutral-20; }
+	0% { opacity: 0.4; }
+	100% { opacity: 1; }
 }
 </style>

--- a/src/components/Skeleton/src/SkeletonText.vue
+++ b/src/components/Skeleton/src/SkeletonText.vue
@@ -76,6 +76,7 @@ export default {
 		top: 50%;
 		width: 100%;
 		height: 75%;
+		background-color: $maker-color-neutral-20;
 		border-radius: $maker-shape-default-border-radius;
 		transform: translateY(-50%);
 		animation: pulsing 0.5s ease-in-out infinite alternate;
@@ -84,7 +85,7 @@ export default {
 }
 
 @keyframes pulsing {
-	0% { background-color: $maker-color-neutral-10; }
-	100% { background-color: $maker-color-neutral-20; }
+	0% { opacity: 0.4; }
+	100% { opacity: 1; }
 }
 </style>


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Lighthouse analysis led to recommend using opacity for the skeleton loaders for better performance (https://web.dev/articles/stick-to-compositor-only-properties-and-manage-layer-count).

Anecdotally, testing locally, I did notice an improvement in the animation with less jag using opacity when simulating on our larger sites with a mid-tier mobile device.

## Describe the changes in this PR
Switch to using opacity for the skeleton loaders.

https://github.com/square/maker/assets/18740390/7d2048a7-2456-420a-93dc-08ad308fd8e8

https://github.com/square/maker/assets/18740390/a6178240-7316-4b97-828a-3afd6ade53e9

