### PR TITLE
perf(image): use static size styles for safari

### DIFF
--- a/src/components/Image/src/Image.vue
+++ b/src/components/Image/src/Image.vue
@@ -155,6 +155,11 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		/* Should only be needed for Safari */
+		shouldUseStaticSizeStyles: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	data() {
@@ -193,11 +198,22 @@ export default {
 		},
 
 		style() {
-			return {
+			const imageStyle = {
 				'--image-height': `${this.height}px`,
 				'--image-object-fit': this.objectFit,
 				'--image-object-position': this.objectPosition,
 			};
+			/*
+				Safari doesn't seem to like `inherit` or `100%` for height/width.
+				By setting it static, the scrolling performance is vastly improved,
+				and it does properly update on screen resize.
+			*/
+			if (this.shouldUseStaticSizeStyles && this.height && this.width) {
+				imageStyle.height = `${this.height}px`;
+				imageStyle.width = `${this.width}px`;
+			}
+
+			return imageStyle;
 		},
 
 		isThumbnail() {
@@ -205,7 +221,7 @@ export default {
 		},
 
 		shouldGetImageDimensions() {
-			return this.shape !== 'square' && this.shape !== 'original';
+			return this.shouldUseStaticSizeStyles || (this.shape !== 'square' && this.shape !== 'original');
 		},
 	},
 
@@ -304,10 +320,8 @@ export default {
 
 .Image {
 	display: block;
-
-	/* Need to use inherit instead of 100% for performance on Safari */
-	width: inherit;
-	height: inherit;
+	width: 100%;
+	height: 100%;
 	object-fit: var(--image-object-fit);
 	object-position: var(--image-object-position);
 	border-radius: $maker-shape-image-border-radius;


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Still trying to narrow down a fix for the Safari scroll issues.

## Describe the changes in this PR
Using overrides in Safari, setting a static height/width style on the images after they render seems to solve the perf issue. Tested on a photo layout site to ensure the images resize properly switching between desktop/mobile. Will only enable this prop for Safari.
