### PR TITLE
feat(toast): add icon size prop

### DIFF
--- a/src/components/Icon/src/Icon.vue
+++ b/src/components/Icon/src/Icon.vue
@@ -13,14 +13,7 @@ import cssValidator from '@square/maker/utils/css-validator';
 import assert from '@square/maker/utils/assert';
 import { MThemeKey, defaultTheme, resolveThemeableProps } from '@square/maker/components/Theme';
 import RenderFn from '@square/maker/utils/RenderFn';
-
-const ICON_SIZES = {
-	small: '16px',
-	medium: '24px',
-	large: '32px',
-	xlarge: '40px',
-	xxlarge: '48px',
-};
+import { ICON_SIZES } from '@square/maker/utils/constants';
 
 // width & height css props accept same set of values
 const sizeValidator = cssValidator('width');

--- a/src/components/Image/README.md
+++ b/src/components/Image/README.md
@@ -247,16 +247,17 @@ Supports attributes from [`<img>`](https://developer.mozilla.org/en-US/docs/Web/
 
 Themable props* can be configured via the [Theme](#/Theme) component using the key `image`.
 
-| Prop                      | Type      | Default    | Possible values                                             | Description                                                                         |
-| ------------------------- | --------- | ---------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| src                       | `string`  | —          | -                                                           | -                                                                                   |
-| srcset                    | `string`  | —          | -                                                           | -                                                                                   |
-| sizes                     | `string`  | —          | -                                                           | -                                                                                   |
-| shape*                    | `string`  | —          | `'original'`, `'square'`, `'circle'`, `'arch'`, `'hexagon'` | Original applies theme's border radius, square applies border radius of 0           |
-| lazyload                  | `boolean` | `false`    | -                                                           | -                                                                                   |
-| object-fit                | `string`  | `'cover'`  | -                                                           | [Object fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)           |
-| object-position           | `string`  | `'center'` | -                                                           | [Object position](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) |
-| should-disable-transition | `boolean` | `false`    | -                                                           | -                                                                                   |
+| Prop                          | Type      | Default    | Possible values                                             | Description                                                                         |
+| ----------------------------- | --------- | ---------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| src                           | `string`  | —          | -                                                           | -                                                                                   |
+| srcset                        | `string`  | —          | -                                                           | -                                                                                   |
+| sizes                         | `string`  | —          | -                                                           | -                                                                                   |
+| shape*                        | `string`  | —          | `'original'`, `'square'`, `'circle'`, `'arch'`, `'hexagon'` | Original applies theme's border radius, square applies border radius of 0           |
+| lazyload                      | `boolean` | `false`    | -                                                           | -                                                                                   |
+| object-fit                    | `string`  | `'cover'`  | -                                                           | [Object fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)           |
+| object-position               | `string`  | `'center'` | -                                                           | [Object position](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) |
+| should-disable-transition     | `boolean` | `false`    | -                                                           | -                                                                                   |
+| should-use-static-size-styles | `boolean` | `false`    | -                                                           | -                                                                                   |
 
 
 ## Events

--- a/src/components/Toast/README.md
+++ b/src/components/Toast/README.md
@@ -936,6 +936,7 @@ Themable props* can be configured via the [Theme](#/Theme) component using the k
 | dismiss-after* | `number`  | `5000`      | -                                                                                                       | auto-dismiss after x milliseconds (ignored if persistent) |
 | icon-name*     | `string`  | `'info'`    | -                                                                                                       | name of icon to show                                      |
 | show-icon*     | `boolean` | `false`     | -                                                                                                       | shows icon                                                |
+| icon-size      | `string`  | `'small'`   | -                                                                                                       | changes icon size                                         |
 | text           | `string`  | `''`        | -                                                                                                       | toast text content                                        |
 | progress       | `number`  | —           | -                                                                                                       | optional toast progress (0 - 100)                         |
 | color*         | `string`  | `'#000000'` | -                                                                                                       | toast text & button color                                 |

--- a/src/components/Toast/src/Toast.vue
+++ b/src/components/Toast/src/Toast.vue
@@ -21,6 +21,7 @@
 				<slot name="icon">
 					<m-icon
 						:name="resolvedIconName"
+						:size="iconSize"
 					/>
 				</slot>
 			</div>
@@ -59,6 +60,7 @@
 			>
 				<m-icon
 					:class="$s.CloseIcon"
+					:size="iconSize"
 					name="close"
 				/>
 			</div>
@@ -81,9 +83,13 @@ import { MProgressBar } from '@square/maker/components/ProgressBar';
 import { MTextButton } from '@square/maker/components/TextButton';
 import { MIcon } from '@square/maker/components/Icon';
 import { MText } from '@square/maker/components/Text';
+import { ICON_SIZES } from '@square/maker/utils/constants';
 import cssValidator from '@square/maker/utils/css-validator';
 import MBread from './Bread.vue';
 import toastApi from './toast-api';
+
+// width & height css props accept same set of values
+const sizeValidator = cssValidator('width');
 
 const MIN_PROGRESS = 0;
 const MAX_PROGRESS = 100;
@@ -147,6 +153,14 @@ export default {
 		showIcon: {
 			type: Boolean,
 			default: undefined,
+		},
+		/**
+		 * changes icon size
+		 */
+		iconSize: {
+			type: String,
+			default: 'small',
+			validator: (size) => ICON_SIZES[size] || sizeValidator(size),
 		},
 		/**
 		 * toast text content

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,1 +1,9 @@
 export const BASE_TEN = 10;
+
+export const ICON_SIZES = {
+	small: '16px',
+	medium: '24px',
+	large: '32px',
+	xlarge: '40px',
+	xxlarge: '48px',
+};


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
The `MToast` component uses an `MIcon` component under the hood. Since the default size for `MIcon` is `small`, all of the toast icons are also small.
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
Added an `icon-size` property to allow devs to control the size of the toast icons.

Example with `icon-size="medium"`

*Before:*
![Screenshot 2024-07-08 at 4 34 50 PM](https://github.com/square/maker/assets/1790262/94a00b2f-1aab-4e78-85f2-a1d113f3a64c)

*After:*
![Screenshot 2024-07-08 at 4 37 44 PM](https://github.com/square/maker/assets/1790262/f56fbb75-1a2c-48ae-a83d-5f104c9b0737)

<!--
  📸 Inline screenshots to better communicate the changes
-->

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
