### PR TITLE
feat(a11y): Adding a11y properties to stepper components

### DIFF
--- a/src/components/Stepper/README.md
+++ b/src/components/Stepper/README.md
@@ -31,19 +31,63 @@ export default {
 </script>
 ```
 
+## Accessibility Example
+
+```vue
+<template>
+	<div style="text-align: center">
+		<m-stepper
+			v-model="quantity"
+			:min="1"
+			:max="10"
+			aria-label="Product quantity selector"
+			decrement-aria-label="Decrease quantity"
+			increment-aria-label="Increase quantity"
+			input-aria-label="Enter desired quantity"
+			quantity-aria-label="Current quantity selection"
+		/>
+		Selected quantity: {{ quantity }}
+	</div>
+</template>
+
+<script>
+import { MStepper } from '@square/maker/components/Stepper';
+
+export default {
+	components: {
+		MStepper,
+	},
+
+	data() {
+		return {
+			quantity: 1,
+		};
+	},
+};
+</script>
+```
+
 <!-- api-tables:start -->
 ## Props
 
 Themable props* can be configured via the [Theme](#/Theme) component using the key `stepper`.
 
-| Prop        | Type            | Default     | Possible values                    | Description                     |
-| ----------- | --------------- | ----------- | ---------------------------------- | ------------------------------- |
-| v-model     | `number`        | —           | -                                  | stepper's current value         |
-| min         | `number|string` | —           | -                                  | stepper min value               |
-| max         | `number|string` | —           | -                                  | stepper max value               |
-| color*      | `string`        | `'#f1f1f1'` | -                                  | stepper button background color |
-| text-color* | `string`        | `'#1b1b1b'` | -                                  | stepper button text color       |
-| shape*      | `string`        | —           | `'squared'`, `'rounded'`, `'pill'` | stepper button shape            |
+| Prop                     | Type            | Default       | Possible values                    | Description                                            |
+| ------------------------ | --------------- | ------------- | ---------------------------------- | ------------------------------------------------------ |
+| v-model                  | `number`        | —             | -                                  | stepper's current value                                |
+| min                      | `number|string` | —             | -                                  | stepper min value                                      |
+| max                      | `number|string` | —             | -                                  | stepper max value                                      |
+| color*                   | `string`        | `'#f1f1f1'`   | -                                  | stepper button background color                        |
+| text-color*              | `string`        | `'#1b1b1b'`   | -                                  | stepper button text color                              |
+| shape*                   | `string`        | —             | `'squared'`, `'rounded'`, `'pill'` | stepper button shape                                   |
+| aria-label               | `string`        | `''`          | -                                  | Overall label for the stepper group                    |
+| aria-labelledby          | `string`        | `''`          | -                                  | References to elements that label the stepper          |
+| aria-describedby         | `string`        | `''`          | -                                  | References to elements that describe the stepper       |
+| decrement-aria-label     | `string`        | `'Decrement'` | -                                  | Custom label for the decrement button                  |
+| increment-aria-label     | `string`        | `'Increment'` | -                                  | Custom label for the increment button                  |
+| input-aria-label         | `string`        | `''`          | -                                  | Custom label for the manual input field                |
+| input-aria-describedby   | `string`        | `''`          | -                                  | Additional description for the input field             |
+| quantity-aria-label      | `string`        | `''`          | -                                  | Custom label for the quantity display                  |
 
 
 ## Events

--- a/src/components/Stepper/src/Stepper.vue
+++ b/src/components/Stepper/src/Stepper.vue
@@ -1,6 +1,10 @@
 <template>
 	<div
 		:class="$s.Stepper"
+		:aria-label="ariaLabel"
+		:aria-labelledby="ariaLabelledby"
+		:aria-describedby="ariaDescribedby"
+		role="group"
 	>
 		<m-button
 			variant="fill"
@@ -9,7 +13,7 @@
 			:text-color="resolvedTextColor"
 			:shape="resolvedShape"
 			:disabled="value === minVal"
-			aria-label="−"
+			:aria-label="decrementAriaLabel"
 			@click="decrement"
 		>
 			<m-icon
@@ -27,16 +31,22 @@
 				:class="$s.QuantityManualInput"
 				:min="min"
 				:max="max"
+				:aria-label="computedInputAriaLabel"
+				:aria-describedby="inputAriaDescribedby"
+				:aria-valuemin="minVal"
+				:aria-valuemax="maxVal"
+				:aria-valuenow="value"
 				type="number"
 				inputmode="numeric"
 				@change="commitManualValue"
 				@blur="commitManualValue"
-			>
+			/>
 			<span
 				:class="[
 					$s.QuantityReadonly,
 					{ [$s.isManualInput]: isSettingManualValue }
 				]"
+				:aria-label="computedQuantityAriaLabel"
 				@click="triggerManualInput"
 			>
 				<!-- This allows us to auto-resize the input as users type -->
@@ -50,7 +60,7 @@
 			:text-color="resolvedTextColor"
 			:shape="resolvedShape"
 			:disabled="value === maxVal"
-			aria-label="+"
+			:aria-label="incrementAriaLabel"
 			@click="increment"
 		>
 			<m-icon
@@ -134,6 +144,63 @@ export default {
 			default: undefined,
 			validator: (shape) => ['squared', 'rounded', 'pill'].includes(shape),
 		},
+		/**
+		 * Stepper aria label
+		 */
+		ariaLabel: {
+			type: String,
+			default: '',
+		},
+		/**
+		 * Stepper aria labelled by
+		 */
+		ariaLabelledby: {
+			type: String,
+			default: '',
+		},
+		/**
+		 * Stepper aria described by
+		 */
+		ariaDescribedby: {
+			type: String,
+			default: '',
+		},
+		/**
+		 * Decrement aria label
+		 */
+		decrementAriaLabel: {
+			type: String,
+			default: 'Decrement',
+		},
+		/**
+		 * Increment aria label
+		 */
+		incrementAriaLabel: {
+			type: String,
+			default: 'Increment',
+		},
+		/**
+		 * Input aria label
+		 */
+		inputAriaLabel: {
+			type: String,
+			default: '',
+		},
+		/**
+		 * Input aria described by
+		 */
+		inputAriaDescribedby: {
+			type: String,
+			default: '',
+		},
+		/**
+		 * Quantity aria label
+		 */
+		quantityAriaLabel: {
+			type: String,
+			default: '',
+		},
+
 	},
 
 	data() {
@@ -156,6 +223,14 @@ export default {
 
 		minVal() {
 			return Number.parseInt(this.min, BASE_TEN);
+		},
+
+		computedInputAriaLabel() {
+			return this.inputAriaLabel || `Enter value between ${this.minVal || 'any'} and ${this.maxVal || 'any'}`;
+		},
+
+		computedQuantityAriaLabel() {
+			return this.quantityAriaLabel || `Current value ${this.value}. Click to edit manually.`;
 		},
 	},
 


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
Improving a11y properties in the stepper component. No behavioral changes

## Describe the changes in this PR

- Added 8 new accessibility props: aria-label, aria-labelledby, aria-describedby, decrement-aria-label, increment-aria-label, input-aria-label, input-aria-describedby, quantity-aria-label
- Added role="group" to stepper container
- Changed increment/decrement buttons from hardcoded symbols to dynamic aria labels with defaults "Increment"/"Decrement"
- Added ARIA value attributes to manual input field (aria-valuemin, aria-valuemax, aria-valuenow)
- Added computed properties for smart default aria labels
- Updated README.md with new props table and accessibility example
- Zero visual impact - all changes are screen reader only
- Maintains full backward compatibility

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
