### PR TITLE
fix(text): prevent always running detect text alignment

### DIFF
--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -123,7 +123,7 @@ export default {
 
 	data() {
 		return {
-			isCentered: false,
+			isCenteredAndSpaced: false,
 		};
 	},
 
@@ -204,7 +204,7 @@ export default {
 			if (this.resolvedLetterSpacing !== 'inherit') {
 				styles.letterSpacing = this.resolvedLetterSpacing;
 			}
-			if (this.isCentered) {
+			if (this.isCenteredAndSpaced) {
 				styles.paddingLeft = styles.letterSpacing;
 			}
 			return styles;
@@ -212,11 +212,11 @@ export default {
 	},
 
 	mounted() {
-		this.detectAlignCenter();
+		this.detectAlignCenterAndLetterSpacing();
 	},
 
 	updated() {
-		this.detectAlignCenter();
+		this.detectAlignCenterAndLetterSpacing();
 	},
 
 	methods: {
@@ -227,10 +227,14 @@ export default {
 		 * Detect if the text is center aligned and add left padding
 		 * to balance out the letter spacing
 		 */
-		detectAlignCenter() {
+		detectAlignCenterAndLetterSpacing() {
+			if (!this.resolvedLetterSpacing) {
+				return;
+			}
+
 			const computedStyle = window.getComputedStyle(this.$el);
 			const textAlign = computedStyle.getPropertyValue('text-align');
-			this.isCentered = textAlign === 'center';
+			this.isCenteredAndSpaced = textAlign === 'center';
 		},
 	},
 


### PR DESCRIPTION
## Describe the problem this PR addresses

This pull request is meant to improve browser performance of the Text component. The current implementation causes the browser to recompute actual styles each time a text component is mounted and/or updated. This occurs only to fix an issue with letter spacing.

## Describe the changes in this PR
This PR ensure the logic to detect center styling only runs if custom letter spacing is passed in to the component, otherwise there is no need to run this. 

## Other information
This issue frequently causes Safari to do a force layout calculation which is inefficient. 
