### PR TITLE
ci: disable npm cache

### DIFF
--- a/.github/workflows/deploy-styleguide-lab.yml
+++ b/.github/workflows/deploy-styleguide-lab.yml
@@ -26,7 +26,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version-file: '.nvmrc'
-          cache: 'npm'
+          # commenting out line which is erroring atm
+          # maybe uncomment this in the future
+          # cache: 'npm'
       - name: Install dependencies
         run: npm ci
       - name: Build & deploy Styleguide & Lab

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -14,7 +14,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version-file: '.nvmrc'
-          cache: 'npm'
+          # commenting out line which is erroring atm
+          # maybe uncomment this in the future
+          # cache: 'npm'
       - name: Install dependencies
         run: npm ci
       - name: Lint code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version-file: '.nvmrc'
-          cache: 'npm'
+          # commenting out line which is erroring atm
+          # maybe uncomment this in the future
+          # cache: 'npm'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
all recent ci checks have failed due to some "caching service" being unavailable during the setup-node step, disabling it to see if that fixes it