### PR TITLE
fix(calendar): improve keyboard navigation

### DIFF
--- a/src/components/Calendar/src/Calendar.vue
+++ b/src/components/Calendar/src/Calendar.vue
@@ -7,6 +7,7 @@
 		<div :class="$s.CalendarHeader">
 			<m-button
 				v-bind="calendarNavButtons"
+				:aria-label="previousMonthAriaLabel"
 				:disabled="isCalendarNavDisabled(-1)"
 				size="medium"
 				variant="fill"
@@ -24,6 +25,7 @@
 
 			<m-button
 				v-bind="calendarNavButtons"
+				:aria-label="nextMonthAriaLabel"
 				:disabled="isCalendarNavDisabled(1)"
 				size="medium"
 				variant="fill"
@@ -59,13 +61,18 @@
 					>
 						<button
 							v-if="date"
+							ref="dateButtons"
 							:class="[$s.DateCellButton, {
 								[$s.selected]: isDateSelected(date),
 								[$s.disabled]: isDateDisabled(date),
 								[$s.today]: isToday(date),
 							}]"
 							type="button"
-							tabindex="-1"
+							:tabindex="isActiveDate(date) && !isDateDisabled(date) ? 0 : -1"
+							@keydown.left.prevent="moveFocus(date, -1)"
+							@keydown.right.prevent="moveFocus(date, 1)"
+							@keydown.up.prevent="moveFocus(date, -7)"
+							@keydown.down.prevent="moveFocus(date, 7)"
 							@click.prevent="emitDate(date)"
 						>
 							{{ date.getDate() }}
@@ -155,11 +162,26 @@ export default {
 			type: String,
 			default: undefined,
 		},
+		/**
+		 * Accessible label for the previous month button.
+		 */
+		previousMonthAriaLabel: {
+			type: String,
+			default: 'Previous month',
+		},
+		/**
+		 * Accessible label for the next month button.
+		 */
+		nextMonthAriaLabel: {
+			type: String,
+			default: 'Next month',
+		},
 	},
 
 	data() {
 		return {
 			showingMonth: new Date(),
+			activeDate: undefined,
 		};
 	},
 
@@ -172,6 +194,12 @@ export default {
 			const firstDayOfWeek = startOfWeek(new Date());
 			const weekdays = Array.from({ length: 7 }, (_, i) => addDays(firstDayOfWeek, i));
 			return weekdays.map((date) => date.toLocaleDateString(this.locale, { weekday: 'short' }));
+		},
+
+		visibleDates() {
+			const dates = [];
+			this.weeks.forEach((week) => dates.push(...week));
+			return dates.filter(Boolean);
 		},
 
 		weeks() {
@@ -226,12 +254,25 @@ export default {
 				this.showingMonth = newSelectedDate;
 			}
 		},
