### PR TITLE
perf(image): scrolling large number of images in Safari

### DIFF
--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -177,11 +177,23 @@ export default {
 		isThumbnail() {
 			return this.width < THUMBNAIL_MAX_WIDTH;
 		},
+
+		shouldGetImageDimensions() {
+			return this.shape !== 'square';
+		},
 	},
 
 	watch: {
 		src: 'load',
 		srcset: 'load',
+		shape: {
+			immediate: true,
+			handler() {
+				if (this.shouldGetImageDimensions && (!this.height || !this.width)) {
+					this.$nextTick(() => this.getImageDimensions());
+				}
+			},
+		},
 	},
 
 	mounted() {
@@ -219,7 +231,9 @@ export default {
 				this.getImageDimensionsTimeout = setTimeout(getImageDimensionsFn, timeoutValue);
 			}
 		};
-		this.$nextTick(getImageDimensionsFn);
+		if (this.shouldGetImageDimensions) {
+			this.$nextTick(getImageDimensionsFn);
+		}
 	},
 
 	beforeDestroy() {
@@ -243,7 +257,7 @@ export default {
 
 		onLoaded() {
 			this.loaded = true;
-			if (!this.height || !this.width) {
+			if (this.shouldGetImageDimensions && (!this.height || !this.width)) {
 				// We can't get the proper height of the image until after the DOM has been updated
 				// The image will otherwise be hidden, and the offsetHeight will be 0
 				this.$nextTick(() => this.getImageDimensions());

--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -138,6 +138,8 @@ export default {
 			throttledResizeHandler: throttle(this.getImageDimensions, THROTTLE_DELAY),
 			height: 0,
 			width: 0,
+			getImageDimensionsFnAttemptsLeft: 20,
+			getImageDimensionsTimeout: undefined,
 		};
 	},
 
@@ -201,11 +203,28 @@ export default {
 			this.load();
 		}
 
-		this.getImageDimensions();
+		// Safari seems to really struggle with getImageDimensions, specifically calling
+		// offsetHeight/offsetWidth which triggers a style recalculation. If you're
+		// scrolling a list that has images, it just causes the main thread to get frozen.
+		// Let's try and preload those values before the image is actually loaded.
+		const timeoutValue = 100;
+		const getImageDimensionsFn = () => {
+			this.getImageDimensions();
+			// Just to ensure we don't have an infinite loop
+			this.getImageDimensionsFnAttemptsLeft -= 1;
+			if (this.getImageDimensionsFnAttemptsLeft === 0) {
+				return;
+			}
+			if (!this.height || !this.width) {
+				this.getImageDimensionsTimeout = setTimeout(getImageDimensionsFn, timeoutValue);
+			}
+		};
+		this.$nextTick(getImageDimensionsFn);
 	},
 
 	beforeDestroy() {
 		observer?.unwatch(this.$el);
+		clearTimeout(this.getImageDimensionsTimeout);
 	},
 
 	methods: {
@@ -214,8 +233,8 @@ export default {
 		},
 
 		getImageDimensions() {
-			this.height = this.$el?.offsetHeight || '0';
-			this.width = this.$el?.offsetWidth || '0';
+			this.height = this.$el?.offsetHeight || 0;
+			this.width = this.$el?.offsetWidth || 0;
 		},
 
 		afterEnter() {
@@ -224,9 +243,11 @@ export default {
 
 		onLoaded() {
 			this.loaded = true;
-			// We can't get the proper height of the image until after the DOM has been updated
-			// The image will otherwise be hidden, and the offsetHeight will be 0
-			this.$nextTick(() => this.getImageDimensions());
+			if (!this.height || !this.width) {
+				// We can't get the proper height of the image until after the DOM has been updated
+				// The image will otherwise be hidden, and the offsetHeight will be 0
+				this.$nextTick(() => this.getImageDimensions());
+			}
 		},
 	},
 };


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Safari seems to really struggle with getImageDimensions, specifically calling offsetHeight/offsetWidth which triggers a style recalculation. If you're scrolling a list that has images (e.g. OO on mobile view), it just causes the main thread to get frozen.

![Screenshot 2023-12-08 at 3 14 12 AM](https://github.com/square/maker/assets/18740390/1d795d72-b6cd-409a-a3cb-fe29102ba253)
![Screenshot 2023-12-08 at 3 14 45 AM](https://github.com/square/maker/assets/18740390/9c953189-f479-4872-b6d2-1280ede59134)

## Describe the changes in this PR
Try to preload the image dimensions in the mounted event instead of waiting of the onLoaded event which can cause the main thread to freeze for a significant amount of time.

Also added logic to just skip getting the image dimensions if the shape is square.
