### PR TITLE
fix(text): removes always computing text element alignment

### DIFF
--- a/src/components/Text/src/Text.vue
+++ b/src/components/Text/src/Text.vue
@@ -232,9 +232,8 @@ export default {
 				return;
 			}
 
-			const computedStyle = window.getComputedStyle(this.$el);
-			const textAlign = computedStyle.getPropertyValue('text-align');
-			this.isCenteredAndSpaced = textAlign === 'center';
+			// this does not account for inheritted centered text
+			this.isCenteredAndSpaced = this.textAlign === 'center';
 		},
 	},
 


### PR DESCRIPTION
## Describe the problem this PR addresses
The text element calls `getComputedStyle` which is very inefficient sometimes causing many milliseconds of lag and layout recalculations. 

## Describe the changes in this PR
This PR removes calculating the computed text alignment. This means the padding fix will only be set when text alignment is directly set on the element and has letter spacing (whether inherited or not). 