+
+		minDate: 'reconcileActiveDate',
+
+		maxDate: 'reconcileActiveDate',
+
+		disabledDates: {
+			deep: true,
+			handler: 'reconcileActiveDate',
+		},
+
+		showingMonth: 'reconcileActiveDate',
 	},
 
 	mounted() {
 		if (this.selectedDateObject) {
 			this.showingMonth = this.selectedDateObject;
 		}
+
+		this.reconcileActiveDate();
 	},
 
 	methods: {
@@ -262,6 +303,74 @@ export default {
 		 */
 		incrementMonth(incrementBy) {
 			this.showingMonth = addMonths(this.showingMonth, incrementBy);
+		},
+
+		/**
+		 * Reconciles the single date button that can receive tab focus.
+		 */
+		reconcileActiveDate() {
+			const selectedDate = this.selectedDateObject;
+			if (selectedDate && this.isDateVisible(selectedDate) && !this.isDateDisabled(selectedDate)) {
+				this.activeDate = formatISOdate(selectedDate);
+				return;
+			}
+
+			const currentActiveDate = this.visibleDates.find((date) => this.isActiveDate(date));
+			if (currentActiveDate && !this.isDateDisabled(currentActiveDate)) {
+				return;
+			}
+
+			const firstEnabledDate = this.visibleDates.find((date) => !this.isDateDisabled(date));
+			this.activeDate = firstEnabledDate && formatISOdate(firstEnabledDate);
+		},
+
+		/**
+		 * Determines if the date is shown in the current calendar month.
+		 * @param {Date} date
+		 * @return {boolean}
+		 */
+		isDateVisible(date) {
+			return date.getFullYear() === this.showingMonth.getFullYear()
+				&& date.getMonth() === this.showingMonth.getMonth();
+		},
+
+		/**
+		 * Determines if the date is the current roving tab stop.
+		 * @param {Date} date
+		 * @return {boolean}
+		 */
+		isActiveDate(date) {
+			return this.activeDate === formatISOdate(date);
+		},
+
+		/**
+		 * Moves roving focus by the given number of days without changing the selection.
+		 * @param {Date} date
+		 * @param {number} incrementBy
+		 */
+		moveFocus(date, incrementBy) {
+			let nextDate = addDays(date, incrementBy);
+			while (this.isDateVisible(nextDate)) {
+				if (!this.isDateDisabled(nextDate)) {
+					this.activeDate = formatISOdate(nextDate);
+					this.$nextTick(() => this.focusActiveDate());
+					return;
+				}
+
+				nextDate = addDays(nextDate, incrementBy);
+			}
+		},
+
+		/**
+		 * Focuses the current roving tab stop after it has rendered.
+		 */
+		focusActiveDate() {
+			const activeDateButton = this.$refs.dateButtons.find(
+				(dateButton) => dateButton.tabIndex === 0,
+			);
+			if (activeDateButton) {
+				activeDateButton.focus();
+			}
 		},
 
 		/**

--- a/src/components/PinInput/src/PinInputControl.vue
+++ b/src/components/PinInput/src/PinInputControl.vue
@@ -8,6 +8,7 @@
 			:class="$s.PinInput"
 			:maxlength="pinLength"
 			:value="inputValue"
+			:aria-label="ariaLabel"
 			type="text"
 			inputmode="numeric"
 			pattern="[0-9]*"
@@ -87,6 +88,14 @@ export default {
 		disabled: {
 			type: Boolean,
 			default: false,
+		},
+
+		/**
+		 * Accessible label for the input group
+		 */
+		ariaLabel: {
+			type: String,
+			default: undefined,
 		},
 	},
 


### PR DESCRIPTION
## Problem

Maker Calendar gave every date button `tabindex="-1"` and did not provide Arrow-key movement between dates, so keyboard users had no predictable Tab entry point into the displayed month. The existing icon-only previous/next month buttons also lacked accessible names.

During browser validation of the initial change, month navigation exposed a focus regression: after Next month, Tab correctly focused date 1 and ArrowRight correctly moved `activeDate` and `tabindex="0"` to date 2, but DOM focus jumped to date 6. Vue's `$refs.dateButtons` order can differ from chronological `visibleDates` order after a month redraw, so the positional ref lookup focused the wrong button.

Maker PinInput renders a native text input behind its visual code cells. The component accepted an accessible-name value at higher levels, but did not apply it to that native input, which leaves iPhone VoiceOver without a reliable field name.

## Changes

### Calendar keyboard navigation

- Give exactly one enabled, visible date `tabindex="0"`; all other date buttons receive `tabindex="-1"`.
- Prefer a valid selected date for the active Tab stop, otherwise preserve a valid active date or fall back to the first enabled visible date.
- Reconcile that active date when the selection, date limits, disabled dates, or displayed month changes.
- Move focus by one day with Left/Right and seven days with Up/Down, repeating the same stride to skip unavailable dates and stopping at the displayed-month boundary.
- Focus the rendered roving Tab stop directly instead of assuming `$refs.dateButtons` and `visibleDates` have matching positions after a month change.
- Add `previousMonthAriaLabel` and `nextMonthAriaLabel` string props, defaulting to `Previous month` and `Next month`, and bind them to the existing icon-only navigation buttons.
- Preserve existing mouse behavior, `calendar:update` payloads, and native Enter/Space button behavior.

### PinInput accessible name

- Add an optional `ariaLabel` prop to PinInput and apply it directly to its native input as `aria-label`.
- Preserve PinInput's visual presentation and verification-code entry behavior.

The scope intentionally excludes full-date labels, `aria-selected`/`aria-current`, grid redesign, live regions, additional keyboard shortcuts, cross-month Arrow navigation.

## Validation

Run with the repository-pinned Node `v16.18.0`:

- Real Chromium reproduction before the final Calendar fix: after Next month → Tab to date 1 → ArrowRight, `activeDate` and the sole `tabindex="0"` moved to date 2 while DOM focus moved to date 6.
- Real Chromium verification after the Calendar fix: the same flow leaves `activeDate`, the sole `tabindex="0"`, and DOM focus on date 2, even while the Vue ref array remains reordered; the clean final run reported no page errors.
- Browser checks covered Left/Right and Up/Down movement, month boundaries, disabled-date skipping at one-day and seven-day strides, no selection or emission from Arrow keys, and exactly one emission each from native Enter, native Space, and click.
- The default `Previous month` and `Next month` accessible labels remained present.
- PinInput checks confirmed the optional accessible name reaches the native input; six digits cause one completion signal, closing removes the input from the Lab prototype, and reopening starts empty.
- Focused ESLint for the changed Calendar and PinInput files — passed.
- Focused Stylelint for the changed Calendar file — passed.
- `npm run lint` against the final commit — passed.
- `npm run build` — passed (existing stale Browserslist database warnings only).
- `git diff --check origin/master..HEAD` — passed.

Maker does not currently have an automated component test suite, so no new test framework was introduced.

## Remaining manual acceptance

Human iPhone VoiceOver verification of the candidate PinInput remains pending. It should be tested on the same device and flow where the baseline fails, confirming that VoiceOver announces the supplied verification-code field name.
