### PR TITLE
feat(a11y): update maker neutral-20 to meet contrast requirements

### DIFF
--- a/src/components/Theme/README.md
+++ b/src/components/Theme/README.md
@@ -412,7 +412,7 @@ export default {
 					primary: '#000000',
 					'neutral-0': '#ffffff',
 					'neutral-10': '#f1f1f1',
-					'neutral-20': '#d3d3d3',
+					'neutral-20': '#949494',
 					'neutral-80': '#707070',
 					'neutral-90': '#1b1b1b',
 					'neutral-100': '#000000',
@@ -520,7 +520,11 @@ We have a preset scale of neutral colors that are used within most components. D
 					class="color"
 					:style="{backgroundColor: value }"
 				>
-					<span class="label">{{ key }}: {{ value }}</span>
+					<span class="label">
+						{{ key }}: {{ value }}
+						<br>
+						Contrast: {{ getContrastRatio(key, true).toFixed(3) }}
+					</span>
 				</li>
 			</ul>
 		</div>
@@ -535,33 +539,52 @@ We have a preset scale of neutral colors that are used within most components. D
 					class="color"
 					:style="{backgroundColor: value }"
 				>
-					<span class="label">{{ key }}: {{ value }}</span>
+					<span class="label">
+						{{ key }}: {{ value }}
+						<br>
+						Contrast: {{ getContrastRatio(key, false).toFixed(3) }}
+					</span>
 				</li>
 			</ul>
 		</div>
 	</div>
 </template>
 <script>
+import makerColors from '@square/maker/utils/maker-colors';
+import { colord } from 'colord';
+
 export default {
 	data() {
+		// Generate colors using the actual maker-colors.js utility
+		const lightColors = makerColors('#ffffff');
+		const darkColors = makerColors('#000000');
+
 		return {
 			colors: {
-				'neutral-0': '#ffffff',
-				'neutral-10': '#f1f1f1',
-				'neutral-20': '#d3d3d3',
-				'neutral-80': '#707070',
-				'neutral-90': '#1b1b1b',
-				'neutral-100': '#000000',
+				'neutral-0': lightColors['neutral-0'],
+				'neutral-10': lightColors['neutral-10'],
+				'neutral-20': lightColors['neutral-20'],
+				'neutral-80': lightColors['neutral-80'],
+				'neutral-90': lightColors['neutral-90'],
+				'neutral-100': lightColors['neutral-100'],
 			},
 			demoDarkColors: {
-				'neutral-0': '#000000',
-				'neutral-10': '#3c3c3c',
-				'neutral-20': '#575757',
-				'neutral-80': '#848484',
-				'neutral-90': '#f1f1f1',
-				'neutral-100': '#ffffff',
+				'neutral-0': darkColors['neutral-0'],
+				'neutral-10': darkColors['neutral-10'],
+				'neutral-20': darkColors['neutral-20'],
+				'neutral-80': darkColors['neutral-80'],
+				'neutral-90': darkColors['neutral-90'],
+				'neutral-100': darkColors['neutral-100'],
 			},
 		};
+	},
+	methods: {
+		getContrastRatio(key, isLight) {
+			const background = isLight ? '#ffffff' : '#000000';
+			const color = isLight ? this.colors[key] : this.demoDarkColors[key];
+			// Calculate WCAG contrast ratio
+			return colord(color).contrast(background);
+		},
 	},
 };
 </script>

--- a/src/components/Theme/src/default-colors.cjs
+++ b/src/components/Theme/src/default-colors.cjs
@@ -5,7 +5,7 @@ module.exports = function defaultColors() {
 	return {
 		'neutral-0': '#ffffff',
 		'neutral-10': '#f1f1f1',
-		'neutral-20': '#d3d3d3',
+		'neutral-20': '#919191',
 		'neutral-80': '#707070',
 		'neutral-90': '#1b1b1b',
 		'neutral-100': '#000000',

--- a/src/utils/maker-colors.js
+++ b/src/utils/maker-colors.js
@@ -18,7 +18,7 @@ const NEUTRAL_RATIOS = {
 	light: {
 		'neutral-0': 0,
 		'neutral-10': 0.05,
-		'neutral-20': 0.155,
+		'neutral-20': 0.385,
 		'neutral-80': 0.527,
 		'neutral-90': 0.9,
 		'neutral-100': 1,
@@ -26,7 +26,7 @@ const NEUTRAL_RATIOS = {
 	dark: {
 		'neutral-0': 0,
 		'neutral-10': 0.225,
-		'neutral-20': 0.37,
+		'neutral-20': 0.385,
 		'neutral-80': 0.55,
 		'neutral-90': 0.95,
 		'neutral-100': 1,


### PR DESCRIPTION
<!--
  🤖 This repo uses Conventional Commits (conventionalcommits.org) to automate
  release notes and versioning. Title your PR using the following template:

  <type>(<scope>): <subject>

  Scope is optional. Indicate a breaking change by adding ! after the type/scope.

  Version influencing types:
  - fix: user-facing bug fix (patch version bump)
  - feat: user-facing feature (minor version bump)

  Other types:
  - docs: changes to the documentation
  - build: changes that affect the build system or external dependencies
  - test: adding missing tests, refactoring tests; no production code change
  - refactor: refactoring production code, eg. renaming a variable
  - style: formatting, missing semi colons, etc; no production code change
  - chore: updating grunt tasks etc; no production code change
  - revert: reverts a previous commit
  - perf: changes that improve performance
  - ci: changes to CI configuration files and scripts (eg. GitHub Actions)

  👍 Do examples:
  - feat(button): primary variant
  - fix(action-bar): inherit event-listeners

  👎 Don't examples:
  - feat(button): [ABC-123] primary variant

  Read CONTRIBUTING.md for more info.
-->

## Describe the problem this PR addresses
The color `neutral-20` generated by the maker colors utility did not pass minimum (3:1) contrast requirements in the components it's used on (input borders, toggle buttons etc).
<!--
  🤐 If you are a Square employee, be mindful of any internal information
  you share in this public repository.
-->

## Describe the changes in this PR
This PR adjusts the values used to generate `neutral-20` so that components using it in their styles pass contrast requirements for accessibility. This PR also updates the README for theme so that it uses the makerColors utility functions to demo the colors and includes their contrast values.

<img width="945" alt="Screenshot 2025-06-25 at 4 15 16 PM" src="https://github.com/user-attachments/assets/c497cd89-52ce-4cc3-8623-08b78b1a9f8a" />

<!--
  📸 Inline screenshots to better communicate the changes
-->

## Other information
<!--
  🙆‍♂️ Provide further context that will help those out-of-the-loop
  to quickly understand the changes.
-->
