### PR TITLE
perf(image): update css for perf on safari

### DIFF
--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -10,8 +10,27 @@
 				$s[`shape_${resolvedShape}`],
 			]"
 		/>
-		<component
-			:is="transitionComponent"
+		<!-- Need to use a template. Using an actual element (e.g span)
+		and needing to style it causes the performance issue in Safari. -->
+		<template v-if="shouldDisableTransition">
+			<img
+				v-show="loaded"
+				:class="{
+					[$s.Image]: true,
+					[$s[`shape_${resolvedShape}`]]: resolvedShape,
+					[$s.thumbnail]: isThumbnail,
+				}"
+				:style="style"
+				:srcset="calculatedSrcSet"
+				:sizes="sizes"
+				:src="calculatedSrc"
+				v-bind="$attrs"
+				@load="onLoaded"
+				v-on="$listeners"
+			>
+		</template>
+		<m-transition-fade-in
+			v-else
 			@after-enter="afterEnter"
 		>
 			<img
@@ -29,7 +48,7 @@
 				@load="onLoaded"
 				v-on="$listeners"
 			>
-		</component>
+		</m-transition-fade-in>
 		<pseudo-window
 			@resize="throttledResizeHandler"
 		/>
@@ -188,13 +207,6 @@ export default {
 		shouldGetImageDimensions() {
 			return this.shape !== 'square' && this.shape !== 'original';
 		},
-
-		transitionComponent() {
-			if (!this.shouldDisableTransition) {
-				return 'm-transition-fade-in';
-			}
-			return 'span';
-		},
 	},
 
 	watch: {
@@ -292,8 +304,10 @@ export default {
 
 .Image {
 	display: block;
-	width: 100%;
-	height: 100%;
+
+	/* Need to use inherit instead of 100% for performance on Safari */
+	width: inherit;
+	height: inherit;
 	object-fit: var(--image-object-fit);
 	object-position: var(--image-object-position);
 	border-radius: $maker-shape-image-border-radius;


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Noticed on our OO sites in Safari removing the images vastly improved the scroll experience. From there it was just removing attributes and CSS until I narrowed it down to the `height: 100%` seemingly causing the issue. Will see if the deployed version provides the same perf gain.
 
## Describe the changes in this PR
Use `inherit` instead of `100%` and remove the parent `span` as that causes perf issues. `img` needs to be a direct child of the `div`.